### PR TITLE
fix(windows): resolve claude.cmd instead of POSIX shell script

### DIFF
--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/Main.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/Main.kt
@@ -22,9 +22,32 @@ import io.ktor.client.request.post
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.decodeFromString
+import java.net.Inet4Address
+import java.net.NetworkInterface
 
 /** Production relay; users connect here by default so `run`/`service-install` need no URL. */
 const val DEFAULT_RELAY = "wss://pocket.ark-nexus.cc"
+
+/** Pick the most likely LAN IPv4 address: a physical, non-virtual site-local address. */
+fun lanIp(): String? {
+    // Common virtual / overlay / tunnel interface name prefixes that are never the user's
+    // physical "LAN" interface even though they look like ordinary NICs to the JVM.
+    val virtualPrefixes = setOf("zt", "tun", "tap", "docker", "veth", "br-", "lo", "gif", "stf",
+        "anpi", "ap", "awdl", "bridge", "llw", "utun")
+    val candidate = NetworkInterface.getNetworkInterfaces().asSequence()
+        .filter { it.isUp && !it.isLoopback && !it.isVirtual }
+        .sortedBy { ni: NetworkInterface ->
+            // prefer physical / non-virtual interfaces over overlay/tunnel ones
+            val name = ni.name.lowercase()
+            if (virtualPrefixes.any { name.startsWith(it) }) 2 else 0
+        }
+        .flatMap { it.interfaceAddresses.asSequence() }
+        .map { it.address }
+        .filterIsInstance<Inet4Address>()
+        .map { it.hostAddress }
+        .firstOrNull { !it.startsWith("127.") && !it.startsWith("169.254.") }
+    return candidate
+}
 
 private class Root : CliktCommand(name = "cc-pocket-daemon") {
     override fun run() = Unit
@@ -51,7 +74,33 @@ private class RunCmd : CliktCommand(name = "run") {
             Runtime.getRuntime().addShutdownHook(Thread { runBlocking { core.shutdown() } })
             runBlocking { relayClient.run() }
         } else {
-            echo("cc-pocket daemon — claude=$exe — ws://$host:$port/v1/ws")
+            // Display a URL with the LAN IP for QR convenience, but NEVER silently widen the
+            // bind unless the user explicitly asked for 0.0.0.0. The direct-LAN path has no
+            // handshake / auth / E2E — anyone on the network can reach /v1/ws.
+            val advertiseIp = if (host == "127.0.0.1" || host == "0.0.0.0") lanIp() else host
+            val url = "ws://${advertiseIp ?: host}:$port/v1/ws"
+            echo("cc-pocket daemon — claude=$exe")
+            echo("")
+            if (host == "0.0.0.0") {
+                echo("  !! UNGUARDED — bound to 0.0.0.0 (all interfaces) !!")
+                echo("  Anyone on your network can open sessions, browse files and approve tools.")
+                echo("")
+            }
+            echo("  LAN server on $url")
+            echo("")
+            if (advertiseIp != null && host == "127.0.0.1") {
+                echo("  Note: daemon is bound to 127.0.0.1 only.")
+                echo("  To accept LAN connections pass --host 0.0.0.0")
+                echo("")
+            }
+            echo("  On your phone, open CC Pocket and tap:")
+            echo("    Advanced: Direct LAN")
+            echo("  Then enter: $url")
+            echo("")
+            if (advertiseIp != null) {
+                echo(QrTerminal.render(url))
+                echo("")
+            }
             DaemonServer(core, host, port).run()
         }
     }

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/relay/DeviceSessions.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/relay/DeviceSessions.kt
@@ -6,6 +6,7 @@ import dev.ccpocket.daemon.identity.Identity
 import dev.ccpocket.daemon.util.logger
 import dev.ccpocket.protocol.Envelope
 import dev.ccpocket.protocol.Frame
+import dev.ccpocket.protocol.PocketError
 import dev.ccpocket.protocol.PocketJson
 import dev.ccpocket.protocol.e2e.E2ESession
 import dev.ccpocket.protocol.e2e.Wire
@@ -93,8 +94,14 @@ class DeviceSessions(
         log.info("← ${env.body::class.simpleName} from ${deviceId.take(8)}…")
 
         val sink = OutboundSink { frame -> sealAndSend(deviceId, frame) }
-        core.router.handle(env.body, sink) { convoId ->
-            mutex.withLock { owned.getOrPut(deviceId) { mutableListOf() }.add(convoId) }
+        try {
+            core.router.handle(env.body, sink) { convoId ->
+                mutex.withLock { owned.getOrPut(deviceId) { mutableListOf() }.add(convoId) }
+            }
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            log.warn("handle ${env.body::class.simpleName} failed: ${e.message}")
+            runCatching { sink.emit(PocketError("internal", e.message ?: "request failed")) }
         }
     }
 

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/server/WsConnection.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/server/WsConnection.kt
@@ -4,6 +4,7 @@ import dev.ccpocket.daemon.conversation.OutboundSink
 import dev.ccpocket.daemon.session.SessionRegistry
 import dev.ccpocket.daemon.util.logger
 import dev.ccpocket.protocol.Envelope
+import dev.ccpocket.protocol.PocketError
 import dev.ccpocket.protocol.PocketJson
 import io.ktor.websocket.WebSocketSession
 import io.ktor.websocket.readText
@@ -51,7 +52,15 @@ class WsConnection(
                     val env = runCatching { PocketJson.decodeFromString<Envelope>(text) }.getOrNull()
                     if (env != null) {
                         log.info("recv ${env.body::class.simpleName}")
-                        launch { router.handle(env.body, sink) { owned.add(it) } }
+                        launch {
+                            try {
+                                router.handle(env.body, sink) { owned.add(it) }
+                            } catch (e: Exception) {
+                                if (e is kotlinx.coroutines.CancellationException) throw e
+                                log.warn("handle ${env.body::class.simpleName} failed: ${e.message}")
+                                runCatching { sink.emit(PocketError("internal", e.message ?: "request failed")) }
+                            }
+                        }
                     } else {
                         log.warn("undecodable frame: ${text.take(120)}")
                     }


### PR DESCRIPTION
## Problem

On Windows, npm-installed `claude` is a POSIX `#!/bin/sh` shell script. Java's `ProcessBuilder` cannot execute POSIX scripts on Windows (CreateProcess error 193: "not a valid Win32 application").

When the phone opens a session, the daemon tries to launch `claude`, fails with error 193, the exception propagates up and crashes the relay WebSocket connection — causing the phone to disconnect. **Both relay mode and direct LAN mode are affected.**

## Changes

### Bug 1: `ClaudeLauncher.kt` — Windows executable resolution
- On Windows, prefer `.cmd`/`.bat` wrappers over POSIX `#!` scripts
- POSIX scripts cannot be executed by `ProcessBuilder` on Windows
- `.cmd` files (generated by npm) are valid Windows executables

### Bug 2: `DeviceSessions.kt` + `WsConnection.kt` — error propagation
- `router.handle()` exceptions should not crash the transport
- Wrapped in try-catch, emit `PocketError` to the phone instead
- Applies to both relay path (DeviceSessions) and direct LAN path (WsConnection)

### Improvement: `Main.kt` — LAN mode UX
- `--local` mode now auto-detects the LAN IP address
- Prints a usable `ws://<lan-ip>:port/v1/ws` URL instead of `ws://0.0.0.0`
- Renders a terminal QR code for easy phone scanning

## Tested on
- Windows 10 x64
- npm-installed Claude Code v2.1.153
- cc-pocket daemon v0.1.0
- Android CC Pocket app