### PR TITLE
test(daemon): pin the #219 announce-echo contract broken-then-fixed by #230

### DIFF
--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/server/RequestRouterOpenSessionTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/server/RequestRouterOpenSessionTest.kt
@@ -47,6 +47,13 @@ import kotlin.test.assertTrue
  * and keep a GUEST clamped to its shared root (`share_out_of_scope`) even at this second gate —
  * GuestGuard vets first, but the router's re-check is the belt-and-suspenders the #115 scope relies
  * on. The lazy open (#61) spawns no process, so a stub backend drives the whole path.
+ *
+ * ANNOUNCE ECHO (issue #219): the SessionLive answering an open must carry the opener's workdir
+ * string VERBATIM, not the daemon's canonicalized form. The phone's identity guard recognizes a
+ * brand-new session (no sessionId yet) by exact string match against the workdir it sent, and only
+ * the daemon knows the remote home/symlink layout — so any canonicalization here ("~" → home,
+ * /var → /private/var) makes the phone drop its own answer and time out. Expansion still happens
+ * internally (validateOrCreateWorkdir); it just must not leak into the announce.
  */
 class RequestRouterOpenSessionTest {
 
@@ -109,19 +116,25 @@ class RequestRouterOpenSessionTest {
         router(CoroutineScope(Dispatchers.Default)).handle(OpenSession(fresh.toString()), { emitted += it })
 
         val live = awaitLive(emitted)
-        assertEquals(fresh.toRealPath().toString(), live.workdir, "the announced cwd is the canonicalized picked dir")
+        // NOT toRealPath(): on macOS the temp dir is /var/… while its real path is /private/var/… —
+        // exactly the canonicalization drift the #219 echo contract exists to keep out of the announce
+        assertEquals(fresh.toString(), live.workdir, "the announce echoes the opener's workdir verbatim (#219)")
         assertTrue(emitted.none { it is PocketError }, "a readable no-history dir must not be refused: $emitted")
     }
 
     @Test
-    fun the_pickers_raw_tilde_workdir_expands_to_the_daemon_home() = runBlocking {
+    fun the_pickers_raw_tilde_workdir_opens_and_is_echoed_verbatim() = runBlocking {
         // the phone's folder browser (issue #152) ships "~"-anchored workdirs raw — only the daemon
-        // knows the remote machine's home (same contract the ListSessions tilde test pins)
+        // knows the remote machine's home (same contract the ListSessions tilde test pins). The open
+        // must succeed (proof the daemon expanded it internally), but the ANNOUNCE must echo "~"
+        // untouched: the phone's #219 guard matches the exact string it sent, and a home-expanded
+        // announce is the "new session from the ~ anchor times out" bug this pins against.
         val emitted = Collections.synchronizedList(mutableListOf<Frame>())
         router(CoroutineScope(Dispatchers.Default)).handle(OpenSession("~"), { emitted += it })
 
         val live = awaitLive(emitted)
-        assertEquals(Path.of(System.getProperty("user.home")).toRealPath().toString(), live.workdir)
+        assertEquals("~", live.workdir, "the raw ~ form must survive into the announce (#219)")
+        assertTrue(emitted.none { it is PocketError }, "the daemon must still expand ~ internally and open it: $emitted")
     }
 
     @Test
@@ -158,6 +171,6 @@ class RequestRouterOpenSessionTest {
             .handle(OpenSession(sub.toString()), { emitted += it }, origin = "share:alex", guestScope = guestScope(root))
 
         val live = awaitLive(emitted)
-        assertEquals(sub.toRealPath().toString(), live.workdir, "in-scope fresh dirs stay openable for a guest")
+        assertEquals(sub.toString(), live.workdir, "in-scope fresh dirs stay openable for a guest, echoed verbatim (#219)")
     }
 }


### PR DESCRIPTION
## 背景

#230（感谢 @icocoon）修复了 1.7 手机从「~」锚点新建会话必超时的 bug：让 `SessionLive` 原样回显 OpenSession 的 workdir，而不是 daemon 规范化后的绝对路径。方向正确，且是唯一能治愈已发货 1.7 手机的 daemon 侧解法。

但 daemon 侧原有 3 个测试钉的是**旧契约**（"the announced cwd is the canonicalized picked dir"），#230 合入后它们转红（`:daemon:test` 实跑确认）：

- `RequestRouterOpenSessionTest > a_directory_with_no_history_opens_a_new_session`
- `RequestRouterOpenSessionTest > the_pickers_raw_tilde_workdir_expands_to_the_daemon_home`
- `RequestRouterOpenSessionTest > a_guest_open_of_a_fresh_subfolder_under_its_root_still_works`

## 本 PR

把这 3 个测试改写到新契约，并把 #219 回归钉死，防止将来有人「顺手」把 announce 改回规范化路径又打断手机：

- 类注释新增 ANNOUNCE ECHO 契约段：announce 必须原样回显开启方的 workdir 字符串（内部照常 `validateOrCreateWorkdir` 展开，只是不泄漏进 announce）。
- 临时目录用例改为断言原文回显——macOS 上 `/var/…` vs `/private/var/…`（`toRealPath` 漂移）正好构成区分新旧契约的实证。
- `~` 用例更名为 `the_pickers_raw_tilde_workdir_opens_and_is_echoed_verbatim`：断言 announce 是 `"~"` 原文 **且** 无 `PocketError`（证明内部展开仍然发生、会话可开）。
- guest 用例同步改为原文断言。

## 验证

- `:daemon:test` 全绿（1191 tests，含本改动，基于 main + #230）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)