### PR TITLE
fix(daemon): Kimi ACP 后端保真度——wire 回放重写、工具卡内容、中途排队、审批描述

### DIFF
--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/kimi/KimiAcpParser.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/kimi/KimiAcpParser.kt
@@ -1,30 +1,33 @@
 package dev.ccpocket.daemon.kimi
 
 import dev.ccpocket.daemon.agent.AgentEvent
-import dev.ccpocket.daemon.opencode.ToolNameMapper
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 
 /**
  * Translates Kimi Code CLI ACP (Agent Client Protocol v1) `session/update` notifications → provider-neutral
- * [AgentEvent] (issue #206). This is the ONE place the ACP update schema is decoded; it is shared by the live
- * backend and — best-effort — by the offline transcript replay (see [KimiTranscriptReplay]).
+ * [AgentEvent] (issue #206). This decodes the STATELESS update kinds (text/thought chunks) for the live
+ * backend.
  *
- * ACP `session/update` params: `{sessionId, update:{sessionUpdate:<kind>, …}}`. The `sessionUpdate`
- * discriminator drives the mapping (per the ACP spec + the confirmed kimi 0.33.0 handshake):
+ * ACP `session/update` params: `{sessionId, update:{sessionUpdate:<kind>, …}}` (probe-verified on 0.34.0):
  *  - `agent_message_chunk` / `agent_thought_chunk`  → assistant text / thinking (ContentBlock `content`)
  *  - `user_message_chunk`                            → UserReplay receipt (prompt consumed)
- *  - `tool_call`                                     → AssistantToolUse (title/kind/rawInput)
- *  - `tool_call_update`                              → ToolResult when it carries content/output (status settled)
- *  - `plan`                                          → Ignored (P2: render plan)
+ *  - `plan` / `available_commands_update` / `session_info_update` / `usage_update` → Ignored (P2)
+ *  - `tool_call` / `tool_call_update`                → NOT HERE — they need per-call state (the input JSON
+ *    streams as cumulative text; `tool_call` carries no `rawInput`), so [KimiBackend] accumulates and
+ *    emits tool events itself.
+ *
+ * The on-disk transcript (`wire.jsonl`) is the CLI's INTERNAL wire format, NOT ACP (probe 0.34.0 — the
+ * pre-auth design assumed otherwise and replay produced zero rows); disk parsing lives in
+ * [KimiTranscriptReplay].
  *
  * Contract: [translate]/[parseLine] NEVER throw. Unknown update kinds degrade to [AgentEvent.Ignored].
  */
 object KimiAcpParser {
     private val json = Json { ignoreUnknownKeys = true; isLenient = true }
 
-    /** One persisted transcript line → events (offline replay path — disk format unverified pre-auth,
-     *  fails safe to empty/Ignored). Accepts a full `session/update` notification or a bare `update` object. */
+    /** One ACP `session/update` notification line → events. Accepts a full notification or a bare `update`
+     *  object. (The DISK transcript is NOT ACP — see [KimiTranscriptReplay]; this is the live-path helper.) */
     fun parseLine(line: String): List<AgentEvent> {
         val t = line.trim()
         if (t.isEmpty()) return emptyList()
@@ -52,27 +55,6 @@ object KimiAcpParser {
                     ?.let { listOf(AgentEvent.AssistantThinking(it)) } ?: emptyList()
             "user_message_chunk" ->
                 listOf(AgentEvent.UserReplay(contentBlockText(update["content"])))
-
-            "tool_call" -> {
-                val id = update.str("toolCallId")
-                // ACP tool_call carries a human `title` + a `kind` (read/edit/execute/…) + `rawInput`.
-                // Prefer the kind for a Claude-shaped tool name (execute→Bash via the mapper), else the title.
-                val name = ToolNameMapper.map(update.str("kind") ?: update.str("title") ?: "tool")
-                val input = update.obj("rawInput")
-                listOf(AgentEvent.AssistantToolUse(id, name, input))
-            }
-            "tool_call_update" -> {
-                val id = update.str("toolCallId")
-                val status = update.str("status")
-                // content is an array of ToolCallContent; rawOutput is the structured result. Surface a
-                // ToolResult only when the call has produced output (settled), mirroring the other backends.
-                val text = contentBlockText(update.obj("content")?.get("content"))
-                    ?: contentBlockText(update["content"])
-                    ?: update.obj("rawOutput")?.toString()
-                if (text != null || status == "completed" || status == "failed") {
-                    listOf(AgentEvent.ToolResult(id, text, isError = status == "failed"))
-                } else emptyList()
-            }
 
             "plan" -> listOf(AgentEvent.Ignored("plan")) // P2: render the plan
             else -> listOf(AgentEvent.Ignored(update.str("sessionUpdate")))

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/kimi/KimiBackend.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/kimi/KimiBackend.kt
@@ -5,6 +5,7 @@ import dev.ccpocket.daemon.agent.AgentEvent
 import dev.ccpocket.daemon.agent.AgentIo
 import dev.ccpocket.daemon.agent.AgentSpec
 import dev.ccpocket.daemon.disk.ReplaySlice
+import dev.ccpocket.daemon.opencode.ToolNameMapper
 import dev.ccpocket.daemon.util.logger
 import dev.ccpocket.protocol.AgentKind
 import dev.ccpocket.protocol.HistoryMessage
@@ -74,6 +75,20 @@ class KimiBackend(
     // askId → (JSON-RPC request id, permission options) — options carry the optionIds we answer with
     private val pendingApprovals = ConcurrentHashMap<String, PendingApproval>()
 
+    // MID-TURN PROMPT QUEUE (probe 0.34.0): ACP rejects a second session/prompt while a turn runs
+    // (-32600 turn.agent_busy "another turn is already in progress") — unlike the Claude CLI, which queues
+    // stdin messages itself. Conversation hands every prompt straight to us (its ledger proves delivery by
+    // the eventual consumption), so the queue lives HERE: at most one session/prompt in flight, the rest
+    // FIFO, flushed when the in-flight prompt settles (any stopReason, incl. cancelled/error).
+    private val promptQueue = ArrayDeque<Prompt>() // guarded by [bootstrap]
+
+    // toolCallId → accumulated tool state. ACP `tool_call` carries NO rawInput (probe 0.34.0): the input
+    // JSON streams as cumulative text in in_progress `tool_call_update`s; the output arrives as `rawOutput`
+    // on the settled update. The START event is therefore emitted only once the input parses complete —
+    // an earlier emission produced the phone's empty Bash/Read cards.
+    private class ToolAccum(val name: String, val title: String?, var inputText: String, var started: Boolean)
+    private val toolCalls = ConcurrentHashMap<String, ToolAccum>()
+
     private data class Prompt(val text: String, val images: List<ImageData>)
     private data class PendingApproval(val rpcId: JsonElement, val options: JsonArray)
 
@@ -92,8 +107,8 @@ class KimiBackend(
         // reset per-process protocol state (runs on every (re)launch)
         sessionId = null
         suppressReplayUpdates = false
-        bootstrap.withLock { pendingPrompt = null }
-        promptIds.clear(); pendingApprovals.clear()
+        bootstrap.withLock { pendingPrompt = null; promptQueue.clear() }
+        promptIds.clear(); pendingApprovals.clear(); toolCalls.clear()
         // kick off the ACP handshake — session open happens when the initialize response lands
         initializeId = rpcRequest("initialize", buildJsonObject {
             put("protocolVersion", 1)
@@ -128,7 +143,10 @@ class KimiBackend(
         return when (id) {
             initializeId -> { openSession(); emptyList() }
             sessionOpenId -> onSessionOpened(result)
-            in promptIds -> { promptIds.remove(id); onPromptDone(result) }
+            in promptIds -> {
+                promptIds.remove(id)
+                onPromptDone(result).also { flushQueuedPrompt() } // settle → next queued prompt goes out
+            }
             else -> emptyList()
         }
     }
@@ -139,6 +157,7 @@ class KimiBackend(
         // an auth wall (no model / not logged in) surfaces here on session open or the first prompt
         if (id == sessionOpenId || (id != null && id in promptIds)) {
             promptIds.remove(id)
+            flushQueuedPrompt() // a failed prompt must not stall the FIFO behind it
             return listOf(
                 AgentEvent.AssistantText("⚠️ $msg"),
                 AgentEvent.TurnResult(finalText = null, usage = null, isError = true),
@@ -196,10 +215,64 @@ class KimiBackend(
         return when (method) {
             "session/update" -> {
                 if (suppressReplayUpdates) return emptyList() // historical replay from session/load — drop
-                params.obj("update")?.let { KimiAcpParser.translate(it) } ?: emptyList()
+                val update = params.obj("update") ?: return emptyList()
+                // tool_call / tool_call_update are handled HERE (stateful input accumulation); every other
+                // update kind stays with the stateless parser.
+                when (update.str("sessionUpdate")) {
+                    "tool_call" -> onToolCall(update)
+                    "tool_call_update" -> onToolCallUpdate(update)
+                    else -> KimiAcpParser.translate(update)
+                }
             }
             else -> emptyList()
         }
+    }
+
+    /** `tool_call`: card opens pending with NO input (probe 0.34.0) — record it, emit nothing yet. */
+    private fun onToolCall(update: JsonObject): List<AgentEvent> {
+        val id = update.str("toolCallId") ?: return emptyList()
+        val title = update.str("title")
+        val name = ToolNameMapper.map(update.str("kind") ?: title ?: "tool")
+        toolCalls[id] = ToolAccum(name, title, inputText = "", started = false)
+        return emptyList()
+    }
+
+    /** `tool_call_update`: the input JSON streams in as CUMULATIVE text while in_progress; the output lands
+     *  as `rawOutput` (a plain string) on the settled update. Emit the START once the accumulated input
+     *  parses as complete JSON (≈ execution begin), and the result on settle. */
+    private fun onToolCallUpdate(update: JsonObject): List<AgentEvent> {
+        val id = update.str("toolCallId") ?: return emptyList()
+        val accum = toolCalls.getOrPut(id) {
+            ToolAccum(ToolNameMapper.map(update.str("title") ?: "tool"), update.str("title"), "", false)
+        }
+        val status = update.str("status")
+        val settled = status == "completed" || status == "failed"
+        val out = ArrayList<AgentEvent>(2)
+        if (!settled) {
+            // in_progress: content text is the CUMULATIVE input JSON being built — latest is fullest.
+            // (on the settled update the same slot carries the OUTPUT — never fold it into the input)
+            toolCallContentText(update["content"])?.let { accum.inputText = it }
+        }
+        if (!accum.started) {
+            val input = runCatching { json.parseToJsonElement(accum.inputText) as? JsonObject }.getOrNull()
+            if (input != null || settled) {
+                accum.started = true
+                out += AgentEvent.AssistantToolUse(
+                    id, accum.name,
+                    input ?: buildJsonObject { accum.title?.let { put("description", it) } },
+                )
+            }
+        }
+        if (settled) {
+            toolCalls.remove(id)
+            // output: rawOutput is a plain STRING (probe 0.34.0), else the settled content text
+            out += AgentEvent.ToolResult(
+                id,
+                update.str("rawOutput") ?: toolCallContentText(update["content"]),
+                isError = status == "failed",
+            )
+        }
+        return out
     }
 
     // ---- inbound: server→client requests (approvals + fs/terminal we decline) ----
@@ -214,8 +287,10 @@ class KimiBackend(
                 val name = dev.ccpocket.daemon.opencode.ToolNameMapper.map(
                     toolCall?.str("kind") ?: toolCall?.str("title") ?: "tool",
                 )
+                // probe 0.34.0: no rawInput here either — the human sentence in the content text is the
+                // only command carrier ("Requesting approval to Running: echo …"); surface it as the card body
                 val input = toolCall?.obj("rawInput") ?: buildJsonObject {
-                    toolCall?.str("title")?.let { put("description", it) }
+                    put("description", toolCallContentText(toolCall?.get("content")) ?: toolCall?.str("title") ?: "tool")
                 }
                 listOf(AgentEvent.ControlRequest(askId, name, input))
             }
@@ -232,9 +307,23 @@ class KimiBackend(
 
     override suspend fun sendPrompt(text: String, images: List<ImageData>) {
         val ready = bootstrap.withLock {
-            if (sessionId == null) { pendingPrompt = Prompt(text, images); false } else true
+            when {
+                sessionId == null -> { pendingPrompt = Prompt(text, images); false }
+                // a turn is in flight — ACP has no mid-turn stdin queue (-32600 turn.agent_busy, probe
+                // 0.34.0), so FIFO it HERE and flush when the in-flight prompt settles
+                promptIds.isNotEmpty() -> { promptQueue.addLast(Prompt(text, images)); false }
+                else -> true
+            }
         }
         if (ready) writePrompt(text)
+    }
+
+    /** The in-flight prompt just settled (any stopReason / error) — send the oldest queued prompt, if any. */
+    private suspend fun flushQueuedPrompt() {
+        val next = bootstrap.withLock {
+            if (sessionId != null && promptIds.isEmpty()) promptQueue.removeFirstOrNull() else null
+        }
+        next?.let { writePrompt(it.text) }
     }
 
     private suspend fun writePrompt(text: String) {

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/kimi/KimiJson.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/kimi/KimiJson.kt
@@ -28,3 +28,13 @@ internal fun contentBlockText(el: JsonElement?): String? = when (el) {
     is JsonArray -> el.mapNotNull { contentBlockText(it) }.joinToString("").takeIf { it.isNotEmpty() }
     else -> null
 }
+
+/** Text of an ACP ToolCallContent array — `[{type:"content", content:{type:"text", text:…}}, …]` (the
+ *  one-wrapper-deeper shape `tool_call`/`tool_call_update` actually carry, probe 0.34.0). Bare ContentBlock
+ *  arrays/elements fall back to [contentBlockText]. */
+internal fun toolCallContentText(el: JsonElement?): String? = when (el) {
+    is JsonArray -> el.mapNotNull { item ->
+        ((item as? JsonObject)?.obj("content"))?.let { contentBlockText(it) } ?: contentBlockText(item)
+    }.joinToString("").takeIf { it.isNotEmpty() }
+    else -> contentBlockText(el)
+}

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/kimi/KimiTranscriptReplay.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/kimi/KimiTranscriptReplay.kt
@@ -1,27 +1,36 @@
 package dev.ccpocket.daemon.kimi
 
-import dev.ccpocket.daemon.agent.AgentEvent
 import dev.ccpocket.daemon.disk.ReplayBudget
 import dev.ccpocket.daemon.disk.ReplaySlice
 import dev.ccpocket.daemon.disk.ReplaySlicer
 import dev.ccpocket.protocol.ChatRole
 import dev.ccpocket.protocol.HistoryMessage
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
 import java.nio.file.Path
 import kotlin.io.path.bufferedReader
 import kotlin.io.path.exists
 
 /**
- * Flattens a Kimi session transcript into [HistoryMessage]s for replaying a resumed chat (issue #206). Runs
- * each line through the SAME [KimiAcpParser] the live backend uses so replay and live can't drift. Mirrors
- * the Claude/Codex/OpenCode replays: user + assistant text + tool cards, with a tool call's later
- * [AgentEvent.ToolResult] merged onto its card (outcome + output).
+ * Flattens a Kimi session transcript into [HistoryMessage]s for replaying a resumed chat (issue #206).
+ * Mirrors the Claude/Codex/OpenCode replays: user + assistant text + tool cards, with a tool call's later
+ * result merged onto its card (outcome + output).
  *
- * ⚠ DISK FORMAT UNVERIFIED (probe blocked on device-code auth, 2026-08-06): no kimi session could be created
- * without login, so the exact on-disk transcript path/shape is unconfirmed. This parses the design's assumed
- * `agents/main/wire.jsonl` defensively — every line failing to parse as an ACP `session/update` simply yields
- * no row (fail-safe to empty), never a crash. Re-verify post-auth (design V2/V7) and adjust if the format
- * differs. Defensive line-length guard (#81 + kimi request-trace lines) caps each line before parse.
+ * DISK FORMAT (probe-verified on 0.34.0, 2026-08-08): `agents/main/wire.jsonl` is the CLI's INTERNAL wire
+ * log — NOT ACP `session/update` notifications as the pre-auth design assumed (that assumption produced
+ * zero replay rows in the field). The chat-bearing line types are:
+ *  - `{"type":"turn.prompt", input:[{type:"text",text:…}]}`        → user row (real prompts only;
+ *    `context.append_message` also carries role:user but folds in `<system-reminder>` wrappers — skipped)
+ *  - `{"type":"context.append_loop_event", event:{type:"content.part", part:{type:"text"|"think", …}}}`
+ *      → assistant text rows (`think` parts are thinking, not chat rows)
+ *  - `… event:{type:"tool.call", toolCallId, name, args}`          → tool card (full input in `args`)
+ *  - `… event:{type:"tool.result", toolCallId, result:{output, isError?}}` → merged onto the card
+ * Everything else (metadata, llm.request, usage.record, step.*, turn.ended, interaction.*) is skipped.
+ * Defensive line-length guard (#81 + kimi request-trace lines) caps each line before parse; unparseable
+ * lines simply yield no row (fail-safe to empty), never a crash.
  */
 object KimiTranscriptReplay {
     private val json = Json { ignoreUnknownKeys = true; isLenient = true }
@@ -60,7 +69,7 @@ object KimiTranscriptReplay {
     private fun parse(file: Path): Pair<List<ReplaySlicer.Row>, Long> {
         if (!file.exists()) return emptyList<ReplaySlicer.Row>() to 0L
         val out = ArrayList<ReplaySlicer.Row>()
-        val toolRowIndex = HashMap<String, Int>() // tool_call_id → index in `out`, to merge its ToolResult
+        val toolRowIndex = HashMap<String, Int>() // toolCallId → index in `out`, to merge its tool.result
         var lineNo = 0L
         runCatching {
             file.bufferedReader().useLines { lines ->
@@ -69,38 +78,55 @@ object KimiTranscriptReplay {
                     val line = raw.trim()
                     if (line.isEmpty()) continue
                     val clipped = if (line.length > MAX_LINE_CHARS) line.take(MAX_LINE_CHARS) else line
-                    for (ev in KimiAcpParser.parseLine(clipped)) {
-                        when (ev) {
-                            is AgentEvent.UserReplay ->
-                                ev.text?.takeIf { it.isNotBlank() }?.let {
-                                    out += ReplaySlicer.Row(HistoryMessage(ChatRole.USER, it), lineNo)
-                                }
-                            is AgentEvent.AssistantText ->
-                                ev.text.takeIf { it.isNotBlank() }?.let {
-                                    out += ReplaySlicer.Row(HistoryMessage(ChatRole.ASSISTANT, it), lineNo)
-                                }
-                            is AgentEvent.AssistantToolUse -> {
-                                val preview = ev.input?.toString()?.take(MAX_TOOL_TEXT) ?: ""
-                                out += ReplaySlicer.Row(
-                                    HistoryMessage(ChatRole.TOOL, preview, tool = ev.name), lineNo,
-                                )
-                                ev.id?.let { toolRowIndex[it] = out.size - 1 }
+                    val root = runCatching { json.parseToJsonElement(clipped) }.getOrNull() as? JsonObject
+                        ?: continue // unparseable — no row, never a crash
+                    when (root.str("type")) {
+                        // a real user prompt entering a turn (context.append_message also logs role:user
+                        // lines, but those fold in <system-reminder> wrappers — turn.prompt stays clean)
+                        "turn.prompt" ->
+                            contentBlockText(root["input"])?.takeIf { it.isNotBlank() }?.let {
+                                out += ReplaySlicer.Row(HistoryMessage(ChatRole.USER, it), lineNo)
                             }
-                            is AgentEvent.ToolResult -> {
-                                val idx = ev.toolUseId?.let { toolRowIndex[it] }
-                                if (idx != null) {
-                                    val prev = out[idx]
-                                    out[idx] = prev.copy(
-                                        msg = prev.msg.copy(
-                                            ok = !ev.isError,
-                                            output = ev.content?.take(MAX_TOOL_OUTPUT),
-                                        ),
-                                        patchLine = lineNo, // #147: a late result mutates an earlier row
+                        "context.append_loop_event" -> {
+                            val ev = root.obj("event") ?: continue
+                            when (ev.str("type")) {
+                                "content.part" -> {
+                                    val part = ev.obj("part") ?: continue
+                                    // text parts are assistant replies; think parts are thinking (not chat rows)
+                                    if (part.str("type") == "text") {
+                                        part.str("text")?.takeIf { it.isNotBlank() }?.let {
+                                            out += ReplaySlicer.Row(HistoryMessage(ChatRole.ASSISTANT, it), lineNo)
+                                        }
+                                    }
+                                }
+                                "tool.call" -> {
+                                    val preview = ev.obj("args")?.toString()?.take(MAX_TOOL_TEXT) ?: ""
+                                    out += ReplaySlicer.Row(
+                                        HistoryMessage(ChatRole.TOOL, preview, tool = ev.str("name") ?: "tool"), lineNo,
                                     )
+                                    ev.str("toolCallId")?.let { toolRowIndex[it] = out.size - 1 }
                                 }
+                                "tool.result" -> {
+                                    val idx = ev.str("toolCallId")?.let { toolRowIndex[it] }
+                                    if (idx != null) {
+                                        val result = ev.obj("result")
+                                        val output = (result?.get("output") as? JsonPrimitive)?.contentOrNull
+                                            ?: result?.toString()
+                                        val isError = (result?.get("isError") as? JsonPrimitive)?.booleanOrNull == true
+                                        val prev = out[idx]
+                                        out[idx] = prev.copy(
+                                            msg = prev.msg.copy(
+                                                ok = !isError,
+                                                output = output?.take(MAX_TOOL_OUTPUT),
+                                            ),
+                                            patchLine = lineNo, // #147: a late result mutates an earlier row
+                                        )
+                                    }
+                                }
+                                else -> {} // step.begin/end, llm.request, usage.record, … — not a chat row
                             }
-                            else -> {} // thinking / usage / ignored / unparseable — not a chat row
                         }
+                        else -> {} // metadata, profile.bind, interaction.*, turn.ended, …
                     }
                 }
             }

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/kimi/KimiTranscriptScanner.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/kimi/KimiTranscriptScanner.kt
@@ -18,10 +18,9 @@ import kotlin.io.path.readText
  * Each index entry carries the session's `workDir`; we match it to the requested workdir with
  * [ProjectPaths.canonicalKey] (the same realpath-normalizing key the cross-backend project merge uses), then
  * read each session's `state.json` for title / lastPrompt / timestamps.
- *
- * ⚠ DISK FORMAT UNVERIFIED (probe blocked on device-code auth, 2026-08-06): no session could be created
- * without login, so the index/state field spellings are the design's assumption. Everything degrades to an
- * empty list on mismatch (never throws). Re-verify post-auth (design V2).
+ * The index spelling is probe-verified on 0.34.0 (2026-08-08): entries carry `sessionId` / `sessionDir` /
+ * `workDir` verbatim. state.json title/lastPrompt spellings remain assumption-based — everything degrades
+ * to an empty list on mismatch (never throws).
  */
 object KimiTranscriptScanner {
     private val json = Json { ignoreUnknownKeys = true; isLenient = true }
@@ -83,13 +82,14 @@ object KimiTranscriptScanner {
         )
     }
 
-    /** Bounded count of user turns in the transcript (approximate messageCount; App tolerates 0). */
+    /** Bounded count of user turns in the transcript (approximate messageCount; App tolerates 0).
+     *  wire.jsonl is the internal wire format (probe 0.34.0): real prompts are `turn.prompt` lines. */
     private fun countChatRows(wire: Path): Int {
         var n = 0
         wire.bufferedReader().useLines { lines ->
             for (raw in lines) {
                 if (n > 5000) break
-                if ("\"user_message_chunk\"" in raw) n++
+                if ("\"turn.prompt\"" in raw) n++
             }
         }
         return n

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/kimi/KimiAcpParserTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/kimi/KimiAcpParserTest.kt
@@ -49,30 +49,9 @@ class KimiAcpParserTest {
     }
 
     @Test
-    fun `tool_call maps kind execute to Bash and carries rawInput`() {
-        val u = """{"update":{"sessionUpdate":"tool_call","toolCallId":"t1","kind":"execute","title":"Run echo","rawInput":{"command":"echo hi"}}}"""
-        val ev = KimiAcpParser.parseLine(u).single() as? AgentEvent.AssistantToolUse
-        assertNotNull(ev)
-        assertEquals("t1", ev.id)
-        assertEquals("Bash", ev.name) // execute → Bash via ToolNameMapper
-        assertEquals("echo hi", ev.input?.get("command").toString().trim('"'))
-    }
-
-    @Test
-    fun `tool_call_update completed becomes a tool result`() {
-        val u = """{"update":{"sessionUpdate":"tool_call_update","toolCallId":"t1","status":"completed","content":[{"type":"text","text":"hi"}]}}"""
-        val ev = KimiAcpParser.parseLine(u).single() as? AgentEvent.ToolResult
-        assertNotNull(ev)
-        assertEquals("t1", ev.toolUseId)
-        assertTrue(!ev.isError)
-    }
-
-    @Test
-    fun `tool_call_update failed marks error`() {
-        val u = """{"update":{"sessionUpdate":"tool_call_update","toolCallId":"t9","status":"failed"}}"""
-        val ev = KimiAcpParser.parseLine(u).single() as? AgentEvent.ToolResult
-        assertNotNull(ev)
-        assertTrue(ev.isError)
+    fun `tool updates are Ignored here — the stateful backend owns them (probe 0_34_0)`() {
+        val u = """{"update":{"sessionUpdate":"tool_call","toolCallId":"t1","kind":"execute","title":"Bash"}}"""
+        assertIs<AgentEvent.Ignored>(KimiAcpParser.parseLine(u).single())
     }
 
     @Test

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/kimi/KimiBackendTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/kimi/KimiBackendTest.kt
@@ -1,0 +1,119 @@
+package dev.ccpocket.daemon.kimi
+
+import dev.ccpocket.daemon.agent.AgentEvent
+import dev.ccpocket.daemon.agent.AgentIo
+import dev.ccpocket.daemon.agent.AgentSpec
+import dev.ccpocket.protocol.PermissionMode
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Drives [KimiBackend] with synthetic ACP JSON-RPC lines (no real `kimi` binary) to lock down the
+ * probe-verified 0.34.0 behaviors (2026-08-08): the mid-turn prompt FIFO (ACP has no stdin queue —
+ * `-32600 turn.agent_busy`), the streamed-cumulative tool input (no `rawInput` on `tool_call`), the
+ * `rawOutput` string result, and the permission card's content-text description.
+ * Request ids are deterministic (idSeq starts at 1: initialize=1, session/new=2, first prompt=3, …).
+ */
+class KimiBackendTest {
+
+    private fun update(sessionUpdate: String) =
+        """{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":$sessionUpdate}}"""
+
+    /** attach + handshake through to a live session "s1"; [w] collects every line the backend writes. */
+    private suspend fun ready(w: MutableList<String>): KimiBackend {
+        val b = KimiBackend(null)
+        b.attach(AgentIo(writeLine = { w += it }, emit = {}), AgentSpec(Path.of("/repo"), mode = PermissionMode.DEFAULT))
+        b.parse("""{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1}}""")          // → session/new (id 2)
+        b.parse("""{"jsonrpc":"2.0","id":2,"result":{"sessionId":"s1"}}""")             // session live
+        return b
+    }
+
+    @Test
+    fun `mid-turn prompt is FIFO-queued and flushed on settle, never errored`() = runBlocking {
+        val w = mutableListOf<String>()
+        val b = ready(w)
+        b.sendPrompt("first", emptyList())
+        assertEquals(1, w.count { "\"session/prompt\"" in it }, "first prompt goes straight out")
+        b.sendPrompt("second", emptyList())
+        b.sendPrompt("third", emptyList())
+        assertEquals(1, w.count { "\"session/prompt\"" in it }, "mid-turn prompts must queue (ACP -32600 otherwise)")
+        // turn settles → oldest queued flushes
+        b.parse("""{"jsonrpc":"2.0","id":3,"result":{"stopReason":"end_turn"}}""")
+        assertEquals(2, w.count { "\"session/prompt\"" in it })
+        assertTrue(w.last { "\"session/prompt\"" in it }.contains("second"))
+        // next settle → last queued flushes
+        b.parse("""{"jsonrpc":"2.0","id":4,"result":{"stopReason":"cancelled"}}""")
+        assertEquals(3, w.count { "\"session/prompt\"" in it })
+        assertTrue(w.last { "\"session/prompt\"" in it }.contains("third"))
+    }
+
+    @Test
+    fun `queued prompt flushes even when the in-flight one errors`() = runBlocking {
+        val w = mutableListOf<String>()
+        val b = ready(w)
+        b.sendPrompt("first", emptyList())
+        b.sendPrompt("second", emptyList())
+        val events = b.parse("""{"jsonrpc":"2.0","id":3,"error":{"code":-32001,"message":"auth required"}}""")
+        assertTrue(events.any { it is AgentEvent.TurnResult && it.isError })
+        assertEquals(2, w.count { "\"session/prompt\"" in it }, "an error must not stall the FIFO")
+    }
+
+    @Test
+    fun `tool start waits for the streamed input and result carries rawOutput`() = runBlocking {
+        val w = mutableListOf<String>()
+        val b = ready(w)
+        // tool_call: pending, NO rawInput (probe 0.34.0) → nothing emitted yet
+        val ev0 = b.parse(update("""{"sessionUpdate":"tool_call","toolCallId":"0:tool_A","title":"Bash","kind":"execute","status":"pending","content":[{"type":"content","content":{"type":"text","text":""}}]}"""))
+        assertTrue(ev0.isEmpty(), "no START before the input is known (empty card bug)")
+        // in_progress: input JSON streams in cumulatively, still incomplete → nothing
+        val ev1 = b.parse(update("""{"sessionUpdate":"tool_call_update","toolCallId":"0:tool_A","status":"in_progress","content":[{"type":"content","content":{"type":"text","text":"{\"command\":\"echo"}}]}"""))
+        assertTrue(ev1.isEmpty())
+        // in_progress: input completes → START with the parsed input
+        val ev2 = b.parse(update("""{"sessionUpdate":"tool_call_update","toolCallId":"0:tool_A","status":"in_progress","content":[{"type":"content","content":{"type":"text","text":"{\"command\":\"echo hi\"}"}}]}"""))
+        val start = ev2.single() as? AgentEvent.AssistantToolUse
+        assertNotNull(start)
+        assertEquals("Bash", start.name)
+        assertEquals("\"echo hi\"", start.input?.get("command").toString())
+        // settled: rawOutput is a plain STRING → ToolResult
+        val ev3 = b.parse(update("""{"sessionUpdate":"tool_call_update","toolCallId":"0:tool_A","status":"completed","content":[{"type":"content","content":{"type":"text","text":"hi\n"}}],"rawOutput":"hi\n"}"""))
+        val result = ev3.single() as? AgentEvent.ToolResult
+        assertNotNull(result)
+        assertEquals("0:tool_A", result.toolUseId)
+        assertEquals("hi\n", result.content)
+        assertTrue(!result.isError)
+    }
+
+    @Test
+    fun `settle without a complete input still opens the card (title fallback) then fails`() = runBlocking {
+        val w = mutableListOf<String>()
+        val b = ready(w)
+        b.parse(update("""{"sessionUpdate":"tool_call","toolCallId":"0:tool_B","title":"Read","kind":"read","status":"pending"}"""))
+        val events = b.parse(update("""{"sessionUpdate":"tool_call_update","toolCallId":"0:tool_B","status":"failed","content":[{"type":"content","content":{"type":"text","text":"\"README.md\" does not exist."}}],"rawOutput":"\"README.md\" does not exist."}"""))
+        assertIs<AgentEvent.AssistantToolUse>(events[0])
+        assertEquals("Read", (events[0] as AgentEvent.AssistantToolUse).name)
+        val result = events[1] as? AgentEvent.ToolResult
+        assertNotNull(result)
+        assertTrue(result.isError)
+        assertEquals("\"README.md\" does not exist.", result.content)
+    }
+
+    @Test
+    fun `permission card surfaces the content-text description`() = runBlocking {
+        val w = mutableListOf<String>()
+        val b = ready(w)
+        val events = b.parse(
+            """{"jsonrpc":"2.0","id":0,"method":"session/request_permission","params":{"sessionId":"s1","options":[{"optionId":"approve_once","name":"Approve once","kind":"allow_once"},{"optionId":"reject","name":"Reject","kind":"reject_once"}],"toolCall":{"toolCallId":"0:tool_A","title":"Bash","content":[{"type":"content","content":{"type":"text","text":"Requesting approval to Running: echo hi"}}]}}}""",
+        )
+        val ask = events.single() as? AgentEvent.ControlRequest
+        assertNotNull(ask)
+        assertEquals("Bash", ask.toolName)
+        assertEquals("Requesting approval to Running: echo hi", ask.input?.get("description").toString().trim('"'))
+        b.respondPermission(ask.requestId, allow = true, remember = false, null, null, null)
+        assertTrue(w.last().contains("approve_once"), w.last())
+    }
+}

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/kimi/KimiTranscriptReplayTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/kimi/KimiTranscriptReplayTest.kt
@@ -6,7 +6,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/** Fixture-driven replay of an ACP session/update transcript into HistoryMessage rows (issue #206). */
+/** Fixture-driven replay of a wire.jsonl transcript into HistoryMessage rows (issue #206).
+ *  Fixtures mirror the probe-verified 0.34.0 on-disk INTERNAL wire format (2026-08-08) — NOT ACP. */
 class KimiTranscriptReplayTest {
 
     private fun wireFile(vararg lines: String) = Files.createTempFile("kimi_wire", ".jsonl").also {
@@ -14,29 +15,60 @@ class KimiTranscriptReplayTest {
     }
 
     @Test
-    fun `text and tool call with result flatten into rows with a merged tool card`() {
+    fun `prompts text parts and tool calls flatten into rows with merged tool cards`() {
         val file = wireFile(
-            """{"update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"run echo"}}}""",
-            """{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Sure."}}}""",
-            """{"update":{"sessionUpdate":"tool_call","toolCallId":"t1","kind":"execute","rawInput":{"command":"echo hi"}}}""",
-            """{"update":{"sessionUpdate":"tool_call_update","toolCallId":"t1","status":"completed","content":[{"type":"text","text":"hi"}]}}""",
-            """{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Done."}}}""",
+            """{"type":"metadata","protocol_version":"1.5","created_at":1786158160922}""",
+            """{"type":"turn.prompt","input":[{"type":"text","text":"run echo"}],"time":1}""",
+            """{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"u1","turnId":"0","step":1,"part":{"type":"think","think":"pondering"}},"time":2}""",
+            """{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"u2","turnId":"0","step":1,"part":{"type":"text","text":"Sure."}},"time":3}""",
+            """{"type":"llm.request","kind":"loop","model":"k3"}""",
+            """{"type":"context.append_loop_event","event":{"type":"tool.call","uuid":"u3","turnId":"0","step":1,"toolCallId":"tool_A","name":"Bash","args":{"command":"echo hi"}},"time":4}""",
+            """{"type":"context.append_loop_event","event":{"type":"tool.result","parentUuid":"u3","toolCallId":"tool_A","result":{"output":"hi\n"}},"time":5}""",
+            """{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"u4","finishReason":"tool_use"},"time":6}""",
+            """{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"u5","turnId":"0","step":2,"part":{"type":"text","text":"Done."}},"time":7}""",
+            """{"type":"turn.ended","turnId":0,"reason":"completed"}""",
         )
         val rows = KimiTranscriptReplay.read(file)
-        // user, assistant("Sure."), tool card, assistant("Done.")
+        // user, assistant("Sure."), tool card, assistant("Done.") — think parts / llm.request / step.* skipped
         assertEquals(listOf(ChatRole.USER, ChatRole.ASSISTANT, ChatRole.TOOL, ChatRole.ASSISTANT), rows.map { it.role })
+        assertEquals("run echo", rows[0].text)
         val tool = rows[2]
         assertEquals("Bash", tool.tool)
-        assertEquals(true, tool.ok) // merged result: completed, no error
-        assertEquals("hi", tool.output)
+        assertEquals(true, tool.ok)
+        assertEquals("hi\n", tool.output)
+        assertTrue(tool.text.contains("echo hi")) // args preview on the card
+    }
+
+    @Test
+    fun `failed tool result marks the card not-ok with its output`() {
+        val file = wireFile(
+            """{"type":"context.append_loop_event","event":{"type":"tool.call","uuid":"u1","toolCallId":"tool_B","name":"Read","args":{"file_path":"README.md"}},"time":1}""",
+            """{"type":"context.append_loop_event","event":{"type":"tool.result","parentUuid":"u1","toolCallId":"tool_B","result":{"output":"\"README.md\" does not exist.","isError":true}},"time":2}""",
+        )
+        val rows = KimiTranscriptReplay.read(file)
+        assertEquals(1, rows.size)
+        assertEquals("Read", rows[0].tool)
+        assertEquals(false, rows[0].ok)
+        assertEquals("\"README.md\" does not exist.", rows[0].output)
+    }
+
+    @Test
+    fun `append_message user lines stay skipped (system-reminder folding)`() {
+        val file = wireFile(
+            """{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"<system-reminder>\nfolded"}]},"time":1}""",
+            """{"type":"turn.prompt","input":[{"type":"text","text":"real prompt"}],"time":2}""",
+        )
+        val rows = KimiTranscriptReplay.read(file)
+        assertEquals(1, rows.size)
+        assertEquals("real prompt", rows[0].text)
     }
 
     @Test
     fun `unknown and unparseable lines produce no rows, never throws`() {
         val file = wireFile(
             "not json",
-            """{"update":{"sessionUpdate":"plan","entries":[]}}""",
-            """{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"ok"}}}""",
+            """{"type":"usage.record","model":"kimi-code/k3","usage":{"output":76}}""",
+            """{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"u","part":{"type":"text","text":"ok"}},"time":1}""",
         )
         val rows = KimiTranscriptReplay.read(file)
         assertEquals(1, rows.size)

--- a/docs/design/kimi-backend-design.md
+++ b/docs/design/kimi-backend-design.md
@@ -250,6 +250,20 @@ probe 脚本 `scripts/probe-kimi-wire.py` 假设 `kimi --wire`，实测该 flag 
 | V9 | **未测** | ACP 权限模式走 session modes（P2）；`-y/--yolo`、`--auto`、`--plan` 是**顶层交互 flag，不作用于 `acp` 子命令**（acp 只接受 `--login`）。P1 审批恒走 request_permission。 |
 | V10 | **未测（auth 阻塞）** | ACP `tool_call`/`tool_call_update` 的 rawInput/content 形状未活体观察；解析器按 ACP spec 实现（tool_call 带完整 rawInput，无需攒流）。 |
 
+### probe 实测结果（2026-08-08，kimi 0.34.0，**已登录**，脚本 `scripts/probe-kimi-acp.py`）
+
+首次登录态全链路探测，**推翻了两个设计假设**（均已修复并落测试）：
+
+| # | 结果 | 实测 |
+|---|---|---|
+| V2 | **PASS（形状证实，假设部分推翻）** | `session_index.jsonl` 逐行 `{sessionId, sessionDir, workDir}`（与设计一致）；`workDir` 存原始路径（实测出现 `d:/`、`D:/`、`D:\` 三种拼写，`canonicalKey` realpath 归一后匹配正常）。**`wire.jsonl` 不是 ACP**——是 CLI 内部 wire 格式：`turn.prompt` / `context.append_message` / `context.append_loop_event{content.part, tool.call, tool.result}` / `llm.request` / `usage.record` / `turn.ended`。按 ACP 解析的旧 Replay 产出 0 行（线上症状：attach 活会话看不到任何历史）。已重写 `KimiTranscriptReplay` 按 wire 格式解析：`turn.prompt`→user 行、`content.part{type:text}`→assistant 行（think 不入聊天行）、`tool.call{name,args}`→工具卡、`tool.result{output,isError}`→合并到卡。`countChatRows` 改数 `turn.prompt`。 |
+| V3 | **PASS（ACP 事件序）** | 一轮内 `session/update` 序：`agent_thought_chunk`×N + `agent_message_chunk`×N + `tool_call`→`tool_call_update`×N（in_progress 流式）→ settled；轮末 prompt 响应 `{stopReason}`。另有 `session_info_update`（标题）、`usage_update{used,size}`（**占用线数据源，P2 接入**）、`available_commands_update`。无 `user_message_chunk`（消费回执缺席，ledger 靠轮边界 settle）。 |
+| V5 | **实测改判** | 轮中再次 `session/prompt` 返回 `-32600 "another turn is already in progress"（turn.agent_busy）`——**ACP 无轮中注入**。已在 `KimiBackend` 内做 in-flight 门闩＋FIFO 排队（prompt 响应落地后按序 flush），手机端不再出现 turn failed。 |
+| V6 | **PASS** | `session/cancel`（notification）实测生效：进行中的写文件长轮次被中断，prompt 响应 `stopReason:"cancelled"`；wire.jsonl 落 `turn.cancel{reason:user_cancelled}` + `turn.ended{reason:cancelled}`。被取消轮中排队的消息由 CLI 以 `<system-reminder>` 包裹折叠进 context（replay 已避开）。 |
+| V10 | **FAIL（spec 假设推翻）→ 已修** | `tool_call` **不带 `rawInput`**（只有 title/kind/pending 状态）；输入 JSON 以**累积文本**形式随 in_progress `tool_call_update` 的 `content[].content.text` 流式到来；输出在 settled 更新的 `rawOutput`（**字符串原语**，非对象）。旧解析三处全错（线上症状：Bash/Read 工具卡空白）。已改 `KimiBackend` 有状态累积：输入解析完整才发 START，settled 发 ToolResult。审批卡：`session/request_permission` 的 `toolCall` 同样无 rawInput，命令藏在 content 文本（"Requesting approval to Running: …"），已接入 description。 |
+| V-win | **PASS** | `irm …/install.ps1 | iex` → `%USERPROFILE%\.kimi-code\bin\kimi.exe`（0.34.0），Git Bash 下 ACP 拉起正常，daemon 无需特殊处理。 |
+| V-auth | **PASS（反向）** | 已登录下 `session/new` 正常返回 `sessionId` + `configOptions`（model/thinking/mode 选项——P2 可用它做会话内模型/模式切换，无需 relaunch）。`initialize` 响应带 `authMethods=[login]` 与 `agentCapabilities.auth.logout`。 |
+
 ### 人工补测项（脚本外）
 
 - V-win：Windows 真机——install.ps1 安装路径、可执行后缀（`.exe`？）、Git Bash 依赖对 daemon 子进程拉起的影响、`%USERPROFILE%\.kimi-code` 路径。

--- a/scripts/probe-kimi-acp.py
+++ b/scripts/probe-kimi-acp.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Probe the Kimi Code CLI's ACP interface (`kimi acp`) end-to-end and record every frame.
+
+Covers the behaviors the cc-pocket daemon depends on (see docs/design/kimi-backend-design.md §9,
+2026-08-08 results): initialize handshake, session/new, tool_call / tool_call_update streaming shape,
+permission requests (auto-approved), mid-turn prompt rejection (-32600 turn.agent_busy), session/cancel.
+
+Usage:
+    py -3 scripts/probe-kimi-acp.py [workdir]          # Windows
+    python3 scripts/probe-kimi-acp.py [workdir]        # macOS/Linux
+
+Writes acp-probe-<ts>.jsonl next to itself's CWD workdir (default: a new temp dir) and prints the
+probe session's on-disk wire.jsonl path at the end (replay-format evidence). Requires a logged-in CLI.
+Run this after EVERY kimi CLI upgrade (auto-update is on by default) — protocol drift lands here first.
+"""
+import json, os, subprocess, sys, tempfile, threading, time
+
+KIMI = os.environ.get("CC_POCKET_KIMI_BIN") or os.path.expanduser("~/.kimi-code/bin/kimi")
+if os.name == "nt" and not KIMI.endswith(".exe"):
+    KIMI += ".exe"
+CWD = os.path.abspath(sys.argv[1]) if len(sys.argv) > 1 else tempfile.mkdtemp(prefix="kimi-acp-probe-")
+LOG = os.path.join(CWD, "acp-probe-%d.jsonl" % time.time())
+
+proc = subprocess.Popen(
+    [KIMI, "acp"], cwd=CWD,
+    stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+    text=True, encoding="utf-8", errors="replace", bufsize=1,
+)
+
+next_id = 0
+log = open(LOG, "w", encoding="utf-8")
+state = {"prompt_done": threading.Event(), "first_update_seen": threading.Event()}
+
+
+def send(obj):
+    line = json.dumps(obj, ensure_ascii=False)
+    log.write(">>> " + line + "\n"); log.flush()
+    proc.stdin.write(line + "\n"); proc.stdin.flush()
+
+
+def request(method, params):
+    global next_id
+    next_id += 1
+    send({"jsonrpc": "2.0", "id": next_id, "method": method, "params": params})
+    return next_id
+
+
+def notify(method, params):
+    send({"jsonrpc": "2.0", "method": method, "params": params})
+
+
+def reader():
+    for line in proc.stdout:
+        line = line.strip()
+        if not line:
+            continue
+        log.write("<<< " + line + "\n"); log.flush()
+        try:
+            msg = json.loads(line)
+        except Exception:
+            continue
+        # auto-approve permission requests with the first allow* option, so tool calls proceed
+        if msg.get("method") == "session/request_permission" and "id" in msg:
+            opts = (msg.get("params") or {}).get("options") or []
+            pick = next((o.get("optionId") for o in opts if str(o.get("kind", "")).startswith("allow")), None)
+            outcome = {"outcome": "selected", "optionId": pick} if pick else {"outcome": "cancelled"}
+            send({"jsonrpc": "2.0", "id": msg["id"], "result": {"outcome": outcome}})
+        if msg.get("method") == "session/update":
+            state["first_update_seen"].set()
+        if "id" in msg and isinstance(msg.get("result"), dict) and "stopReason" in msg["result"]:
+            state["prompt_done"].set()
+
+
+threading.Thread(target=reader, daemon=True).start()
+
+request("initialize", {"protocolVersion": 1, "clientCapabilities": {"fs": {"readTextFile": False, "writeTextFile": False}}})
+time.sleep(2)
+request("session/new", {"cwd": CWD, "mcpServers": []})
+time.sleep(3)
+
+sid = None
+log.flush()
+for l in open(LOG, encoding="utf-8"):
+    if l.startswith("<<<") and '"sessionId"' in l:
+        try:
+            sid = json.loads(l[4:])["result"]["sessionId"]
+        except Exception:
+            pass
+print("sessionId:", sid)
+if not sid:
+    print("FATAL: no session (not logged in? run `kimi` and /login first)")
+    log.close(); proc.kill(); sys.exit(1)
+
+# phase 1: a tool-using turn (Bash + Read) — captures tool_call/tool_call_update shapes
+state["prompt_done"].clear()
+request("session/prompt", {"sessionId": sid, "prompt": [{"type": "text", "text":
+    "Please do exactly two tool calls in order: 1) use Bash to run: echo hello-from-probe ; "
+    "2) use Read to read the first 3 lines of README.md in the current directory (if missing, just say so). "
+    "Tell me what you did at each step."}]})
+print("phase1 (tools) settled:", state["prompt_done"].wait(timeout=180))
+
+# phase 2: long turn + mid-turn prompt (expect -32600) + session/cancel (expect stopReason=cancelled)
+state["prompt_done"].clear(); state["first_update_seen"].clear()
+request("session/prompt", {"sessionId": sid, "prompt": [{"type": "text", "text":
+    "Write a file long.md in the current directory: 400 lines of markdown, each line a different "
+    "sentence. Do not stop to summarize until finished."}]})
+state["first_update_seen"].wait(timeout=60)
+time.sleep(3)
+request("session/prompt", {"sessionId": sid, "prompt": [{"type": "text", "text": "mid-turn probe message"}]})
+time.sleep(3)
+notify("session/cancel", {"sessionId": sid})
+print("phase2 (cancel) settled:", state["prompt_done"].wait(timeout=60))
+time.sleep(2)
+log.close()
+proc.kill()
+print("probe log:", LOG)
+
+# locate the on-disk transcript of THIS probe session for replay-format checks
+index = os.path.expanduser("~/.kimi-code/session_index.jsonl")
+try:
+    for l in open(index, encoding="utf-8"):
+        e = json.loads(l)
+        if e.get("sessionId") == sid:
+            print("wire.jsonl:", os.path.join(e["sessionDir"], "agents", "main", "wire.jsonl"))
+            break
+except FileNotFoundError:
+    pass


### PR DESCRIPTION
背景
1.7.0 接入的 Kimi Code 后端（#206）在发布时因设备码登录阻塞从未在登录态下活体实测——设计文档 §9 的 V2/V3/V10 等关键项全是「待验证」，两处核心假设是按 ACP spec 推断的。本次在 kimi 0.34.0 已登录环境下做了全链路 probe（新增 scripts/probe-kimi-acp.py，设计文档 §9 已回填实测结果），并在真实客户端（HarmonyOS 移植版）上实测暴露了 4 个缺陷。两个设计假设被实测推翻。

实测发现与修复
1. 会话历史回放产出 0 行：wire.jsonl 不是 ACP
假设（错）：~/.kimi-code/sessions/**/wire.jsonl 落盘的是 ACP session/update 帧，回放与 live 共用 KimiAcpParser。
实测：落盘的是 CLI 内部 wire 格式——turn.prompt / context.append_message / context.append_loop_event{content.part, tool.call, tool.result} / llm.request / usage.record / turn.ended 等。旧解析每行都 miss，回放静默为空。
症状：attach/resume 一个 kimi 活会话，App 看不到 attach 点之前的任何历史。
修复：KimiTranscriptReplay 按实测格式重写——turn.prompt→用户行（避开 context.append_message 的 <system-reminder> 折叠）、content.part{type:text}→助手行（think 不入聊天行）、tool.call{name,args}→工具卡、tool.result{output,isError}→合并到卡。KimiTranscriptScanner.countChatRows 同步改数 turn.prompt（原来数的 user_message_chunk 在磁盘格式里不存在，messageCount 恒 0）。

2. 工具卡空白：tool_call 没有 rawInput
假设（错）：tool_call 按 ACP spec 携带完整 rawInput。
实测：tool_call 只有 title/kind/pending 状态；输入 JSON 以累积文本形式随 in_progress tool_call_update 的 content[].content.text 流式到来；输出在 settled 更新的 rawOutput——且是字符串原语而非对象。旧解析三处全错（obj("rawInput")→null、obj("rawOutput")→null、content 多包一层取不出）。
症状：App 上 Bash/Read 工具卡只有工具名，没有命令/路径/输出。
修复：KimiBackend 改为有状态累积（toolCallId → ToolAccum）：输入文本解析成完整 JSON 时才发 START（≈执行开始），settled 时发 ToolResult。KimiAcpParser 回归无状态（只翻 text/thought chunk），工具事件归 backend。

3. 轮中发消息 turn failed：ACP 没有 stdin 排队
实测：轮次进行中第二个 session/prompt 直接被拒——-32600 "another turn is already in progress"（turn.agent_busy）。Claude CLI 会自己排队 stdin 消息，ACP 不会；Conversation 按既有契约把 prompt 直接交给 backend，于是错误 TurnResult 冒泡到 App。
症状：App 显示「turn failed」；且错误 TurnResult 误清 executing，运行指示和 ■ 打断按钮一并消失（用户体感「没有暂停功能」）。
修复：KimiBackend 内做 in-flight 门闩＋FIFO 排队（promptIds 非空则入队，prompt 响应/错误落地后按序 flush）。行为对齐 Claude：不丢消息、不报错、不打断进行中的轮次。

4. 审批卡没有命令内容
实测：session/request_permission 的 toolCall 同样无 rawInput，命令只存在于 content 文本（"Requesting approval to Running: echo …"）。
修复：审批卡 description 取该 content 文本。
影响面
零外溢。diff 全部在 daemon/kimi/ 包内（+ 设计文档 + probe 脚本）：protocol/、Conversation、其他三后端零改动；包外引用点（Main.kt 工厂注册、DaemonCore、RequestRouter、DirectoryService）的公开签名全部不变，只动了内部实现。KimiJson 辅助函数为 internal 且仅包内使用。

测试
新增 KimiBackendTest 5 例（fake AgentIo 驱动合成 ACP 帧）：中途 FIFO 排队与错误不卡队、流式输入完整才发 START、rawOutput 结果、无输入 settle 兜底、审批描述。
KimiTranscriptReplayTest 按 probe 实录的 wire 格式夹具重写（旧夹具本身写的就是被推翻的错误格式）。
KimiAcpParserTest 移除工具分支用例（已移交 backend），保留 chunk 翻译。
:daemon:test 中 kimi.* + conversation.* 全绿。（Windows 本机另有 19 个测试类的环境固有失败——符号链接特权/POSIX 权限假设，与本改动无关，改动前后一致。）
真机回归通过：HarmonyOS 客户端 attach 活会话可见完整历史、工具卡有内容。
probe 脚本
scripts/probe-kimi-acp.py（入库）：驱动真实 kimi acp 跑 initialize→session/new→工具轮→轮中注入→cancel 全程并录制帧，自动应答审批。Kimi CLI 迭代极快且自更新默认开（tui.toml [upgrade].auto_install），升级后跑一遍即可回归协议漂移。

未覆盖（follow-up）
usage_update{used,size} → 上下文占用线（session.live contextUsed/Window）
session/new 响应的 configOptions（model/thinking/mode 选项）→ 会话内模型/模式切换，可去掉换模型必须 relaunch 的限制
plan 更新渲染、available_commands_update 接入指令目录、session_info_update 标题同步