### PR TITLE
fix(daemon): announce the raw OpenSession workdir in SessionLive (#219)

### DIFF
--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/Conversation.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/Conversation.kt
@@ -128,6 +128,11 @@ class Conversation(
      *  expires (the default). Read at each arm (a mode switch or open), so a preference flip bites the next
      *  switch. Defaults to the runtime mirror; a knob only so tests can arm a short clock without waiting. */
     private val fullControlExpiryMs: () -> Long = { dev.ccpocket.daemon.agent.ApprovalTimeout.fullControlExpiryMs },
+    /** The workdir string the phone OPENED with — may be a raw "~"-relative path (issue #219: the phone's
+     *  identity guard matches SessionLive.workdir against the workdir IT sent, which is "~/x" from the
+     *  home anchor, never the daemon's canonicalized absolute form). Announced in SessionLive verbatim so
+     *  the guard matches; null → fall back to the canonical [workdir] (pre-#219 behaviour). */
+    private val announcedWorkdir: String? = null,
 ) {
     // ── approval design M2 §5.4: the task boundary a TASK grant binds to ──────────────────────────
     // One task per top-level user prompt: rotated when a prompt STARTS a new turn (mid-turn queued
@@ -513,7 +518,7 @@ class Conversation(
     /** The announce frame, stamped with everything mutable the phone reconciles from (mode, executing, model, effort, agent). */
     private fun live(sid: String?) =
         SessionLive(
-            convoId, workdir.toString(), sid, mode = mode, executing = executing, model = displayModel(), effort = effort,
+            convoId, announcedWorkdir ?: workdir.toString(), sid, mode = mode, executing = executing, model = displayModel(), effort = effort,
             // stamp the 1M/200k window from the model so the phone's usage % has an authoritative denominator
             // (issue #20) instead of sniffing the id itself. Phones that predate the field simply ignore it.
             contextWindow = claudeWindow(),

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/server/RequestRouter.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/server/RequestRouter.kt
@@ -471,6 +471,7 @@ class RequestRouter(
                             peerSupportsOpencode = caps?.supportsOpencode == true,
                             peerSupportsKimi = caps?.supportsKimi == true,
                             bridgeAllowedCommands = bridgeAllowedCommands,
+                            announcedWorkdir = frame.workdir, // #219: announce the RAW workdir the phone opened (may be "~/x")
                             ownerBypass = ownerBypass, // trusted in-process open flag ⇒ owner's own session
                         )
                         if (convoId.isNotEmpty()) onOpened(convoId) // "" = backend unavailable (PocketError already sent)

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/session/SessionRegistry.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/session/SessionRegistry.kt
@@ -268,6 +268,9 @@ class SessionRegistry(
         // issue #201: a HEADLESS fire (the scheduler) has no client attached, so its asks must keep the
         // bounded window even when the owner turned on "wait for my decision" — see Conversation's noAutoDeny.
         headless: Boolean = false,
+        // issue #219: the workdir the phone OPENED with (raw "~"-relative allowed) — announced verbatim in
+        // SessionLive so the phone's identity guard matches it; null → the daemon's canonical workdir.
+        announcedWorkdir: String? = null,
     ): String {
         val resume = open.resumeId
         // §3.3 INITIATOR AUTO-SPECTATE: the clients streaming from a conversation the handoff rebuild is
@@ -411,6 +414,7 @@ class SessionRegistry(
             pushHookProvider = { pushHook }, origin = origin, askPushHookProvider = { askPushHook },
             pathScope = pathScope, bridgeAllowedCommands = bridgeAllowedCommands, ownerBypass = ownerBypass,
             handoffAccess = handoffAccess, headless = headless,
+            announcedWorkdir = announcedWorkdir,
             approvals = approvals, grants = grants, riskEngine = riskEngine,
         )
         mutex.withLock { convos[convoId] = c }


### PR DESCRIPTION
## 问题描述

升级到 **1.7.0** 后，手机 App **新建会话**时提示「会话没有打开——电脑未响应」，8 秒后超时。1.6 版本正常。该问题在**自建中继（self-hosted relay）**环境下复现（本 PR 即自建中继用户报告并修复），官方 relay 用户理论上同样受影响。

## 根因分析

1. 1.7 手机 App 新增了 #219 的 `acceptsSessionLive` 身份守卫（`mobile/.../PocketRepository.kt`）：新建会话（`resumeId == null`）没有 sessionId 可识别，因此用 `f.workdir == pendingNewOpenWd` 做**精确字符串匹配**来判断「这是我要打开的会话」（1.6 手机无条件接受 SessionLive，无此守卫）。
2. 手机从「~」（home）锚点新建会话时，`OpenSession.workdir` 传的是**原始 `"~/xxx"` 形式**（`DirectoryPicker.browseWorkdirOf` = `joinNative("~", subPath)`，注释明确 "the raw ~ form the daemon expands"）。
3. daemon 侧 `validateWorkdir` 对 workdir 做 `expandTilde` + `toRealPath()` 规范化（`DirectoryService.kt`），因此 `SessionLive.workdir` 返回的是绝对路径 `"C:\Users\admin\xxx"`。
4. `"C:\Users\admin\xxx" != "~/xxx"` → 守卫条件**永远不满足** → 手机丢弃 SessionLive → 8 秒超时 → 显示「电脑未响应」。

从磁盘根锚点（如 `C:\`）打开项目时 workdir 是绝对路径，不会触发；从「~」锚点新建会话必现。

## 修复内容（daemon 侧，3 个文件）

让 `SessionLive.workdir` **回显手机在 OpenSession 中发出的原始 workdir**（可能是 `"~/xxx"` 原始形式），而不是规范化后的绝对路径：

- `daemon/.../conversation/Conversation.kt`：新增 `announcedWorkdir: String? = null` 构造参数；`live()` 用 `announcedWorkdir ?: workdir.toString()` 构造 `SessionLive.workdir`
- `daemon/.../session/SessionRegistry.kt`：`open()` 透传 `announcedWorkdir` 到 Conversation
- `daemon/.../server/RequestRouter.kt`：`registry.open(..., announcedWorkdir = frame.workdir)` —— 传手机发来的原始 workdir

`announcedWorkdir` 默认 `null`（未传时行为不变，回退到规范化 workdir），不影响其他调用方（scheduler/headless 等）。

## 验证

- `./gradlew :daemon:installDist` BUILD SUCCESSFUL
- 替换 daemon 主 jar 后，手机新建会话（「~」锚点）正常打开，不再超时
- daemon `attached`，relay 正常

## 备注（关于 main 分支）

仓库公开的 `main` 分支目前停在 **1.5.2**（2026-07-26），而 v1.7.0 是在 release 流程中发布的（2026-08-07）。本 PR 基于 **v1.7.0**，相对 `main` 的 diff 较大；建议维护者直接 cherry-pick 本修复的 3 个文件改动（`announcedWorkdir` 相关，共 +11/-1 行），或合入后同步 release。
