### PR TITLE
fix(harmony/relay): #203 评审修复——心跳回显、E2E 串行化、convoId 门与 Push Kit v3

### DIFF
--- a/harmony/README.md
+++ b/harmony/README.md
@@ -9,9 +9,12 @@ HarmonyOS 工程（stage 模型，API 12+），按 `protocol/` 的 wire 规范�
 - 6 位码配对（POST /v1/pair/code → /v1/pair/redeem）
 - relay WebSocket 连接 + DeviceHello/Attached + 4-DH E2E 握手 + AES-256-GCM transport
 - 应用层 pocket/ping 心跳（鸿蒙 webSocket API 不暴露协议层 ping）
-- 项目列表 → 会话列表 → 聊天（历史回放 / 流式 chunk / 工具行 / 思考块）
-- 权限审批卡（允许一次 / 始终允许 / 拒绝）+ AskUserQuestion 单选问答卡
-- 断线指数退避重连（2s→30s），回前台立即重连；会话自动重开（restoreAfterReconnect 最小版）
+- 项目列表 → 会话列表 → 聊天（历史回放 / 流式 chunk / 工具行 / 思考块 / Markdown 渲染）
+- 权限审批卡（允许一次 / 始终允许 / 拒绝）+ AskUserQuestion 单选 / 多选问答卡
+- 图片 / 文件附件（相册选图内联、文档分块上传落 `.ccpocket/inbox/`、`@path` 引用折进 prompt）
+- 会话内权限模式切换 + 新会话默认模式（设置页）
+- Push Kit 离线推送（`pocket/push.register` → relay `HuaweiSender`，见下节）
+- 断线指数退避重连（2s→30s），回前台立即重连；会话自动重开（仅在握有具体 sessionId 时 resume，避免 fork）
 
 ## 架构决策（与 Kotlin 端的对应关系）
 
@@ -37,8 +40,13 @@ cryptoFramework 的 `AsyKeySpec` 系列（ECCKeyPairSpec / getAsyKeySpecBigInt�
 ## Push Kit（离线推送）
 
 链路：鸿蒙 App `pushService.getToken()` → `pocket/push.register`（platform=`"huawei"`，每次重连重发）
-→ relay `HuaweiSender`（AGC REST，`IM` 类目）→ 系统通知。**不需要受限 ACL**，与 DevEco
-自动化签名兼容。
+→ relay `HuaweiSender`（HarmonyOS NEXT Push Kit v3 REST，`IM` 自分类）→ 系统通知。**不需要受限 ACL**，
+与 DevEco 自动化签名兼容。
+
+> ⚠️ **relay 必须先合入本修复分支并 redeploy**（Ping 回显 + `HuaweiSender` v3 端点修正）。现网
+> 1.6.0 relay 的 device 腿不回显应用层 `pocket/pong`，鸿蒙端 10s 收不到 pong 即断连 →
+> 每约 30s 掉线循环；且旧 `HuaweiSender` 用的是 HMS Android 旧端点，推送会静默不发。两者都在
+> 本分支的 relay 侧修复里，未 redeploy 前鸿蒙端不可用。
 
 启用步骤（一次性，AGC 控制台操作为主）：
 
@@ -48,12 +56,13 @@ cryptoFramework 的 `AsyKeySpec` 系列（ECCKeyPairSpec / getAsyKeySpecBigInt�
 2. **开通 Push Kit**：项目 → 增长 → 推送服务 → 开通。
 3. **（建议）申请自分类权益**：推送服务 → 配置 → 自分类权益，申请 IM 类目。
    不申请也能推，但会落入资讯营销通道（限量、可能折叠）。
-4. **拿三个值**（项目设置 → 常规）：`Client ID`、`Client Secret`、`App ID`。
+4. **拿三个值**（项目设置 → 常规）：`Client ID`、`Client Secret`、`项目 ID`（Project ID，
+   Push Kit v3 端点 `POST /v3/{projectId}/messages:send` 的路径参数）。
 5. **App 端**：把 Client ID 填进 `entry/src/main/module.json5` 的
    `metadata.client_id`（替换 `REPLACE_WITH_AGC_CLIENT_ID`），重新打包装机。
    首次启动会弹通知授权。
 6. **relay 端**：主机环境变量加三行后重启 relay：
-   `CCPOCKET_HUAWEI_APP_ID` / `CCPOCKET_HUAWEI_CLIENT_ID` / `CCPOCKET_HUAWEI_CLIENT_SECRET`。
+   `CCPOCKET_HUAWEI_PROJECT_ID` / `CCPOCKET_HUAWEI_CLIENT_ID` / `CCPOCKET_HUAWEI_CLIENT_SECRET`。
    启动日志应见 `[push] Huawei sender ready`。
 7. **验证**：杀掉 App，让 daemon 产生一次审批/回复，手机应收系统通知；relay 侧
    `journalctl -u cc-pocket-relay` 能看到 huawei 发送记录。
@@ -95,8 +104,11 @@ modelVersion 必须与 hvigor/hvigor-config.json5 一致（均 "5.0.0"），否�
 
 ## 未覆盖（后续里程碑）
 
-- Push Kit 推送唤醒（M2，含 relay 侧 huawei sender）
-- 图片/文件附件、语音输入
-- Markdown 渲染 / 代码高亮（聊天文本当前是纯文本）
+> Push Kit 推送、图片 / 文件附件、Markdown 渲染均已在 M1 落地（见「功能范围」），不在此列。
+
+- 语音输入
+- 代码高亮（Markdown 已渲染，代码块暂无语法着色）
 - 多设备绑定管理、folder-share / bridge 管理面
-- Usage 统计、模型/模式切换、调度任务
+- Usage 统计、模型切换、调度任务
+- opencode 后端（M1 仅 claude：`frameClientCaps` 诚实声明空 `supportsAgents`，
+  开放前须把 agent 从 `SessionSummary` 透传进 `frameOpenSession`）

--- a/harmony/entry/src/main/ets/pocket/crypto/E2ECrypto.ets
+++ b/harmony/entry/src/main/ets/pocket/crypto/E2ECrypto.ets
@@ -195,7 +195,7 @@ export class E2ECrypto {
   /** AES-256-GCM seal：nonce 12 字节；返回 ciphertext‖tag（16 字节），同 Java AES/GCM 输出布局。 */
   static async seal(key: Uint8Array, nonce: Uint8Array, plaintext: Uint8Array, aad: Uint8Array): Promise<Uint8Array> {
     const symKey = await E2ECrypto.aesKey(key);
-    const cipher = cryptoFramework.createCipher('AES256|GCM|PKCS7');
+    const cipher = cryptoFramework.createCipher('AES256|GCM|NoPadding');
     const spec = E2ECrypto.gcmSpec(nonce, aad, new Uint8Array(0));
     cipher.initSync(cryptoFramework.CryptoMode.ENCRYPT_MODE, symKey, spec);
     const part1 = cipher.updateSync({ data: plaintext });
@@ -218,7 +218,7 @@ export class E2ECrypto {
     const tag = ctTag.slice(ctTag.length - 16);
     try {
       const symKey = await E2ECrypto.aesKey(key);
-      const cipher = cryptoFramework.createCipher('AES256|GCM|PKCS7');
+      const cipher = cryptoFramework.createCipher('AES256|GCM|NoPadding');
       const spec = E2ECrypto.gcmSpec(nonce, aad, tag);
       cipher.initSync(cryptoFramework.CryptoMode.DECRYPT_MODE, symKey, spec);
       const part1 = cipher.updateSync({ data: ct });
@@ -315,6 +315,24 @@ export class E2ECrypto {
       if ((await E2ECrypto.open(key, nonce, tampered, aad)) !== null) failures.push('gcm-tamper-accepted');
     } catch (e) {
       failures.push(`gcm-throw:${e}`);
+    }
+    try {
+      // 跨端已知答案向量（KAT）：与 JVM 参考实现逐字节一致，钉死「无填充」（ct 长 = pt 长 + 16 tag）
+      // 与字节序，防止 seal/open 自封自解两侧同错却全绿。
+      const katKey = hexToBytes('000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f');
+      const katNonce = hexToBytes('000000000000000000000001'); // 11 字节 0x00 ‖ 0x01（4 零 ‖ 8B BE 计数器 ctr=1）
+      const katAad = utf8('ccpocket-e2e-v1');
+      const katPt = utf8('cc-pocket cross-impl gcm kat');
+      const katExpect = hexToBytes(
+        '76b5928c2b975b7b7a0e324b83d549da' +
+        '7cf26c3844d537e9536b62ad215d7e15' +
+        'c886c3bc7001a3af2836aa5d');
+      const katSealed = await E2ECrypto.seal(katKey, katNonce, katPt, katAad);
+      if (!bytesEqual(katSealed, katExpect)) failures.push('gcm-kat-ximpl');
+      const katOpened = await E2ECrypto.open(katKey, katNonce, katExpect, katAad);
+      if (katOpened === null || !bytesEqual(katOpened, katPt)) failures.push('gcm-kat-open');
+    } catch (e) {
+      failures.push(`gcm-kat-throw:${e}`);
     }
     return failures;
   }

--- a/harmony/entry/src/main/ets/pocket/data/Repository.ets
+++ b/harmony/entry/src/main/ets/pocket/data/Repository.ets
@@ -89,6 +89,18 @@ export class PendingFile {
   landedName: string = '';
 }
 
+/**
+ * session.gone 恢复用的"最近一条 prompt"暂存（对齐 PocketRepository.PromptRetry）。
+ * daemon 丢了会话（断线期被回收 / daemon 重启）时，自动 resume 同一会话后把这条 prompt
+ * 补发一次；promptId 随行，若原发其实已落地，daemon 会去重（issue #66）。
+ */
+class PendingPrompt {
+  text: string = '';
+  images: ImageData[] = [];
+  workdir: string = '';
+  promptId: string = '';
+}
+
 @Observed
 export class Repository {
   static readonly instance = new Repository();
@@ -139,6 +151,8 @@ export class Repository {
   private uploadCancelCap: string | null = null;
   private fileAckTimer = -1;
   private pendingDefaultMode = '';    // 新会话待应用的默认模式（首个 session.live 后补 mode.switch）
+  private pendingPrompt: PendingPrompt | null = null; // session.gone 恢复：最近一条待补发的 prompt
+  private promptResendArmed = false;  // session.gone 已触发重开、等下一个匹配的 session.live 补发
 
   // ═══ 生命周期 ═══
 
@@ -259,6 +273,8 @@ export class Repository {
     this.currentAsk = null;
     this.executing = false;
     this.activity = '';
+    this.pendingPrompt = null;
+    this.promptResendArmed = false;
     this.clearAttachments();
     this.screen = 'projects';
     this.connect();
@@ -299,6 +315,8 @@ export class Repository {
     this.messages = [];
     this.convoId = null;
     this.currentSessionId = null;
+    this.pendingPrompt = null;
+    this.promptResendArmed = false;
     this.clearAttachments();
     if (this.paired === null) {
       this.screen = 'pairing';
@@ -337,8 +355,12 @@ export class Repository {
             conn.sendControl(controlRegisterPush('huawei', t));
           }
         });
-        // 重连后恢复打开的会话（对齐 restoreAfterReconnect 的最小版）；带当前模式避免重置
-        if (repo.convoId !== null && repo.currentWorkdir.length > 0) {
+        // 重连后恢复打开的会话（对齐 restoreAfterReconnect 的最小版）；带当前模式避免重置。
+        // 必须同时握有 convoId 与具体 sessionId 才自动 resume（对齐 mobile 的
+        // `convo != null && sid != null && wd != null`）：新会话在 session.live 回填 sessionId
+        // 前断线重连时，resumeId=null 会被 daemon 当成"开全新会话" → fork（本仓库修过的
+        // "冗余会话=fork"老病）。宁可不自动重开、让用户手动重进，也不制造分叉。
+        if (repo.convoId !== null && repo.currentSessionId !== null && repo.currentWorkdir.length > 0) {
           conn.send(frameOpenSession(repo.currentWorkdir, repo.currentSessionId, null, repo.mode));
         }
       },
@@ -398,6 +420,8 @@ export class Repository {
     this.executing = false;
     this.activity = '';
     this.allowRules = []; // 规则是会话级的（对齐：换会话即清空本地镜像）
+    this.pendingPrompt = null; // 换会话即丢弃上个会话的补发暂存（否则同 workdir 换会话会误投）
+    this.promptResendArmed = false;
     this.clearAttachments();
     // 新会话带默认模式；OpenSession 无原生模式字段，'auto' 经首个 session.live 后补 mode.switch
     this.pendingDefaultMode = sessionId === null ? this.defaultMode : '';
@@ -459,7 +483,31 @@ export class Repository {
     this.executing = true;
     this.pendingImages = [];
     this.pendingFiles = [];
+    // session.gone 恢复暂存：这条 prompt 打进了活会话，若 daemon 已把会话回收，收到
+    // session.gone 后自动 resume 并补发这份（单次）。首个真·回合证据（chunk/tool/turn.done）到达即清。
+    const pending = new PendingPrompt();
+    pending.text = outText;
+    pending.images = images;
+    pending.workdir = this.currentWorkdir;
+    pending.promptId = promptId;
+    this.pendingPrompt = pending;
+    this.promptResendArmed = false;
     this.conn?.send(frameSendPrompt(convoId, outText, promptId, images));
+  }
+
+  /** 真·回合证据到达（chunk/tool/turn.done）：prompt 已被处理，丢掉补发暂存（对齐 promptEvidence）。 */
+  private promptEvidence(): void {
+    this.pendingPrompt = null;
+  }
+
+  /**
+   * 会话域帧 convoId 门（跨会话转录污染防线，对齐 PocketRepository 各 `f.convoId == convoId.value`）：
+   * 当前无活跃会话，或帧的 convoId 与当前会话不符，一律忽略。session.live 是"确立 convoId"的帧、
+   * 不走此门；列表/审批清单/usage 等非会话域帧同样不受影响。
+   */
+  private forCurrentConvo(body: Record<string, Object>): boolean {
+    const c = this.convoId;
+    return c !== null && js(body['convoId']) === c;
   }
 
   // ═══ 附件 ═══
@@ -696,6 +744,8 @@ export class Repository {
       this.conn?.send(frameCloseSession(convoId));
     }
     this.convoId = null;
+    this.pendingPrompt = null;
+    this.promptResendArmed = false;
     this.clearAttachments();
     this.backToSessions();
   }
@@ -735,9 +785,20 @@ export class Repository {
             this.conn?.send(frameModeSwitch(this.convoId, want));
           }
         }
+        // session.gone 恢复（对齐 PocketRepository 的 SessionLive 分支）：重开已落地，补发那条
+        // 打进死会话的 prompt。单次——同 promptId 让 daemon 去重；workdir 匹配防止用户中途
+        // 导航走后误投。第二次 session.gone 会走诚实报错分支，绝不成环。
+        const retry = this.pendingPrompt;
+        if (this.promptResendArmed && retry !== null && retry.workdir === this.currentWorkdir) {
+          this.pendingPrompt = null;
+          this.promptResendArmed = false;
+          this.executing = true;
+          this.conn?.send(frameSendPrompt(this.convoId, retry.text, retry.promptId, retry.images));
+        }
         break;
       }
       case 'pocket/history': {
+        if (!this.forCurrentConvo(body)) break; // 跨会话回放会污染/清空当前 transcript
         const delta = jb(body['delta']);
         const rows = ja(body['messages']).map((v: Object) => this.historyToChat(HistoryMessage.from(v)));
         if (delta) {
@@ -750,6 +811,8 @@ export class Repository {
         break;
       }
       case 'pocket/chunk': {
+        if (!this.forCurrentConvo(body)) break; // 刚离开的会话的流尾不能渲染进当前会话
+        this.promptEvidence();
         const piece = jo(body['piece']);
         const kind = js(piece['t']);
         const text = js(piece['text']);
@@ -763,6 +826,8 @@ export class Repository {
         break;
       }
       case 'pocket/tool': {
+        if (!this.forCurrentConvo(body)) break;
+        this.promptEvidence();
         const phase = js(body['phase']);
         const tool = js(body['tool']);
         const preview = jstr(body['inputPreview']);
@@ -784,10 +849,12 @@ export class Repository {
         break;
       }
       case 'pocket/ask': {
+        if (!this.forCurrentConvo(body)) break; // 别的会话的审批不弹进当前会话
         this.currentAsk = PermissionAsk.from(body);
         break;
       }
       case 'pocket/ask.withdrawn': {
+        if (!this.forCurrentConvo(body)) break;
         const askId = js(body['askId']);
         if (this.currentAsk !== null && this.currentAsk.askId === askId) {
           this.currentAsk = null;
@@ -795,6 +862,8 @@ export class Repository {
         break;
       }
       case 'pocket/turn.done': {
+        if (!this.forCurrentConvo(body)) break;
+        this.promptEvidence();
         this.executing = false;
         this.activity = '';
         this.finalizeStreaming();
@@ -807,6 +876,7 @@ export class Repository {
         break;
       }
       case 'pocket/prompt.ack': {
+        if (!this.forCurrentConvo(body)) break;
         const promptId = js(body['promptId']);
         this.messages = this.messages.map((m: ChatMessage) => {
           if (m.promptId === promptId) m.delivered = true;
@@ -815,15 +885,31 @@ export class Repository {
         break;
       }
       case 'pocket/error': {
+        // convoId 缺省 = 连接级错误，照单展示；带了别的会话的 convoId 则不属于当前会话，忽略
+        const ec = jstr(body['convoId']);
+        if (ec !== null && ec !== this.convoId) break;
         const m = this.newMessage('error');
         m.text = js(body['message'], js(body['code'], 'error'));
         this.pushMessage(m);
         break;
       }
       case 'pocket/session.gone': {
-        // daemon 丢了这个会话（对齐：自动重开）。M1：重开当前会话。
-        if (this.currentWorkdir.length > 0) {
+        // daemon 丢了这个会话（断线期被回收 / daemon 重启）。对齐 PocketRepository 的 SessionGone：
+        // 有待补发的 prompt 才自动 resume——重开落地后由 session.live 分支补发那条 prompt（单次）；
+        // 没有 pending prompt（或已重试过一次），诚实报错、别空转。convoId 必须匹配（跨会话不处理）。
+        if (!this.forCurrentConvo(body)) break;
+        const retry = this.pendingPrompt;
+        if (retry !== null && !this.promptResendArmed && this.currentSessionId !== null && this.currentWorkdir.length > 0) {
+          this.promptResendArmed = true;
           this.conn?.send(frameOpenSession(this.currentWorkdir, this.currentSessionId, null, this.mode));
+        } else {
+          this.promptResendArmed = false;
+          this.pendingPrompt = null;
+          this.executing = false;
+          this.activity = '';
+          const m = this.newMessage('error');
+          m.text = '电脑端已回收该会话——再发一条消息可重新拉起';
+          this.pushMessage(m);
         }
         break;
       }
@@ -837,6 +923,7 @@ export class Repository {
         break;
       }
       case 'pocket/file.uploaded': {
+        if (!this.forCurrentConvo(body)) break;
         this.onFileUploaded(FileUploaded.from(body));
         break;
       }

--- a/harmony/entry/src/main/ets/pocket/data/TranscriptMerge.ets
+++ b/harmony/entry/src/main/ets/pocket/data/TranscriptMerge.ets
@@ -111,8 +111,28 @@ export function mergeHistory(local: ChatMessage[], replay: ChatMessage[]): ChatM
     const r = replay[ri];
     if (couldPair(l, r)) {
       if (l.role === 'assistant') {
-        // 流式泡泡与磁盘行对齐：谁在文本上延伸就取谁（回放滞后保住流式，离线回补补全文本）
-        l.text = r.text.startsWith(l.text) ? r.text : l.text;
+        // 一条本地流式气泡可能跨回放里的多条 assistant 行：appendStream 把同回合连续的 text
+        // block 粘成一条气泡，回放却按 block 分行落地。只在本地文本"还有未匹配余量"时才继续
+        // 吃下一条回放行——一旦覆盖，后面的 assistant 行就是真正的新内容（各自成泡），不能再吞，
+        // 否则重连回放会被误当断线回补追加 → 内容重复（对齐 TranscriptMerge.kt 61-83 的 acc 逻辑）。
+        let acc = r.text;
+        while (ri + 1 < replay.length && acc.length < l.text.length) {
+          const nx = replay[ri + 1];
+          if (nx.role !== 'assistant') break;
+          const cand = acc + nx.text;
+          if (l.text.startsWith(cand) || cand.startsWith(l.text)) {
+            acc = cand;
+            ri++;
+          } else {
+            break;
+          }
+        }
+        // 回放追上（或越过）气泡 → 采用回放全文；本地仍领先且回放后面还有 assistant 行 =
+        // 本地泡泡是跨掉块粘起来的、信磁盘 → 也采用 acc；否则是磁盘读落后于流 → 保留本地。
+        const nextIsAssistant = ri + 1 < replay.length && replay[ri + 1].role === 'assistant';
+        if (acc.startsWith(l.text) || nextIsAssistant) {
+          l.text = acc;
+        }
       } else if (l.role === 'tool' && l.ok === null && r.ok !== null) {
         l.ok = r.ok;
       }

--- a/harmony/entry/src/main/ets/pocket/net/RelayConnection.ets
+++ b/harmony/entry/src/main/ets/pocket/net/RelayConnection.ets
@@ -26,6 +26,7 @@ const TAG = 'ccpocket';
 const HANDSHAKE_TIMEOUT_MS = 15000;
 const PING_INTERVAL_MS = 20000;
 const PONG_TIMEOUT_MS = 10000;
+const PONG_MAX_MISSES = 2; // 连续未收到 pong 达此次数才判定掉线（配合 relay Ping 回显，抖动时少一次全量重连）
 
 export interface RelayCallbacks {
   /** 完成 Attached + E2E 握手，transport 可用。 */
@@ -61,7 +62,12 @@ export class RelayConnection {
   private pingTimer = -1;
   private handshakeTimer = -1;
   private pongTimer = -1;
+  private pongMisses = 0; // 连续未命中 pong 计数；收到 pong 或停止心跳清零（见 armPongWait/onPongTimeout）
   private alive = false; // 本连接是否仍被需要（主动断开后回调全部丢弃）
+  // 出/入站各持一条 promise 链，把 AES seal/open 串行化：保证「取号顺序 = 上线顺序」「按到达顺序解密投递」，
+  // 否则各帧异步加密完成先后不定 → daemon 严格递增计数器检查把迟到的小计数器帧当重放静默丢弃（对齐 Kotlin 单协程写端）。
+  private sendChain: Promise<void> = Promise.resolve();
+  private recvChain: Promise<void> = Promise.resolve();
   private cb: RelayCallbacks;
 
   constructor(cb: RelayCallbacks) {
@@ -159,18 +165,23 @@ export class RelayConnection {
       return;
     }
     if (this.phase === 'transport' && type === 2 && this.session !== null) {
-      this.session.open(payload).then((pt) => {
-        if (pt === null) {
-          hilog.warn(0x0000, TAG, 'transport frame dropped (decrypt/replay)');
-          return;
-        }
-        try {
-          const env = JSON.parse(fromUtf8(pt)) as Record<string, Object>;
-          const body = (env['body'] ?? {}) as Record<string, Object>;
-          this.cb.onFrame(body);
-        } catch (e) {
-          hilog.warn(0x0000, TAG, 'bad envelope json');
-        }
+      const session = this.session;
+      // 进入 recvChain：open→dispatch 按到达顺序串行，避免异步解密乱序回写 recvCtr 小值 + 乱序投递。
+      this.recvChain = this.recvChain.then((): Promise<void> => {
+        if (!this.alive || this.session === null) return Promise.resolve();
+        return session.open(payload).then((pt) => {
+          if (pt === null) {
+            hilog.warn(0x0000, TAG, 'transport frame dropped (decrypt/replay)');
+            return;
+          }
+          try {
+            const env = JSON.parse(fromUtf8(pt)) as Record<string, Object>;
+            const body = (env['body'] ?? {}) as Record<string, Object>;
+            this.cb.onFrame(body);
+          } catch (e) {
+            hilog.warn(0x0000, TAG, 'bad envelope json');
+          }
+        });
       }).catch((e: Error) => this.fail(`decrypt:${e.message}`));
     }
   }
@@ -214,9 +225,15 @@ export class RelayConnection {
   private sealAndSend(envelopeJsonText: string): void {
     const session = this.session;
     if (session === null) return;
-    session.seal(utf8(envelopeJsonText)).then((sealed) => {
-      if (!this.alive) return;
-      this.sendBinary(concatBytes(new Uint8Array([2]), sealed));
+    // 进入 sendChain：把 seal 的「取号 + 上线」整体串行，保证取号顺序 = 上线顺序。
+    // .catch 正常返回 → 链复位为 resolved，一次失败不永久卡死后续帧（fail 已置 alive=false，后续帧自动短路）。
+    this.sendChain = this.sendChain.then((): Promise<void> => {
+      if (!this.alive || this.session === null) return Promise.resolve();
+      return session.seal(utf8(envelopeJsonText)).then((sealed) => {
+        if (this.alive) {
+          this.sendBinary(concatBytes(new Uint8Array([2]), sealed));
+        }
+      });
     }).catch((e: Error) => this.fail(`seal:${e.message}`));
   }
 
@@ -248,7 +265,18 @@ export class RelayConnection {
       this.pongTimer = -1;
     }
     if (arm) {
-      this.pongTimer = setTimeout(() => this.fail('pong-timeout'), PONG_TIMEOUT_MS);
+      this.pongTimer = setTimeout(() => this.onPongTimeout(), PONG_TIMEOUT_MS);
+    } else {
+      this.pongMisses = 0; // 收到 pong（或停止心跳）→ 清零连续未命中计数
+    }
+  }
+
+  private onPongTimeout(): void {
+    this.pongTimer = -1;
+    this.pongMisses++;
+    // 未达阈值不立即断连：下一个 ping 周期（PING_INTERVAL_MS > PONG_TIMEOUT_MS）会再次 armPongWait 复探。
+    if (this.pongMisses >= PONG_MAX_MISSES) {
+      this.fail('pong-timeout');
     }
   }
 
@@ -294,5 +322,8 @@ export class RelayConnection {
     this.session = null;
     this.initiator = null;
     this.outbox = [];
+    this.sendChain = Promise.resolve(); // 复位串行链，避免复用连接对象时残留旧的 rejected/pending 态
+    this.recvChain = Promise.resolve();
+    this.pongMisses = 0;
   }
 }

--- a/harmony/entry/src/main/ets/pocket/protocol/Protocol.ets
+++ b/harmony/entry/src/main/ets/pocket/protocol/Protocol.ets
@@ -180,7 +180,12 @@ export interface BodyPing {
 }
 
 export function frameClientCaps(): FrameClientCaps {
-  return { t: 'pocket/client.caps', supportsAgents: ['opencode'] };
+  // M1 只支持 claude 后端（frameOpenSession 硬编码 agent:'claude'）：绝不能谎报 'opencode'。
+  // daemon 看到该声明会把 opencode 会话行下发给手机（RequestRouter.emitSessions：
+  // supportsOpencode==true 才不过滤），用户点开一条 opencode 会话会被以 claude resume → fork
+  // 出一个新会话。空列表 = 诚实声明，daemon 会为本端过滤掉 opencode 行（claude/codex 行照常）。
+  // 后续支持 opencode 时：须把 agent 从 SessionSummary 透传进 frameOpenSession，再在这里加回 'opencode'。
+  return { t: 'pocket/client.caps', supportsAgents: [] };
 }
 
 export function frameListDirectories(root: string | null = null): FrameDirsList {

--- a/harmony/entry/src/main/ets/pocket/ui/AskCard.ets
+++ b/harmony/entry/src/main/ets/pocket/ui/AskCard.ets
@@ -5,34 +5,57 @@ import { Tok } from './Theme';
 /**
  * 权限审批卡 / AskUserQuestion 提问卡（深色主题）。
  * 权限：允许一次 / 始终允许（有 rule 且非 one-off）/ 拒绝。
- * 提问：逐题单选，提交时 answers = {questionText: label}（对齐 PermissionVerdict.answers）。
+ * 提问：单选题逐题单选、多选题（multiSelect=true）可多选；提交时 answers =
+ * {questionText: label(s)}，多选值为逗号连接的选项 labels（选项原序），对齐 mobile
+ * QuestionCard.answerOf 的 `joinToString(", ")` 与 PermissionVerdict.answers 形状。
  */
 @Component
 export struct AskCard {
   @Prop ask: PermissionAsk;
   @ObjectLink repo: Repository;
-  @State picked: Map<string, string> = new Map();
+  // 每题 → 已选 label 数组（单选长度 ≤1，多选可多个）。改后重赋触发刷新（ArkUI V1 观察语义）。
+  @State selections: Map<string, string[]> = new Map();
 
-  private pick(question: string, label: string): void {
-    const next = new Map(this.picked);
-    next.set(question, label);
-    this.picked = next;
+  private isPicked(question: string, label: string): boolean {
+    const arr = this.selections.get(question);
+    return arr !== undefined && arr.includes(label);
+  }
+
+  /** 切换选中（对齐 mobile QuestionCard.toggle）：单选=替换/再点取消；多选=加入/移除。 */
+  private toggle(question: string, label: string, multi: boolean): void {
+    const cur = this.selections.get(question) ?? [];
+    const next = new Map(this.selections);
+    if (!multi) {
+      next.set(question, cur.includes(label) ? [] : [label]);
+    } else if (cur.includes(label)) {
+      next.set(question, cur.filter((x: string) => x !== label));
+    } else {
+      next.set(question, [...cur, label]);
+    }
+    this.selections = next;
   }
 
   private allAnswered(): boolean {
     const qs = this.ask.questions;
     if (qs === null || qs.length === 0) return false;
     for (const q of qs) {
-      if (!this.picked.has(q.question)) return false;
+      const arr = this.selections.get(q.question);
+      if (arr === undefined || arr.length === 0) return false;
     }
     return true;
   }
 
   private submitAnswers(): void {
     const answers: Record<string, string> = {};
-    this.picked.forEach((label: string, question: string) => {
-      answers[question] = label;
-    });
+    const qs = this.ask.questions;
+    if (qs !== null) {
+      for (const q of qs) {
+        const sel = this.selections.get(q.question) ?? [];
+        // 选项原序过滤已选，逗号（+空格）连接——多选值形如 "A, B"（对齐 answerOf 的 joinToString(", ")）
+        const labels = q.options.map((o: AskOption) => o.label).filter((l: string) => sel.includes(l));
+        answers[q.question] = labels.join(', ');
+      }
+    }
     this.repo.answerAsk('allow', false, answers);
   }
 
@@ -86,25 +109,35 @@ export struct AskCard {
         // ── AskUserQuestion ──
         ForEach(this.ask.questions, (q: AskQuestion) => {
           Column({ space: 8 }) {
-            Text(q.question)
-              .fontSize(14)
-              .fontColor(Tok.tx)
-              .fontWeight(FontWeight.Medium)
+            Row({ space: 6 }) {
+              Text(q.question)
+                .fontSize(14)
+                .fontColor(Tok.tx)
+                .fontWeight(FontWeight.Medium)
+                .layoutWeight(1)
+              if (q.multiSelect) {
+                Text('可多选')
+                  .fontSize(11)
+                  .fontColor(Tok.tx2)
+              }
+            }
+            .width('100%')
+            .alignItems(VerticalAlign.Center)
             Flex({ wrap: FlexWrap.Wrap }) {
               ForEach(q.options, (opt: AskOption) => {
                 Text(opt.label)
                   .fontSize(12)
-                  .fontColor(this.picked.get(q.question) === opt.label ? '#FFFFFF' : Tok.tx2)
+                  .fontColor(this.isPicked(q.question, opt.label) ? '#FFFFFF' : Tok.tx2)
                   .padding({ left: 12, right: 12, top: 6, bottom: 6 })
                   .margin({ right: 6, bottom: 6 })
-                  .backgroundColor(this.picked.get(q.question) === opt.label ? Tok.accent : Tok.raised)
+                  .backgroundColor(this.isPicked(q.question, opt.label) ? Tok.accent : Tok.raised)
                   .borderRadius(14)
                   .border({
                     width: 1,
-                    color: this.picked.get(q.question) === opt.label ? Tok.accent : Tok.hair,
+                    color: this.isPicked(q.question, opt.label) ? Tok.accent : Tok.hair,
                     radius: 14,
                   })
-                  .onClick(() => this.pick(q.question, opt.label))
+                  .onClick(() => this.toggle(q.question, opt.label, q.multiSelect))
               }, (opt: AskOption) => opt.label)
             }
           }

--- a/relay/src/main/kotlin/dev/ccpocket/relay/RelayServer.kt
+++ b/relay/src/main/kotlin/dev/ccpocket/relay/RelayServer.kt
@@ -300,11 +300,16 @@ class RelayServer(
      *  whole purpose is being woken for an offer. That is safe precisely because the two exclusions are
      *  separate: it still never appears in [RelayStore.pushTargets], so the token it registers can only ever
      *  be reached by a TARGETED [NotifyPush] naming its own deviceId. */
-    private suspend fun handleDeviceControl(deviceId: String, text: String) {
+    internal suspend fun handleDeviceControl(conn: Conn, text: String) {
+        val deviceId = conn.deviceId ?: return
         when (val body = runCatching { PocketJson.decodeFromString<Envelope>(text).body }.getOrNull()) {
             is RegisterPush -> if (store.getDevice(deviceId)?.mayRegisterPush == true) {
                 runCatching { store.setPushToken(deviceId, body.platform, body.token, clock()) }
             }
+            // app-level liveness echo on THIS socket only (mirrors the daemon leg's Ping handling). Clients
+            // with no protocol-layer ping (HarmonyOS webSocket API) drive pocket/ping→pocket/pong themselves
+            // and drop the link on a missed pong — without the echo they loop-reconnect every ~30s.
+            is Ping -> runCatching { conn.sendText(controlText(Pong(body.ts))) }
             else -> {}
         }
     }
@@ -351,7 +356,7 @@ class RelayServer(
         try {
             for (frame in incoming) when (frame) {
                 is Frame.Binary -> broker.toDaemonFrom(account, hello.deviceId, frame.data)
-                is Frame.Text -> handleDeviceControl(hello.deviceId, frame.readText())
+                is Frame.Text -> handleDeviceControl(conn, frame.readText())
                 else -> {}
             }
         } finally {

--- a/relay/src/main/kotlin/dev/ccpocket/relay/push/HuaweiSender.kt
+++ b/relay/src/main/kotlin/dev/ccpocket/relay/push/HuaweiSender.kt
@@ -17,17 +17,18 @@ import java.net.http.HttpResponse
 import java.time.Duration
 
 /**
- * Huawei Push Kit (AGC) REST sender for HarmonyOS devices. Mints an OAuth access token via the
+ * Huawei Push Kit (AGC) REST sender for HarmonyOS NEXT devices. Mints an OAuth access token via the
  * client_credentials grant (cached until ~5 min before expiry), then POSTs an IM-category
- * notification to /v1/{appId}/messages:send. Credentials are the AGC project's client id/secret
- * (AppGallery Connect → 项目设置 → 常规), never in the repo — see PushConfig env names.
+ * notification to the v3 endpoint /v3/{projectId}/messages:send with the mandatory push-type: 0 header
+ * (0 = 通知消息). Credentials are the AGC project's client id/secret (AppGallery Connect → 项目设置 →
+ * 常规), never in the repo — see PushConfig env names.
  *
  * The IM category rides the 自分类权益 the project applied for in AGC; without it Huawei may
  * downgrade delivery to the quota-capped 资讯营销 lane. Token-invalid mapping: AGC answers
  * HTTP 200 with {"code":"80000000"} on success; 80300007 = token invalid/unknown → prune.
  */
 class HuaweiSender(
-    private val appId: String,
+    private val projectId: String,
     private val clientId: String,
     private val clientSecret: String,
     private val now: () -> Long = System::currentTimeMillis,
@@ -73,21 +74,7 @@ class HuaweiSender(
                     putJsonObject("clickAction") { put("actionType", 0) } // 0 = 打开应用首页
                     // 路由数据随点击的 want 带回（对齐 FcmSender 的 data 形状：wd/sid 直达会话，
                     // hid 落到 offer 收件箱；kind 是内容无关的类别提示）。通知体本身不展示这些。
-                    route?.let { r ->
-                        val d = buildString {
-                            append('{')
-                            var first = true
-                            fun kv(k: String, v: String?) {
-                                if (v == null) return
-                                if (!first) append(',')
-                                first = false
-                                append("\"$k\":\"$v\"")
-                            }
-                            kv("wd", r.workdir); kv("sid", r.sessionId); kv("hid", r.handoffId); kv("kind", r.kind)
-                            append('}')
-                        }
-                        if (d != "{}") put("data", d)
-                    }
+                    routeData(route)?.let { put("data", it) }
                 }
             }
             putJsonObject("target") {
@@ -97,10 +84,11 @@ class HuaweiSender(
         val resp = withContext(Dispatchers.IO) {
             http.send(
                 HttpRequest.newBuilder()
-                    .uri(URI.create("https://push-api.cloud.huawei.com/v1/$appId/messages:send"))
+                    .uri(URI.create("https://push-api.cloud.huawei.com/v3/$projectId/messages:send"))
                     .timeout(Duration.ofSeconds(10))
                     .header("authorization", "Bearer $auth")
                     .header("content-type", "application/json")
+                    .header("push-type", "0") // 0 = 通知消息（v3 必填）
                     .POST(HttpRequest.BodyPublishers.ofString(payload)).build(),
                 HttpResponse.BodyHandlers.ofString(),
             )
@@ -120,5 +108,21 @@ class HuaweiSender(
         }
         System.err.println("[push] huawei ${resp.statusCode()}: ${resp.body()}")
         return if (resp.statusCode() == 404) SendResult.INVALID_TOKEN else SendResult.FAILED
+    }
+
+    companion object {
+        /** Inner routing JSON (a stringified object, per Push Kit's clickAction data). Built with
+         *  [buildJsonObject] so a Windows workdir's backslashes / quotes escape correctly — a hand-spliced
+         *  string would emit invalid JSON the client's JSON.parse chokes on. Null (键不放) when empty. */
+        internal fun routeData(route: NotifyRoute?): String? {
+            val r = route ?: return null
+            val obj = buildJsonObject {
+                r.workdir?.let { put("wd", it) }
+                r.sessionId?.let { put("sid", it) }
+                r.handoffId?.let { put("hid", it) }
+                r.kind?.let { put("kind", it) }
+            }
+            return if (obj.isEmpty()) null else obj.toString()
+        }
     }
 }

--- a/relay/src/main/kotlin/dev/ccpocket/relay/push/PushConfig.kt
+++ b/relay/src/main/kotlin/dev/ccpocket/relay/push/PushConfig.kt
@@ -11,8 +11,8 @@ import java.io.File
  *   APNs: CCPOCKET_APNS_KEY_P8 (path to .p8) · CCPOCKET_APNS_KEY_ID · CCPOCKET_APNS_TEAM_ID
  *         · CCPOCKET_APNS_TOPIC (= iOS bundle id)
  *   FCM:  CCPOCKET_FCM_CREDENTIALS (or GOOGLE_APPLICATION_CREDENTIALS) — path to service-account JSON
- *   Huawei (HarmonyOS Push Kit): CCPOCKET_HUAWEI_APP_ID · CCPOCKET_HUAWEI_CLIENT_ID
- *         · CCPOCKET_HUAWEI_CLIENT_SECRET — AGC 项目设置 → 常规 → 项目凭据
+ *   Huawei (HarmonyOS Push Kit): CCPOCKET_HUAWEI_PROJECT_ID · CCPOCKET_HUAWEI_CLIENT_ID
+ *         · CCPOCKET_HUAWEI_CLIENT_SECRET — AGC 项目设置 → 常规 → 项目 ID / 项目凭据
  */
 object PushConfig {
     fun load(store: RelayStore, env: (String) -> String? = System::getenv): PushService {
@@ -39,13 +39,13 @@ object PushConfig {
             }.onFailure { println("[push] FCM config error: ${it.message}") }
         }
 
-        val hwAppId = env("CCPOCKET_HUAWEI_APP_ID")
+        val hwProjectId = env("CCPOCKET_HUAWEI_PROJECT_ID")
         val hwClientId = env("CCPOCKET_HUAWEI_CLIENT_ID")
         val hwClientSecret = env("CCPOCKET_HUAWEI_CLIENT_SECRET")
-        if (hwAppId != null && hwClientId != null && hwClientSecret != null) {
+        if (hwProjectId != null && hwClientId != null && hwClientSecret != null) {
             runCatching {
-                senders["huawei"] = HuaweiSender(hwAppId, hwClientId, hwClientSecret)
-                println("[push] Huawei sender ready (appId=$hwAppId)")
+                senders["huawei"] = HuaweiSender(hwProjectId, hwClientId, hwClientSecret)
+                println("[push] Huawei sender ready (projectId=$hwProjectId)")
             }.onFailure { println("[push] Huawei config error: ${it.message}") }
         }
 

--- a/relay/src/test/kotlin/dev/ccpocket/relay/PushTest.kt
+++ b/relay/src/test/kotlin/dev/ccpocket/relay/PushTest.kt
@@ -1,5 +1,7 @@
 package dev.ccpocket.relay
 
+import dev.ccpocket.protocol.PocketJson
+import dev.ccpocket.relay.push.HuaweiSender
 import dev.ccpocket.relay.push.LoggingPushService
 import dev.ccpocket.relay.push.NotifyRoute
 import dev.ccpocket.relay.push.PushConfig
@@ -12,10 +14,13 @@ import dev.ccpocket.relay.store.InMemoryRelayStore
 import dev.ccpocket.relay.store.RelayStore
 import dev.ccpocket.relay.store.SqliteRelayStore
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class PushTest {
@@ -177,6 +182,25 @@ class PushTest {
 
     @Test fun configFallsBackToLoggingWithoutCredentials() {
         assertIs<LoggingPushService>(PushConfig.load(InMemoryRelayStore()) { null })
+    }
+
+    /** Huawei route → clickAction data: a Windows workdir's backslashes and any quotes must escape into
+     *  valid JSON (the old hand-spliced string emitted `"wd":"C:\Users\…"` that JSON.parse rejects). */
+    @Test fun huaweiRouteDataEscapesBackslashesAndQuotes() {
+        val json = HuaweiSender.routeData(NotifyRoute(workdir = """C:\Users\me\a"b""", sessionId = "s1"))
+        // it must round-trip back to the exact original strings
+        val obj = PocketJson.parseToJsonElement(json!!).jsonObject
+        assertEquals("""C:\Users\me\a"b""", obj["wd"]!!.jsonPrimitive.content)
+        assertEquals("s1", obj["sid"]!!.jsonPrimitive.content)
+        // and be literally escaped in the wire text, not raw
+        assertTrue(json.contains("""C:\\Users\\me\\a\"b"""))
+    }
+
+    /** 空对象不放 semantics preserved: no route (or an all-null route) yields no `data` key at all. */
+    @Test fun huaweiRouteDataOmitsEmpty() {
+        assertNull(HuaweiSender.routeData(null))
+        assertNull(HuaweiSender.routeData(NotifyRoute()))
+        assertEquals("""{"hid":"h1"}""", HuaweiSender.routeData(NotifyRoute(handoffId = "h1")))
     }
 
     private class RecordingSender : PushSender {

--- a/relay/src/test/kotlin/dev/ccpocket/relay/RelayServerControlTest.kt
+++ b/relay/src/test/kotlin/dev/ccpocket/relay/RelayServerControlTest.kt
@@ -1,0 +1,47 @@
+package dev.ccpocket.relay
+
+import dev.ccpocket.protocol.Envelope
+import dev.ccpocket.protocol.Ping
+import dev.ccpocket.protocol.PocketJson
+import dev.ccpocket.protocol.Pong
+import dev.ccpocket.protocol.RegisterPush
+import dev.ccpocket.protocol.Role
+import dev.ccpocket.protocol.Route
+import dev.ccpocket.relay.store.InMemoryRelayStore
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/** device control TEXT plane (RelayServer.handleDeviceControl): the app-level liveness echo. */
+class RelayServerControlTest {
+
+    private fun server() = RelayServer("127.0.0.1", 0, InMemoryRelayStore(), clock = { 1_000 })
+
+    private fun control(body: dev.ccpocket.protocol.Frame): String =
+        PocketJson.encodeToString(Envelope(id = "d", ts = 0, to = Route.RELAY, body = body))
+
+    @Test fun device_ping_is_echoed_as_pong_on_the_same_socket() = runBlocking {
+        val sent = mutableListOf<String>()
+        val conn = Conn("acct", Role.DEVICE, "dev1", sendText = { sent += it }, sendBinary = {}, close = {})
+
+        server().handleDeviceControl(conn, control(Ping(ts = 777)))
+
+        val echo = assertIs<Pong>(PocketJson.decodeFromString<Envelope>(sent.single()).body)
+        assertEquals(777, echo.ts) // the Pong carries the Ping's ts back verbatim
+    }
+
+    @Test fun non_ping_control_produces_no_echo() = runBlocking {
+        val sent = mutableListOf<String>()
+        // no device row → RegisterPush is a silent no-op, and it must never trigger a Pong either
+        val conn = Conn("acct", Role.DEVICE, "dev1", sendText = { sent += it }, sendBinary = {}, close = {})
+
+        server().handleDeviceControl(conn, control(RegisterPush("fcm", "tok")))
+        server().handleDeviceControl(conn, control(Pong(ts = 1))) // a stray pong isn't echoed
+
+        assertTrue(sent.isEmpty())
+    }
+}


### PR DESCRIPTION
## #203 评审修复：三个互通阻塞项 + 推送通道修正（供 @Xinkun-WANG 评估）

对 #203 做了全面评审（wire 兼容 + E2E 加密双路独立审查）。移植质量很高：wire 词汇表逐项对照 `protocol/` 未发现拼写或字节序错误，加密核心结构可靠（对端公钥曲线上验证、4-DH／HKDF／nonce 逐字节等价 JVM 参考实现）。但有三个会阻断与现网 1.6.0 稳定互通的问题，本 PR 基于 `feat/harmony-port`（＝#203 head 的镜像分支）逐项修复，diff 只含修复本身。采纳后可直接合进你的分支（#203 已开 maintainer edit），或 cherry-pick。

### 修复内容（三笔 commit 对应三个层面）

**1️⃣ relay（`5dcc5a45`，Kotlin，测试全绿）**
- **心跳必死修复**：现网 relay 的 device 腿 TEXT 控制面只处理 `RegisterPush`，`pocket/ping` 落 `else -> {}` 静默丢弃（Pong 回显只有 daemon 腿有）。鸿蒙端 10s 收不到 pong 即断连 → **每约 30 秒掉线循环**（真机测试大概率被 2s 快速重连＋会话自动重开掩盖了）。现在 device 腿在发起 socket 上回 `Pong`。
- **HuaweiSender 端点版本修正**：原实现是 HMS Android 旧端点 `v1/{appId}` 配 HarmonyOS v3 形状报文的混搭；HarmonyOS NEXT Push Kit 实际是 `v3/{projectId}/messages:send` ＋ 必填 `push-type: 0` 头（华为官方文档核实）。env 相应改为 `CCPOCKET_HUAWEI_PROJECT_ID`。
- **路由 data JSON 转义**：手拼 `"\"$k\":\"$v\""` 无转义，Windows daemon 的 workdir 含 `\` 时客户端 `JSON.parse` 必炸。改用 `buildJsonObject`（同 `FcmSender`）。
- 新增 `RelayServerControlTest`（Ping 回显）＋ `PushTest` 转义用例，`:relay:test` 全绿。

**2️⃣ harmony 网络／加密层（`c7b6f769`）**
- **E2E seal/open 串行化**：原来每帧 fire-and-forget `seal(...).then(send)`，AES 完成顺序无保证；daemon 计数器严格递增（`E2ESession.kt:34-41`），ctr=1 先上线则迟到的 ctr=0 被当重放**静默永久丢弃**——onReady 连发 4 帧和重连 flushOutbox 是高危窗口，症状是「列表偶尔拉不到」这类概率性失败。现在出／入站各一条 promise 链，取号顺序＝上线顺序、按到达顺序解密投递。
- **GCM 填充修正**：`AES256|GCM|PKCS7` → `NoPadding`。GCM 无填充；若 cryptoFramework 真按 PKCS7 生效则跨端解密必败，而自封自解 selfTest 两侧同错全绿测不出。`selfTest()` 新增 **JVM 参考实现生成的跨端 KAT**（逐字节断言 `ct‖tag`，44=28+16 同时钉死无填充与字节序）。
- pong 超时改连续 2 次未中才断连（配合 relay 回显，弱网少一次全量重连）。

**3️⃣ harmony 数据／UI 层（`d5d84a39`）**
- **会话域帧补 `convoId` 门**（history/chunk/tool/ask/turn.done/prompt.ack/file.uploaded…，对齐 mobile `PocketRepository` 逐帧过滤）：修会话切换窗口期 A 会话在途帧污染 B 会话转录（锚点合并还可能判「硬分叉」整体替换）、迟到 ask 顶掉当前审批卡。
- **重连不 fork**：自动 resume 收紧为「必须握有具体 sessionId」——新会话在 `session.live` 回填前断线重连，`resumeId=null` 会被 daemon 当开新会话（这仓库修过的「冗余会话＝fork」老病，115c79a）。
- **`session.gone` 按协议语义**（`Messages.kt:1097-1105` 的 auto-reopen **and resend**）：暂存最近 prompt，匹配才重开、`session.live` 后同 `promptId` 补发一次（daemon 去重），无 pending 则诚实报错不空转。
- **ClientCaps 纠偏**：`supportsAgents: ['opencode']` → `[]`。openSession 硬编码 `agent:'claude'`，谎报会让用户点 opencode 会话被以 claude resume → fork。后续支持时需把 agent 从 `SessionSummary` 透传进 OpenSession（README 已记）。
- **TranscriptMerge 移植 acc 连续消费**（`TranscriptMerge.kt:61-83`）：一条流式气泡跨多条回放行时不再被当断线回补重复追加。
- **AskUserQuestion 支持 `multiSelect`**：answers 值为选项原序 `", "` 连接（对齐 `QuestionCard.answerOf`）；原实现降级单选造成答案语义失真。
- README 与实现终态对齐，补 relay 部署顺序警告。

### 验证情况（诚实声明）

- ✅ relay／protocol：`:relay:test` `:protocol:jvmTest` 全绿（含新测试）。
- ✅ GCM KAT 由 JVM 参考实现生成，并经 Node `aes-256-gcm` 独立复算逐字节吻合。
- ⚠️ ArkTS 改动**未经编译验证**（本机无 DevEco 工具链）：语法严格模仿文件既有形态（promise 链显式返回类型、无解构、数组展开等均取自仓库已有先例），但请你在 DevEco 里编译并真机过一遍。
- ⚠️ 推送链路仍未真机端到端验证（依赖 AGC 凭据），v3 端点按官方文档修正，`clickAction`/`data` 的落点请在真机首验时确认。

### 建议的验收硬条件

真机对现网 1.6.0 daemon（relay 需先合入本分支并 redeploy）：完整握手 → 一轮收发 → **挂机 5 分钟不掉线**（验证心跳）→ 快速连发多条消息（验证串行化）→ 会话间快速切换（验证 convoId 门）。

### 已知未修（评审发现、非阻塞，留后续）

明文存储迁 HUKS／Asset Store（你已列 TODO；配对 ticket 也一并迁）、离线期 outbox prompt 丢失、`K_FIRST_TICKET` 单槽多电脑窗口、token 空注销、断线上传误导文案、delta 分支盲追加（当前死代码）、AskUserQuestion 自由文本回复入口、`HistoryMessage` answers 回放摘要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
