### PR TITLE
fix(daemon): don't fork session on cold resume

### DIFF
--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/Conversation.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/Conversation.kt
@@ -126,11 +126,11 @@ class Conversation(
         this.model = model
         this.effort = effort // restore the session's last reasoning effort on a fresh resume (transcript doesn't carry it)
         this.openedResumeId = resumeId
-        // fork on take-over / cold-resume: the resumed id may belong to a desktop `claude --resume` or a
-        // still-live terminal, and claude doesn't lock transcripts — so we branch into a fresh id (carrying
-        // the full history) and write there, leaving the original .jsonl untouched. The pump re-announces
-        // the forked sessionId below. No-op when resumeId is null (a brand-new session).
-        launchProcess(ClaudeSpec(workdir, resumeId, model, mode, effort = effort, forkSession = true))
+        // resume the session in-place — no fork. The registry already checked that no desktop
+        // `claude --resume` is actively writing this transcript (ObserveSession) and that we don't
+        // already own a live session for this id (reattach). Forking here would mint a new .jsonl
+        // every time the phone re-enters an idle session, cluttering the session list.
+        launchProcess(ClaudeSpec(workdir, resumeId, model, mode, effort = effort, forkSession = false))
         // claude in `--input-format stream-json` emits NOTHING (not even the system/init that would
         // drive SessionLive) until the first user turn lands on stdin. But the phone needs convoId —
         // carried by SessionLive — before it can send that first turn. Waiting for claude's init here


### PR DESCRIPTION
## 问题

进入一个已有会话（桌面 claude 创建的）时，每次进入都会在会话列表中多出一个重复条目。原因是 `Conversation.open()` 永远传 `forkSession = true`，导致 daemon 冷启动已完成的会话时用 `--fork-session` 创建新的 claude 会话 ID，写入新的 `.jsonl` 文件。

## 修复

`Conversation.open()` 中 `forkSession = true` → `forkSession = false`。

fork 的原始意图是保护正在被并发写入的 transcript——但 `SessionRegistry.open()` 在这之前已经走了两个分支：活进程 reattach、活跃 transcript 走 ObserveSession（只读）。走到 `Conversation.open()` 的只能是已完成的会话，不存在并发写入风险，fork 完全多余。

## 测试

- daemon 单元测试通过
- 桌面客户端 + 本地 daemon 实测：进入已有会话 → 发消息 → 退出 → 再进入，会话列表不再出现重复条目