### PR TITLE
完善 Codex 会话恢复与移动端交互

### DIFF
--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/agent/AgentBackend.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/agent/AgentBackend.kt
@@ -41,6 +41,13 @@ interface AgentBackend {
     /** Encode + write an interrupt for the in-flight turn; no-op if the process isn't ready. */
     suspend fun interrupt()
 
+    /** Compact the backend's native conversation context. True means the request was accepted (it may
+     * complete asynchronously); false means this backend has no native compaction API. */
+    suspend fun compact(): Boolean = false
+
+    /** Start the backend's native code-review flow. Null/blank means review all uncommitted changes. */
+    suspend fun review(instructions: String? = null): Boolean = false
+
     /** Ask the LIVE agent process to rename its session (issue #158) — Claude: a `rename_session`
      *  control_request; the CLI appends its own `custom-title` record and acks, so the daemon never
      *  writes a transcript its child holds. True = the agent acknowledged (record on disk). Default
@@ -119,6 +126,12 @@ interface AgentBackend {
      *  model + context window before the first new turn's init lands. Null when unknown / not on disk (default;
      *  e.g. Codex). Claude reads it from the transcript. */
     fun resumeModel(workdir: String, sessionId: String): String? = null
+
+    /** Human-facing title persisted by the backend. Used to make SessionLive self-contained for entry
+     *  points (push/deep link) that know only workdir + session id. Backends may override with a cheaper
+     *  direct lookup; the default keeps OpenCode and third-party implementations correct. */
+    fun resumeTitle(workdir: String, sessionId: String): String? =
+        listSessions(workdir).firstOrNull { it.sessionId == sessionId }?.title
 
     /** The model this backend WOULD use for a session started with NO explicit `--model` — read from config so
      *  a brand-new session's header shows the real model BEFORE the first turn (issue #96; lazy start #61 spawns

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/agent/AgentSpec.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/agent/AgentSpec.kt
@@ -19,8 +19,9 @@ data class AgentSpec(
     val permissionMode: String? = null,
     /** Backend-native service tier (Codex `priority` = Fast); null follows the CLI/account default. */
     val serviceTier: String? = null,
-    // Claude only: fork the resumed session into a fresh id (--fork-session) instead of appending to the
-    // original transcript. Set when the phone takes over / cold-resumes a session another writer may hold.
+    // Fork the resumed session into a fresh id instead of appending to the original transcript. Set when
+    // the phone takes over a session another writer may hold: Claude maps this to --fork-session; Codex
+    // maps it to the app-server's native thread/fork request.
     val forkSession: Boolean = false,
     // Claude only, issue #282 (docs/design/REWIND-FORK.md): truncate the resumed context at a chain entry
     // (`--resume-session-at <uuid>`) — the CLI keeps everything up to and including that entry and drops the

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/claude/ClaudeBackend.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/claude/ClaudeBackend.kt
@@ -243,6 +243,9 @@ class ClaudeBackend(
     override fun resumeModel(workdir: String, sessionId: String): String? =
         TranscriptScanner.lastModel(ProjectPaths.dirFor(workdir).resolve("$sessionId.jsonl"))
 
+    override fun resumeTitle(workdir: String, sessionId: String): String? =
+        TranscriptScanner.summarize(ProjectPaths.dirFor(workdir).resolve("$sessionId.jsonl"))?.title
+
     // issue #96: read the configured default (settings.json `model` / $ANTHROPIC_MODEL) so a brand-new
     // session's header shows the real model before the first turn. configDir = the daemon's isolated
     // CLAUDE_CONFIG_DIR when credential isolation is on (settings.json is symlinked back to the real one).

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/codex/CodexBackend.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/codex/CodexBackend.kt
@@ -49,6 +49,7 @@ class CodexBackend(
     @Volatile private var resolvedExe: Path? = null // codex binary, resolved lazily on first launch
     @Volatile private var workdir: String = ""
     @Volatile private var resumeId: String? = null
+    @Volatile private var forkSession: Boolean = false
     @Volatile private var mode: PermissionMode = PermissionMode.DEFAULT
     @Volatile private var model: String? = null
     @Volatile private var effort: String? = null
@@ -57,6 +58,8 @@ class CodexBackend(
     @Volatile private var threadId: String? = null
     @Volatile private var currentTurnId: String? = null
     private var pendingPrompt: Prompt? = null // buffered first turn (guarded by [bootstrap])
+    private var pendingCompact = false // /compact may arrive while thread resume/fork is still handshaking
+    private var pendingReview: String? = null // empty marker = uncommitted-changes review
 
     // JSON-RPC id correlation: which of our outstanding requests this id belongs to
     @Volatile private var initializeId: Long = -1
@@ -64,6 +67,7 @@ class CodexBackend(
 
     // a turn's running state, reset on turn/completed
     @Volatile private var lastAgentText: String? = null
+    @Volatile private var lastErrorText: String? = null
     @Volatile private var lastUsage = Usage()
     @Volatile private var usageSeen = false // no tokenUsage event yet → TurnResult must say "no usage", not zeros
     private val deltaSeen = ConcurrentHashMap.newKeySet<String>() // agentMessage itemIds that streamed deltas → don't re-emit final
@@ -85,14 +89,15 @@ class CodexBackend(
         this.io = io
         this.workdir = spec.workdir.toString()
         this.resumeId = spec.resumeId
+        this.forkSession = spec.forkSession
         this.mode = spec.mode
         this.model = spec.model
         this.effort = normalizeEffort(spec.model, spec.effort)
         this.serviceTier = normalizeServiceTier(spec.model, spec.serviceTier)
         // reset per-process protocol state (this runs on every (re)launch)
         threadId = null; currentTurnId = null
-        bootstrap.withLock { pendingPrompt = null }
-        lastAgentText = null; lastUsage = Usage(); usageSeen = false
+        bootstrap.withLock { pendingPrompt = null; pendingCompact = false; pendingReview = null }
+        lastAgentText = null; lastErrorText = null; lastUsage = Usage(); usageSeen = false
         deltaSeen.clear(); fileChangePaths.clear(); fileChangeDiffs.clear(); pendingApprovals.clear()
         // kick off the handshake — initialized + thread open happen when the response lands (see handleResponse)
         initializeId = rpcRequest("initialize", buildJsonObject {
@@ -136,8 +141,11 @@ class CodexBackend(
     private suspend fun openThread() {
         val rid = resumeId
         threadOpenId = if (rid != null) {
-            rpcRequest("thread/resume", buildJsonObject {
+            rpcRequest(if (forkSession) "thread/fork" else "thread/resume", buildJsonObject {
                 put("threadId", rid)
+                // thread/fork and thread/resume accept the same relevant overrides in the v2 app-server
+                // protocol (Codex 0.147). Native fork is the Codex mirror of Claude --fork-session: a
+                // phone take-over never creates a second writer on the desktop's live rollout.
                 codexModel()?.let { put("model", it) }
                 serviceTier?.let { put("serviceTier", it) }
             })
@@ -155,11 +163,17 @@ class CodexBackend(
     private suspend fun onThreadReady(result: JsonObject?): List<AgentEvent> {
         val thread = result?.obj("thread") ?: return emptyList()
         val tid = thread.str("id") ?: return emptyList()
+        result.str("model")?.let { model = it }
         val flush = bootstrap.withLock {
             threadId = tid
-            pendingPrompt.also { pendingPrompt = null }
+            val prompt = pendingPrompt.also { pendingPrompt = null }
+            val compact = pendingCompact.also { pendingCompact = false }
+            val review = pendingReview.also { pendingReview = null }
+            Triple(prompt, compact, review)
         }
-        flush?.let { writeTurnStart(it.text, it.images) }
+        flush.first?.let { writeTurnStart(it.text, it.images) }
+        if (flush.second) requestCompact(tid)
+        flush.third?.let { requestReview(tid, it) }
         return listOf(AgentEvent.SessionInit(sessionId = tid, cwd = workdir, model = result.str("model")))
     }
 
@@ -192,8 +206,11 @@ class CodexBackend(
             "turn/completed" -> onTurnCompleted(params.obj("turn"))
             "error" -> {
                 val msg = params.obj("error")?.str("message") ?: "codex error"
-                // turn/completed (status=failed) still follows and clears `executing`; surface the text now
-                listOf(AgentEvent.AssistantText("⚠️ $msg"))
+                // The v2 protocol guarantees turn.error on a failed completion, but keep this notification
+                // as a fallback for older app-server builds. Emitting it immediately duplicated the error and
+                // left Conversation to synthesize the unhelpful literal "turn failed" afterwards.
+                lastErrorText = msg
+                emptyList()
             }
             else -> emptyList() // unknown notification type — tolerate (codex adds these over time)
         }
@@ -248,14 +265,16 @@ class CodexBackend(
 
     private fun onTurnCompleted(turn: JsonObject?): List<AgentEvent> {
         val status = turn?.str("status")
+        val failure = turn?.obj("error")?.str("message") ?: lastErrorText
         val u = lastUsage
         val ev = AgentEvent.TurnResult(
-            finalText = lastAgentText,
+            finalText = lastAgentText ?: failure,
             // a turn that never saw a tokenUsage event reports "unknown" (null), not an empty window
             usage = if (usageSeen) TokenUsage(u.input, u.output, null, u.cached) else null,
             isError = status == "failed",
         )
         lastAgentText = null
+        lastErrorText = null
         currentTurnId = null
         deltaSeen.clear()
         fileChangePaths.clear(); fileChangeDiffs.clear() // approvals for this turn are resolved by now — don't accumulate
@@ -316,10 +335,28 @@ class CodexBackend(
     // ---- outbound (called by Conversation) ----
 
     override suspend fun sendPrompt(text: String, images: List<ImageData>) {
+        val promptText = codexPrompt(text)
         val ready = bootstrap.withLock {
-            if (threadId == null) { pendingPrompt = Prompt(text, images); false } else true
+            if (threadId == null) { pendingPrompt = Prompt(promptText, images); false } else true
         }
-        if (ready) writeTurnStart(text, images)
+        if (ready) {
+            val activeTurn = currentTurnId
+            if (activeTurn != null) writeTurnSteer(promptText, images, activeTurn)
+            else writeTurnStart(promptText, images)
+        }
+    }
+
+    /** `/simplify` is a Claude built-in skill, not an app-server method. Keep CC Pocket's action useful
+     * for Codex by expanding it into an explicit, stable task instead of sending an unknown slash token. */
+    private fun codexPrompt(text: String): String {
+        val trimmed = text.trim()
+        if (trimmed.substringBefore(' ').substringBefore('\n') != "/simplify") return text
+        val extra = trimmed.removePrefix("/simplify").trim()
+        return buildString {
+            append("Review the current uncommitted changes and simplify the implementation without changing behavior. ")
+            append("Prioritize reuse, clarity, and removing unnecessary complexity; run relevant validation after editing.")
+            if (extra.isNotEmpty()) append(" Additional instructions: ").append(extra)
+        }
     }
 
     private suspend fun writeTurnStart(text: String, images: List<ImageData>) {
@@ -346,10 +383,59 @@ class CodexBackend(
         })
     }
 
+    /** Append input to the turn Codex is already running. Starting a second turn on the same thread is
+     * rejected by app-server as an active-writer conflict; turn/steer is its native in-flight input API. */
+    private suspend fun writeTurnSteer(text: String, images: List<ImageData>, turnId: String) {
+        val tid = threadId ?: return
+        rpcRequest("turn/steer", buildJsonObject {
+            put("threadId", tid)
+            putJsonArray("input") {
+                addJsonObject { put("type", "text"); put("text", text) }
+                // images: Codex takes image{url}/localImage{path}, not base64 inline — deferred (Tier C)
+            }
+            put("expectedTurnId", turnId)
+        })
+    }
+
     override suspend fun interrupt() {
         val tid = threadId ?: return
         val turn = currentTurnId ?: return
         rpcRequest("turn/interrupt", buildJsonObject { put("threadId", tid); put("turnId", turn) })
+    }
+
+    override suspend fun compact(): Boolean {
+        val tid = bootstrap.withLock {
+            threadId.also { if (it == null) pendingCompact = true }
+        }
+        if (tid != null) requestCompact(tid)
+        return true
+    }
+
+    private suspend fun requestCompact(tid: String) {
+        rpcRequest("thread/compact/start", buildJsonObject { put("threadId", tid) })
+    }
+
+    override suspend fun review(instructions: String?): Boolean {
+        val review = instructions?.trim().orEmpty()
+        val tid = bootstrap.withLock {
+            threadId.also { if (it == null) pendingReview = review }
+        }
+        if (tid != null) requestReview(tid, review)
+        return true
+    }
+
+    private suspend fun requestReview(tid: String, instructions: String) {
+        rpcRequest("review/start", buildJsonObject {
+            put("threadId", tid)
+            put("delivery", "inline")
+            putJsonObject("target") {
+                if (instructions.isBlank()) put("type", "uncommittedChanges")
+                else {
+                    put("type", "custom")
+                    put("instructions", instructions)
+                }
+            }
+        })
     }
 
     override suspend fun respondPermission(
@@ -414,9 +500,15 @@ class CodexBackend(
         CodexPaths.findSession(sessionId)?.let { CodexTranscriptReplay.page(it, beforeSeq, limit) }
             ?: dev.ccpocket.daemon.disk.ReplaySlice.EMPTY
 
-    // Codex usage is live-only (thread/tokenUsage/updated) — the rollout carries no per-turn usage
-    // record to read back, so there's nothing to seed the statusline with on resume.
-    override fun resumeContextTokens(workdir: String, sessionId: String): Long? = null
+    override fun resumeContextTokens(workdir: String, sessionId: String): Long? =
+        CodexPaths.findSession(sessionId)?.let { CodexTranscriptScanner.runtimeState(it).contextUsed }
+
+    override fun resumeModel(workdir: String, sessionId: String): String? =
+        CodexPaths.findSession(sessionId)?.let { CodexTranscriptScanner.runtimeState(it).model }
+
+    override fun resumeTitle(workdir: String, sessionId: String): String? =
+        CodexTranscriptScanner.threadNames()[sessionId]?.takeIf { it.isNotBlank() }
+            ?: CodexPaths.findSession(sessionId)?.let { CodexTranscriptScanner.summarize(it, workdir)?.title }
 
     // issue #96: read the configured default (top-level `model` in $CODEX_HOME/config.toml) so a brand-new
     // Codex session's header shows the real model before the first turn instead of a blank segment.

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/codex/CodexTranscriptScanner.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/codex/CodexTranscriptScanner.kt
@@ -20,11 +20,92 @@ object CodexTranscriptScanner {
     private val json = Json { ignoreUnknownKeys = true; isLenient = true }
     const val LIVE_WINDOW_MS = 20_000L
 
+    /** Last runtime settings persisted by Codex in a rollout. These are the source of truth when the
+     * desktop owns a session and cc-pocket is only observing it. */
+    data class RuntimeState(
+        val model: String? = null,
+        val contextWindow: Long? = null,
+        val contextUsed: Long? = null,
+    )
+
     /** All Codex sessions whose recorded cwd is [workdir], newest-first. */
     fun scan(workdir: String): List<SessionSummary> {
         val titles = threadNames() // one index read per listing, shared across every rollout summarized below
         return CodexPaths.sessionFiles().mapNotNull { runCatching { summarize(it, workdir, titles) }.getOrNull() }
             .sortedByDescending { it.lastModified }
+    }
+
+    /**
+     * The newest resumable Codex session for each externally-live cwd. Unlike [scan], this is called by
+     * the 10-second project-list refresh, so it walks the rollout tree ONCE and stops reading each matching
+     * file after the first real user prompt (messageCount is intentionally only a lower bound here). A
+     * full session list still uses [scan]; the active row only needs id/title/mtime/agent.
+     *
+     * Returned keys preserve the caller's cwd spelling; matching itself uses [ProjectPaths.canonicalKey].
+     */
+    fun activeSummaries(
+        workdirs: Set<String>,
+        files: List<Path> = CodexPaths.sessionFiles(),
+    ): Map<String, SessionSummary> {
+        if (workdirs.isEmpty()) return emptyMap()
+        val requested = workdirs.associateBy(ProjectPaths::canonicalKey)
+        val remaining = requested.keys.toMutableSet()
+        val out = LinkedHashMap<String, SessionSummary>()
+        val titles = threadNames()
+        for (file in files) {
+            if (remaining.isEmpty()) break
+            val hit = runCatching { summarizeActive(file, remaining, titles) }.getOrNull() ?: continue
+            val requestedCwd = requested[hit.first] ?: continue
+            out[requestedCwd] = hit.second
+            remaining.remove(hit.first)
+        }
+        return out
+    }
+
+    /** Canonical cwd key + lightweight summary, or null when this rollout is not a requested live cwd. */
+    private fun summarizeActive(
+        file: Path,
+        wantedKeys: Set<String>,
+        titles: Map<String, String>,
+    ): Pair<String, SessionSummary>? {
+        var id: String? = null
+        var cwd: String? = null
+        var version: String? = null
+        var firstPrompt: String? = null
+        file.bufferedReader().use { r ->
+            val meta = metaPayload(r) ?: return null
+            id = meta.str("id"); cwd = meta.str("cwd"); version = meta.str("cli_version")
+            val recorded = cwd ?: return null
+            val key = ProjectPaths.canonicalKey(recorded)
+            if (key !in wantedKeys) return null
+            var line = r.readLine()
+            while (line != null && firstPrompt == null) {
+                val obj = runCatching { json.parseToJsonElement(line.trim()) }.getOrNull() as? JsonObject
+                val p = obj?.takeIf { it.str("type") == "response_item" }?.obj("payload")
+                if (p != null && p.str("type") == "message" && p.str("role") == "user") {
+                    codexMessageText(p)?.takeIf { !isSyntheticUserText(it) }?.let { firstPrompt = it }
+                }
+                line = r.readLine()
+            }
+            if (firstPrompt == null) return null
+        }
+        val sid = id ?: return null
+        val recorded = cwd ?: return null
+        val fp = firstPrompt ?: return null
+        val mtime = file.getLastModifiedTime().toMillis()
+        return ProjectPaths.canonicalKey(recorded) to SessionSummary(
+            sessionId = sid,
+            title = titles[sid]?.takeIf { it.isNotBlank() }
+                ?: fp.lineSequence().firstOrNull { it.isNotBlank() }?.trim()?.take(60)
+                ?: sid,
+            firstPrompt = fp,
+            messageCount = 1,
+            cwd = recorded,
+            lastModified = mtime,
+            version = version,
+            live = System.currentTimeMillis() - mtime < LIVE_WINDOW_MS,
+            agent = AgentKind.CODEX,
+        )
     }
 
     // Codex's session_index.jsonl (id → thread title) — memoized by the index's mtime so a directory list
@@ -79,6 +160,38 @@ object CodexTranscriptScanner {
 
     private fun readCwd(file: Path): String? = file.bufferedReader().use { metaPayload(it)?.str("cwd") }
 
+    /** Read the newest Codex model and token metadata from a rollout. Model settings are written in
+     * `turn_context`; token counts are `event_msg/token_count`. Older rollouts simply return null fields. */
+    fun runtimeState(file: Path): RuntimeState {
+        var state = RuntimeState()
+        file.bufferedReader().useLines { lines ->
+            for (raw in lines) {
+                val obj = runCatching { json.parseToJsonElement(raw.trim()) }.getOrNull() as? JsonObject ?: continue
+                state = mergeRuntimeState(state, obj)
+            }
+        }
+        return state
+    }
+
+    private fun mergeRuntimeState(current: RuntimeState, obj: JsonObject): RuntimeState {
+        val payload = obj.obj("payload") ?: return current
+        val model = when (obj.str("type")) {
+            "turn_context" -> payload.str("model")
+                ?: payload.obj("collaboration_mode")?.obj("settings")?.str("model")
+            "world_state" -> payload.obj("state")?.str("model")
+            "event_msg" -> payload.obj("thread_settings")?.str("model")
+            else -> null
+        }
+        val info = payload.obj("info")
+        val window = payload.long("model_context_window") ?: info?.long("model_context_window")
+        val used = info?.obj("last_token_usage")?.long("total_tokens")
+        return RuntimeState(
+            model = model ?: current.model,
+            contextWindow = window ?: current.contextWindow,
+            contextUsed = used ?: current.contextUsed,
+        )
+    }
+
     /** The rollout's first-line `session_meta` payload (id/cwd/cli_version live here), or null. Advances
      *  [r] past that line so [summarize] can keep scanning turns from the same reader. */
     private fun metaPayload(r: java.io.BufferedReader): JsonObject? {
@@ -95,6 +208,7 @@ object CodexTranscriptScanner {
         var version: String? = null
         var firstPrompt: String? = null
         var userCount = 0
+        var runtime = RuntimeState()
         file.bufferedReader().use { r ->
             val meta = metaPayload(r) ?: return null
             id = meta.str("id"); cwd = meta.str("cwd"); version = meta.str("cli_version")
@@ -107,6 +221,7 @@ object CodexTranscriptScanner {
             var line = r.readLine()
             while (line != null) {
                 val obj = runCatching { json.parseToJsonElement(line.trim()) }.getOrNull() as? JsonObject
+                if (obj != null) runtime = mergeRuntimeState(runtime, obj)
                 val p = obj?.takeIf { it.str("type") == "response_item" }?.obj("payload")
                 if (p != null && p.str("type") == "message" && p.str("role") == "user") {
                     val t = codexMessageText(p)
@@ -138,6 +253,7 @@ object CodexTranscriptScanner {
             version = version,
             live = System.currentTimeMillis() - mtime < LIVE_WINDOW_MS,
             agent = AgentKind.CODEX,
+            model = runtime.model,
         )
     }
 

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/Conversation.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/Conversation.kt
@@ -214,6 +214,10 @@ class Conversation(
     @Volatile
     private var model: String? = null
 
+    /** Transcript/index truth for the chat header. Null only for a genuinely unnamed fresh session. */
+    @Volatile
+    private var sessionTitle: String? = null
+
     // mutable: a phone can switch reasoning effort mid-session via `/effort <level>`
     @Volatile
     private var effort: String? = null
@@ -719,6 +723,7 @@ class Conversation(
             origin = origin, // "via <bridge>" label (issue #91); null for interactive sessions
             permissionMode = permissionMode,
             serviceTier = serviceTier,
+            title = sessionTitle,
         )
 
     /** The current permission mode — read by the shell approval gate so it can't be spoofed from the phone. */
@@ -782,8 +787,8 @@ class Conversation(
         // EAGERLY, on purpose. Its whole semantics are "seize this session NOW", and the take-over fork decision
         // (issue #35: branch a fresh id off a possibly-live desktop `claude --resume`, carried in [fork]) was already
         // computed by the registry and must be honored at open time — deferring it to an uncertain first prompt would
-        // break "tap to take over" and could let two writers clobber one transcript. Codex ignores forkSession; a
-        // null resumeId is a brand-new session either way.
+        // break "tap to take over" and could let two writers clobber one transcript. Codex maps forkSession to
+        // app-server thread/fork; a null resumeId is a brand-new session either way.
         if (takeOver) {
             // [resumeId] is valid for every backend here: for OpenCode it is the REAL opencode session id
             // (the scanner read it out of opencode.db — the registry keys conversations by that same id),
@@ -804,6 +809,9 @@ class Conversation(
         // transcript up front; once the first prompt spawns the agent, the pump re-emits SessionLive with the real
         // sessionId.
         scope.launch {
+            sessionTitle = resumeId?.let {
+                runCatching { backend.resumeTitle(workdir.toString(), it) }.getOrNull()?.takeIf(String::isNotBlank)
+            }
             // Seed model + usage from the resumed transcript so the header shows the real model/window and the
             // usage statusline on open — before the first new turn's init lands (a headless claude is silent
             // until then, issue #27). Done off the relay inbound loop; the transcript read can be a multi-MB parse.
@@ -2156,6 +2164,9 @@ class Conversation(
             promptId?.let { sink.emit(PromptAck(convoId, it)) } // handled by the daemon = delivered
             return
         }
+        if (sessionTitle == null && text.isNotBlank()) {
+            sessionTitle = text.lineSequence().firstOrNull { it.isNotBlank() }?.trim()?.take(60)
+        }
         // approval design M2 §5.4 / §18.1 P1-4: EVERY top-level user prompt begins a new task — the
         // previous task's grants die right here, whether or not the CLI folds the message into a running
         // turn. A new instruction never inherits an old authorization; task identity is decoupled from
@@ -2280,6 +2291,8 @@ class Conversation(
         val handler: suspend () -> Unit = when (trimmed.substringBefore(' ').substringBefore('\n')) {
             "/model" -> ({ handleModelCommand(trimmed) })
             "/effort" -> ({ handleEffortCommand(trimmed) })
+            "/compact" -> if (backend.kind == AgentKind.CODEX) ({ handleCodexCompactCommand() }) else return false
+            "/review" -> if (backend.kind == AgentKind.CODEX) ({ handleCodexReviewCommand(trimmed) }) else return false
             "/clear" -> ({ handleClearCommand() })
             else -> return false
         }
@@ -2288,6 +2301,61 @@ class Conversation(
         promptId?.let { markPromptConsumed(it) }
         handler()
         return true
+    }
+
+    /** Codex exposes compaction as app-server control-plane RPC, not a slash prompt. The process must be
+     * ready because compact applies to its opened thread; a cold resume is launched without creating a turn. */
+    private suspend fun handleCodexCompactCommand() {
+        if (isExecuting()) {
+            reply("Wait for the current Codex turn to finish before compacting context.")
+            return
+        }
+        if (proc == null) {
+            val anchor = sessionId ?: openedResumeId
+            val fork = if (sessionId == null) openedWithFork else false
+            val launched = runCatching {
+                launchProcess(
+                    AgentSpec(
+                        workdir, anchor, model, mode, effort = effort,
+                        permissionMode = permissionMode, serviceTier = serviceTier, forkSession = fork,
+                    ),
+                )
+            }
+            if (launched.isFailure) {
+                reply("Could not start Codex to compact this session: ${launched.exceptionOrNull()?.message ?: "unknown error"}")
+                return
+            }
+        }
+        // CodexBackend queues this across an in-flight thread resume/fork handshake, so a cold session's
+        // first Compact tap still becomes exactly one native thread/compact/start request.
+        if (!backend.compact()) reply("This Codex version does not expose native context compaction.")
+    }
+
+    /** Codex code review is another app-server control-plane operation. `/review` defaults to all working
+     * tree changes; text after the command becomes the native custom review target. */
+    private suspend fun handleCodexReviewCommand(text: String) {
+        if (isExecuting()) {
+            reply("Wait for the current Codex turn to finish before starting a review.")
+            return
+        }
+        if (proc == null) {
+            val anchor = sessionId ?: openedResumeId
+            val fork = if (sessionId == null) openedWithFork else false
+            val launched = runCatching {
+                launchProcess(
+                    AgentSpec(
+                        workdir, anchor, model, mode, effort = effort,
+                        permissionMode = permissionMode, serviceTier = serviceTier, forkSession = fork,
+                    ),
+                )
+            }
+            if (launched.isFailure) {
+                reply("Could not start Codex review: ${launched.exceptionOrNull()?.message ?: "unknown error"}")
+                return
+            }
+        }
+        val instructions = text.removePrefix("/review").trim().takeIf { it.isNotEmpty() }
+        if (!backend.review(instructions)) reply("This Codex version does not expose native code review.")
     }
 
     /** Handle the phone's `/model [name]` — the agent `-p` ignores it, so the daemon honors it. */
@@ -2338,6 +2406,7 @@ class Conversation(
         openedResumeId = null // brand-new session — no resume lineage left to preserve
         openedWithFork = false
         backfilledModel = null
+        sessionTitle = null
         failedTurnStreak = 0 // a fresh session starts healthy — the degraded warning belongs to the old transcript
         sawSyntheticThisTurn = false
         lastSyntheticText = null
@@ -2422,6 +2491,7 @@ class Conversation(
         openedResumeId = null // fresh session in the new cwd — no resume lineage left to preserve
         openedWithFork = false
         backfilledModel = null
+        sessionTitle = null
         failedTurnStreak = 0 // fresh session in a new cwd — degraded state died with the old transcript
         sawSyntheticThisTurn = false
         lastSyntheticText = null

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/ObserveSession.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/ObserveSession.kt
@@ -1,5 +1,7 @@
 package dev.ccpocket.daemon.conversation
 
+import dev.ccpocket.daemon.codex.CodexTranscriptReplay
+import dev.ccpocket.daemon.codex.CodexTranscriptScanner
 import dev.ccpocket.daemon.disk.TranscriptReplay
 import dev.ccpocket.daemon.disk.TranscriptScanner
 import dev.ccpocket.protocol.AgentKind
@@ -29,6 +31,7 @@ class ObserveSession(
     private val file: Path,
     private val sink: OutboundSink,
     parentScope: CoroutineScope,
+    private val agent: AgentKind = AgentKind.CLAUDE,
     /** The observing client's transcript cursor from its OpenSession (issue #147). NON-NULL also
      *  DECLARES the client understands delta frames (a new client sends 0 when it holds no transcript
      *  yet) — an old client omits the field and keeps today's full-window tick behavior: feeding a
@@ -50,7 +53,10 @@ class ObserveSession(
                     if (mtime != lastMtime) {
                         lastMtime = mtime
                         emitLive() // model/window/occupancy move as the observed terminal writes turns
-                        val slice = TranscriptReplay.slice(file, sinceSeq = sentCursor)
+                        val slice = when (agent) {
+                            AgentKind.CODEX -> CodexTranscriptReplay.slice(file, sinceSeq = sentCursor)
+                            else -> TranscriptReplay.slice(file, sinceSeq = sentCursor)
+                        }
                         // an empty DELTA = the client is already caught up (noise-only appends) — nothing
                         // to send. An empty FULL still goes out: that's today's "file gone/empty" wipe.
                         if (slice.messages.isNotEmpty() || !slice.delta) {
@@ -74,7 +80,10 @@ class ObserveSession(
 
     /** Older-history page for an observed session (issue #147) — same shape as Conversation's. */
     suspend fun fetchHistoryPage(beforeSeq: Long, limit: Int, to: OutboundSink) {
-        val slice = TranscriptReplay.page(file, beforeSeq, limit.coerceIn(1, 200))
+        val slice = when (agent) {
+            AgentKind.CODEX -> CodexTranscriptReplay.page(file, beforeSeq, limit.coerceIn(1, 200))
+            else -> TranscriptReplay.page(file, beforeSeq, limit.coerceIn(1, 200))
+        }
         to.emit(dev.ccpocket.protocol.ConvoHistoryPage(convoId, slice.messages, firstSeq = slice.firstSeq, hasMore = slice.hasMore))
     }
 
@@ -82,13 +91,23 @@ class ObserveSession(
      *  model, its usage as occupancy, and the window derived the same way live sessions derive it —
      *  including the observed-usage upgrade for beta-gated 1M models (occupancy > 200k proves 1M). */
     private suspend fun emitLive() {
-        val model = runCatching { TranscriptScanner.lastModel(file) }.getOrNull()
-        val used = runCatching { TranscriptScanner.lastContextTokens(file) }.getOrNull()
-        val window = dev.ccpocket.protocol.provenWindow(model?.let(::contextWindowFor), used)
+        val codex = if (agent == AgentKind.CODEX) runCatching { CodexTranscriptScanner.runtimeState(file) }.getOrNull() else null
+        val title = when (agent) {
+            AgentKind.CODEX -> CodexTranscriptScanner.threadNames()[sessionId]?.takeIf { it.isNotBlank() }
+                ?: runCatching { CodexTranscriptScanner.summarize(file, workdir)?.title }.getOrNull()
+            AgentKind.CLAUDE -> runCatching { TranscriptScanner.summarize(file)?.title }.getOrNull()
+            else -> null // Non-Claude/Codex sessions are never opened through ObserveSession.
+        }
+        val model = codex?.model
+            ?: if (agent == AgentKind.CLAUDE) runCatching { TranscriptScanner.lastModel(file) }.getOrNull() else null
+        val used = codex?.contextUsed
+            ?: if (agent == AgentKind.CLAUDE) runCatching { TranscriptScanner.lastContextTokens(file) }.getOrNull() else null
+        val declaredWindow = codex?.contextWindow ?: model?.let(::contextWindowFor)
+        val window = dev.ccpocket.protocol.provenWindow(declaredWindow, used)
         sink.emit(
             SessionLive(
                 convoId, workdir, sessionId, observing = true,
-                model = model, contextWindow = window, contextUsed = used, agent = AgentKind.CLAUDE,
+                model = model, contextWindow = window, contextUsed = used, agent = agent, title = title,
             ),
         )
     }

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/disk/DirectoryService.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/disk/DirectoryService.kt
@@ -29,6 +29,9 @@ class DirectoryService(
     private val zcodeCwds: () -> Map<String, Long> = { dev.ccpocket.daemon.zcode.ZCodeTranscriptScanner.cwdsByNewest() },
     private val dshCwds: () -> Map<String, Long> = { dev.ccpocket.daemon.dsh.DshTranscriptScanner.cwdsByNewest() },
     private val liveClaudeCwds: () -> Set<String> = LiveProcesses::claudeCwds,
+    private val liveCodexCwds: () -> Set<String> = LiveProcesses::codexCwds,
+    private val activeCodexSessions: (Set<String>) -> Map<String, dev.ccpocket.protocol.SessionSummary> =
+        dev.ccpocket.daemon.codex.CodexTranscriptScanner::activeSummaries,
     private val nowMillis: () -> Long = System::currentTimeMillis,
     // issue #290 test seam: tests create their fixture workdirs UNDER the real system temp, so they pin
     // this to emptyList() to opt out of the noise filter; production uses the machine's temp roots.
@@ -78,17 +81,62 @@ class DirectoryService(
     ): List<DirectoryEntry> {
         // canonical-keyed so ANY spelling mismatch (tilde, symlink, separators) between OpenSession's
         // workdir and a transcript's recorded cwd still matches
-        val liveNorm = liveByCwd.entries.groupBy({ ProjectPaths.canonicalKey(it.key) }, { it.value }).mapValues { (_, v) -> v.flatten() }
-        // SessionRegistry keys background work by its canonical OpenSession path, while transcript/index
-        // sources may retain a symlink spelling. Busy is project identity, so normalize it at the same merge
-        // boundary as live sessions; otherwise ActiveSession.busy=true can coexist with a false project scalar.
-        val busyNorm = busyCwds.mapTo(HashSet()) { ProjectPaths.canonicalKey(it) }
-        val claude = claudeDirectories(busyNorm, liveNorm)
         val codex = runCatching(codexCwds).getOrDefault(emptyMap())
         val opencode = if (includeOpencode) runCatching(opencodeCwds).getOrDefault(emptyMap()) else emptyMap()
         val kimi = if (includeKimi) runCatching(kimiCwds).getOrDefault(emptyMap()) else emptyMap()
         val zcode = if (includeZcode) runCatching(zcodeCwds).getOrDefault(emptyMap()) else emptyMap()
         val dsh = if (includeDsh) runCatching(dshCwds).getOrDefault(emptyMap()) else emptyMap()
+        val daemonLive = liveByCwd.entries
+            .groupBy({ ProjectPaths.canonicalKey(it.key) }, { it.value })
+            .mapValues { (_, v) -> v.flatten() }
+        // A Codex CLI launched from Terminal/Codex Desktop is outside SessionRegistry, so enrich the
+        // project list from its process cwd and the newest rollout for that cwd. Process presence means
+        // `open`; transcript freshness only decides `executing`. The daemon-owned row wins on a duplicate
+        // session id because it has exact turn state, while this external probe is necessarily heuristic.
+        val externalCodexCwds = runCatching { liveCodexCwds() }.getOrDefault(emptySet())
+            .filterTo(linkedSetOf()) { cwd ->
+                codex.keys.any { ProjectPaths.canonicalKey(it) == ProjectPaths.canonicalKey(cwd) }
+            }
+        // A daemon-owned Codex process is already authoritative proof that this session is live. Include
+        // those workdirs even when no separate Terminal/Codex Desktop process exists; otherwise the
+        // transcript probe never runs and the exact daemon row keeps its intentionally-null title.
+        val daemonCodexCwds = liveByCwd.entries
+            .filterTo(linkedSetOf()) { (_, sessions) -> sessions.any { it.agent == AgentKind.CODEX } }
+            .mapTo(linkedSetOf()) { it.key }
+        val codexTitleCwds = externalCodexCwds + daemonCodexCwds
+        val externalCodexLive = runCatching { activeCodexSessions(codexTitleCwds) }.getOrDefault(emptyMap())
+            .map { (cwd, session) ->
+                ProjectPaths.canonicalKey(cwd) to ActiveSession(
+                    sessionId = session.sessionId,
+                    title = session.title,
+                    executing = session.live,
+                    gitBranch = session.gitBranch,
+                    agent = AgentKind.CODEX,
+                )
+            }
+            .groupBy({ it.first }, { it.second })
+        val liveNorm = (daemonLive.keys + externalCodexLive.keys).associateWith { key ->
+            val external = externalCodexLive[key].orEmpty()
+            val externalById = external.associateBy { it.sessionId }
+            // Keep the daemon's exact execution/busy/origin state, but fill its deliberately-null
+            // presentation metadata from the transcript probe. A plain distinctBy kept the daemon row
+            // whole and discarded the duplicate probe row, so tapping a live Codex project opened the
+            // correct session with a null title and the phone rendered its generic "Chat" fallback.
+            val authoritative = daemonLive[key].orEmpty().map { live ->
+                val transcript = externalById[live.sessionId]
+                live.copy(
+                    title = live.title ?: transcript?.title,
+                    gitBranch = live.gitBranch ?: transcript?.gitBranch,
+                )
+            }
+            (authoritative + external.filterNot { probe -> authoritative.any { it.sessionId == probe.sessionId } })
+                .sortedByDescending { it.executing }
+        }
+        // SessionRegistry keys background work by its canonical OpenSession path, while transcript/index
+        // sources may retain a symlink spelling. Busy is project identity, so normalize it at the same merge
+        // boundary as live sessions; otherwise ActiveSession.busy=true can coexist with a false project scalar.
+        val busyNorm = busyCwds.mapTo(HashSet()) { ProjectPaths.canonicalKey(it) }
+        val claude = claudeDirectories(busyNorm, liveNorm)
         // issue #290: programmatic one-shot sessions (a dsh plugin driving OpenCode per image, …) leave
         // dozens of throwaway cwds under the system temp dir and drown the project list. Hide temp rows
         // unless something keeps them relevant — a live/busy conversation, or the user having opened the

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/disk/LiveProcesses.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/disk/LiveProcesses.kt
@@ -28,6 +28,41 @@ object LiveProcesses {
         }.getOrDefault(emptySet())
     }
 
+    /**
+     * Working directories of `codex` CLI processes that are NOT children of this daemon. Codex keeps its
+     * rollout files under one global tree, so the project list cannot map a cwd to one particular rollout.
+     * This coarse project-level view therefore uses process cwd; [externalCodexAt] separately uses the
+     * exact rollout fd when deciding whether one session may be resumed safely.
+     *
+     * Only the exact `codex` executable counts: helpers such as `codex-code-mode-host` inherit the same cwd
+     * and would otherwise duplicate/extend liveness after their owning CLI disappeared. Daemon-owned Codex
+     * children are excluded because [SessionRegistry.liveByCwd] already reports them with authoritative
+     * turn state.
+     */
+    fun codexCwds(): Set<String> {
+        if (System.getProperty("os.name").lowercase().contains("win")) return emptySet() // no lsof
+        val selfPid = ProcessHandle.current().pid()
+        val pids = runCatching {
+            ProcessHandle.allProcesses()
+                .filter { isCodexExecutable(it.info().command().orElse("")) }
+                .filter { !hasAncestor(it, selfPid) }
+                .map { it.pid().toString() }
+                .toList()
+        }.getOrDefault(emptyList())
+        if (pids.isEmpty()) return emptySet()
+        return lsofLines(listOf("lsof", "-a", "-d", "cwd", "-p", pids.joinToString(","), "-Fn"))
+            ?.filter { it.startsWith("n") }
+            ?.map { it.substring(1) }
+            ?.toSet()
+            .orEmpty()
+    }
+
+    /** Exact basename match, separator-agnostic so the process probe behaves on Unix and Windows paths. */
+    internal fun isCodexExecutable(command: String): Boolean {
+        val name = command.substringAfterLast('/').substringAfterLast('\\').lowercase()
+        return name == "codex" || name == "codex.exe"
+    }
+
     /** Verdict of [externalClaudeAt]. UNKNOWN = "couldn't tell" — the CALLER picks the safe fallback
      *  (SessionRegistry keeps the mtime verdict: a spurious fork beats a two-writer clobber). */
     enum class ExternalClaude { PRESENT, ABSENT, UNKNOWN }
@@ -41,27 +76,56 @@ object LiveProcesses {
      * Windows (no lsof), enumeration failure, or an lsof failure/timeout all return UNKNOWN.
      */
     fun externalClaudeAt(workdir: String, transcript: Path): ExternalClaude {
+        return externalAgentAt(workdir, transcript, matchesCommand = { it.contains("/claude") })
+    }
+
+    /**
+     * Codex counterpart of [externalClaudeAt], used by read-only observe / safe take-over.
+     *
+     * Unlike Claude, current Codex keeps its active rollout open even while idle. That exact fd is the
+     * authoritative signal for an old transcript. cwd remains useful for a RECENT rollout (there is a
+     * short interval before/around the fd becoming visible), but must not make every old Codex session in
+     * the same project look live merely because one unrelated Codex process has that cwd.
+     */
+    fun externalCodexAt(workdir: String, transcript: Path): ExternalClaude {
+        val recent = runCatching {
+            System.currentTimeMillis() - java.nio.file.Files.getLastModifiedTime(transcript).toMillis() <
+                TranscriptScanner.LIVE_WINDOW_MS
+        }.getOrDefault(false)
+        return externalAgentAt(workdir, transcript, ::isCodexExecutable, allowCwdMatch = recent)
+    }
+
+    private fun externalAgentAt(
+        workdir: String,
+        transcript: Path,
+        matchesCommand: (String) -> Boolean,
+        allowCwdMatch: Boolean = true,
+    ): ExternalClaude {
         if (System.getProperty("os.name").lowercase().contains("win")) return ExternalClaude.UNKNOWN
         val selfPid = ProcessHandle.current().pid()
         val external = runCatching {
             ProcessHandle.allProcesses()
-                .filter { it.info().command().orElse("").contains("/claude") }
+                .filter { matchesCommand(it.info().command().orElse("")) }
                 .filter { !hasAncestor(it, selfPid) }
                 .map { it.pid() }
                 .toList()
         }.getOrNull() ?: return ExternalClaude.UNKNOWN
-        if (external.isEmpty()) return ExternalClaude.ABSENT // no claude outside the daemon at all
+        if (external.isEmpty()) return ExternalClaude.ABSENT // no matching agent outside the daemon at all
+        // Exact transcript ownership outranks age and cwd: an idle agent can hold a rollout for hours
+        // without touching its mtime, and that writer must never be resumed by a second process.
+        val holders = lsofLines(listOf("lsof", "-t", "--", transcript.toString()))
+            ?.mapNotNull { it.trim().toLongOrNull() }
+            ?.toSet()
+        val externalPids = external.toSet()
+        if (holders?.any { it in externalPids } == true) return ExternalClaude.PRESENT
+        if (!allowCwdMatch) return if (holders == null) ExternalClaude.UNKNOWN else ExternalClaude.ABSENT
+
         val cwdLines = lsofLines(listOf("lsof", "-a", "-d", "cwd", "-p", external.joinToString(","), "-Fn"))
             ?: return ExternalClaude.UNKNOWN
         // match raw AND canonical forms: lsof reports resolved real paths, the workdir may arrive symlinked
         val targets = pathForms(workdir)
         if (cwdLines.filter { it.startsWith("n") }.any { it.substring(1) in targets }) return ExternalClaude.PRESENT
-        // strengthener only: a claude launched from elsewhere but holding this transcript's fd is also a live
-        // writer. Its failure never demotes to UNKNOWN — the cwd check (the main judgement) already ran clean.
-        val holders = lsofLines(listOf("lsof", "-t", "--", transcript.toString()))
-            ?.mapNotNull { it.trim().toLongOrNull() }?.toSet() ?: emptySet()
-        val externalPids = external.toSet()
-        return if (holders.any { it in externalPids }) ExternalClaude.PRESENT else ExternalClaude.ABSENT
+        return ExternalClaude.ABSENT
     }
 
     /** True when [pid] appears in [p]'s ancestor chain (bounded walk — no cycles, but be paranoid). */

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/disk/SlashCommandScanner.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/disk/SlashCommandScanner.kt
@@ -56,7 +56,12 @@ object SlashCommandScanner {
         agent: AgentKind = AgentKind.CLAUDE,
     ): List<SlashCommand> {
         val byName = LinkedHashMap<String, SlashCommand>()
-        builtins.forEach { byName[skillKey(it.name)] = it }
+        val supportedBuiltins = if (agent == AgentKind.CODEX) {
+            // App-server control plane / daemon equivalents plus actions that are valid Codex prompts.
+            // Claude-only CLI skills (/init, /run, /deep-research, …) must not be advertised as Codex commands.
+            builtins.filter { it.name in CODEX_BUILTINS }
+        } else builtins
+        supportedBuiltins.forEach { byName[skillKey(it.name)] = it }
         // Claude custom commands are not a Codex/OpenCode capability. Preserve the legacy OpenCode
         // listing until that backend has its own command discovery contract.
         if (agent != AgentKind.CODEX) {
@@ -118,6 +123,8 @@ object SlashCommandScanner {
     }
 
     private data class Frontmatter(val description: String?, val argumentHint: String?)
+
+    private val CODEX_BUILTINS = setOf("model", "effort", "compact", "clear", "review", "simplify")
 
     /** Minimal YAML frontmatter read: top-level `description:` and `argument-hint:` scalars only. */
     private fun frontmatter(file: Path): Frontmatter {

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/session/SessionRegistry.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/session/SessionRegistry.kt
@@ -10,6 +10,7 @@ import dev.ccpocket.daemon.conversation.OutboundSink
 import dev.ccpocket.daemon.conversation.PromptFate
 import dev.ccpocket.daemon.conversation.PushHook
 import dev.ccpocket.daemon.conversation.sinkKey
+import dev.ccpocket.daemon.codex.CodexPaths
 import dev.ccpocket.daemon.disk.LiveProcesses
 import dev.ccpocket.daemon.disk.ProjectPaths
 import dev.ccpocket.daemon.disk.SessionGroups
@@ -58,6 +59,19 @@ class SessionRegistry(
     // decision matrix is unit-testable; the real probe shells out to lsof (LiveProcesses.externalClaudeAt)
     private val processProbe: (workdir: String, transcript: Path) -> LiveProcesses.ExternalClaude =
         LiveProcesses::externalClaudeAt,
+    // Codex equivalent of [processProbe]. Kept separate so the existing Claude decision-matrix tests and
+    // call sites stay source-compatible while Codex gets the same observe/take-over safety semantics.
+    private val codexProcessProbe: (workdir: String, transcript: Path) -> LiveProcesses.ExternalClaude =
+        LiveProcesses::externalCodexAt,
+    // Resolve an agent's durable transcript. Injectable so Codex observe tests use a temp rollout rather
+    // than the developer's real ~/.codex tree.
+    private val transcriptResolver: (agent: AgentKind, workdir: String, sessionId: String) -> Path? = { agent, workdir, sessionId ->
+        when (agent) {
+            AgentKind.CLAUDE -> ProjectPaths.dirFor(workdir).resolve("$sessionId.jsonl")
+            AgentKind.CODEX -> CodexPaths.findSession(sessionId)
+            else -> null
+        }
+    },
     // Claude transcript root — injectable ONLY so [renameSession]'s disk write is unit-testable against
     // a temp dir instead of the user's real ~/.claude/projects (every other path resolves via the
     // backends / ProjectPaths directly, same default)
@@ -123,9 +137,26 @@ class SessionRegistry(
      *  leaves a fresh mtime for up to 20s — trusting it blindly forked take-overs and demoted plain opens
      *  to read-only observe against a writer that no longer exists (the main "mystery fork" source).
      *  Internal (not private) so the decision matrix is unit-testable with a stubbed [processProbe]. */
-    internal suspend fun externallyActive(sessionId: String, workdir: String, file: Path): Boolean {
+    internal suspend fun externallyActive(
+        sessionId: String,
+        workdir: String,
+        file: Path,
+        agent: AgentKind = AgentKind.CLAUDE,
+    ): Boolean {
         // one stat serves both the freshness gate and the ownership checks below
         val mtime = runCatching { if (file.exists()) file.getLastModifiedTime().toMillis() else null }.getOrNull() ?: return false
+        // Codex keeps the exact active rollout open while idle. Probe before the generic freshness and
+        // restart-amnesia gates so an hours-old but still-owned rollout remains read-only. The production
+        // Codex probe only permits cwd matching for fresh rollouts, so this cannot promote unrelated old
+        // sessions from the same project.
+        val earlyCodexProbe = if (agent == AgentKind.CODEX) {
+            runCatching { withContext(Dispatchers.IO) { codexProcessProbe(workdir, file) } }
+                .getOrDefault(LiveProcesses.ExternalClaude.UNKNOWN)
+        } else null
+        if (earlyCodexProbe == LiveProcesses.ExternalClaude.PRESENT) {
+            log.info("externallyActive(${sessionId.take(8)}…): Codex holds exact rollout → true")
+            return true
+        }
         if (System.currentTimeMillis() - mtime >= TranscriptScanner.LIVE_WINDOW_MS) return false
         // Restart amnesia: a write that predates this daemon's boot came from our PREVIOUS instance's own
         // claude (children die with the daemon, and the restart wiped [selfClosed], which would otherwise
@@ -143,7 +174,7 @@ class SessionRegistry(
         // OS. Only reached on a fresh foreign-looking mtime, so the lsof cost stays off every ordinary open.
         // UNKNOWN (Windows / lsof failure / timeout) keeps the old mtime verdict: a wrongly forked session
         // is recoverable, two writers clobbering one transcript is not.
-        val probe = runCatching { withContext(Dispatchers.IO) { processProbe(workdir, file) } }
+        val probe = earlyCodexProbe ?: runCatching { withContext(Dispatchers.IO) { processProbe(workdir, file) } }
             .getOrDefault(LiveProcesses.ExternalClaude.UNKNOWN)
         val verdict = probe != LiveProcesses.ExternalClaude.ABSENT
         log.info(
@@ -300,6 +331,15 @@ class SessionRegistry(
         announcedWorkdir: String? = null,
     ): String {
         val resume = open.resumeId
+        // A resume id is the durable backend identity. Older Apps did not send `agent`, and a newer App
+        // can still carry a stale per-session guess persisted before Codex support. Trust the transcript
+        // that actually owns the id when the requested backend has no such transcript. Without this
+        // correction a Codex rollout is opened by the Claude backend, so both the badge and replay are
+        // wrong (Claude's scanner quite correctly finds no history in a Codex JSONL).
+        val effectiveAgent = resume?.let { resolveResumeAgent(open.agent, open.workdir, it) } ?: open.agent
+        if (effectiveAgent != open.agent) {
+            log.info("open ${resume?.take(8)}…: corrected stale agent ${open.agent} → $effectiveAgent from transcript")
+        }
         // §3.3 INITIATOR AUTO-SPECTATE: the clients streaming from a conversation the handoff rebuild is
         // about to close, moved onto the rebuilt one below so the owner keeps watching without re-opening.
         var spectators: List<OutboundSink> = emptyList()
@@ -410,13 +450,13 @@ class SessionRegistry(
                 log.info("open ${resume.take(8)}… → live candidate ${attach.convoId.take(8)}… expired before reattach claim; resuming cold")
                 live = null
             }
-            // observe a Claude session running OUTSIDE the daemon (e.g. a terminal) — read-only, no spawn.
-            // Claude-transcript specific; Codex resume falls through to a controlled thread/resume below.
+            // Observe a Claude/Codex session running OUTSIDE the daemon (e.g. a terminal) — read-only,
+            // no second writer. Each backend supplies its own transcript resolver/replay and process probe.
             // externallyActive requires a LIVE external process, not just a fresh mtime — a terminal claude
             // the user quit seconds ago falls through to an ordinary in-place resume, not read-only observe.
-            if (open.agent == AgentKind.CLAUDE && !open.takeOver) {
-                val file = ProjectPaths.dirFor(open.workdir).resolve("$resume.jsonl")
-                val recent = externallyActive(resume, open.workdir, file)
+            if (effectiveAgent in setOf(AgentKind.CLAUDE, AgentKind.CODEX) && !open.takeOver) {
+                val file = transcriptResolver(effectiveAgent, open.workdir, resume)
+                val recent = file != null && externallyActive(resume, open.workdir, file, effectiveAgent)
                 if (recent) {
                     // a bridge gets a clean refusal instead of a read-only ObserveSession: observes have
                     // no prompt path, and a headless adapter can't render "someone else is driving this"
@@ -440,7 +480,10 @@ class SessionRegistry(
                     }
                     val convoId = UUID.randomUUID().toString()
                     log.info("open ${resume.take(8)}… → OBSERVE ${convoId.take(8)}… (live foreign writer)")
-                    val obs = ObserveSession(convoId, open.workdir, resume, file, sink, scope, sinceSeq = open.lastEventSeq)
+                    val obs = ObserveSession(
+                        convoId, open.workdir, resume, file!!, sink, scope,
+                        agent = effectiveAgent, sinceSeq = open.lastEventSeq,
+                    )
                     mutex.withLock { observes[convoId] = obs }
                     obs.start()
                     return convoId
@@ -448,9 +491,9 @@ class SessionRegistry(
             }
         }
         // resume + control: an idle session, or an explicit "Continue here" take-over
-        val factory = backends[open.agent]
+        val factory = backends[effectiveAgent]
         if (factory == null) {
-            sink.emit(PocketError("agent_unavailable", "no backend registered for ${open.agent}"))
+            sink.emit(PocketError("agent_unavailable", "no backend registered for $effectiveAgent"))
             return ""
         }
         // create() is cheap + never throws (the binary resolves lazily on first launch); the real "CLI not
@@ -473,11 +516,12 @@ class SessionRegistry(
         // forks). Otherwise resume IN PLACE on the same sessionId: the phone truly takes over (issue #18 — no
         // duplicate session) and the desktop picks up the phone's turns on its next --resume (issue #22 — sync).
         // Ordinary cold/idle resume already appends in place. Same detector as the ObserveSession guard above.
-        val forkForTakeOver = open.takeOver && resume != null &&
-            externallyActive(resume, open.workdir, ProjectPaths.dirFor(open.workdir).resolve("$resume.jsonl"))
+        val takeOverTranscript = resume?.let { transcriptResolver(effectiveAgent, open.workdir, it) }
+        val forkForTakeOver = open.takeOver && resume != null && takeOverTranscript != null &&
+            externallyActive(resume, open.workdir, takeOverTranscript, effectiveAgent)
         log.info(
             "open ${resume?.take(8) ?: "new"}${if (open.takeOver) " (take-over)" else ""} → " +
-                "convo ${convoId.take(8)}… agent=${open.agent}${if (forkForTakeOver) " FORK" else ""}",
+                "convo ${convoId.take(8)}… agent=$effectiveAgent${if (forkForTakeOver) " FORK" else ""}",
         )
         // takeOver → Conversation.open spawns EAGERLY (seize the session now); a plain open starts lazily on the
         // first prompt (issue #61) so merely previewing a session never holds/occupies it for the desktop.
@@ -496,7 +540,7 @@ class SessionRegistry(
         if (started.isFailure) {
             mutex.withLock { convos.remove(convoId) }
             runCatching { c.close() }
-            sink.emit(PocketError("agent_unavailable", "${open.agent} CLI not found — is it installed? (${started.exceptionOrNull()?.message})"))
+            sink.emit(PocketError("agent_unavailable", "$effectiveAgent CLI not found — is it installed? (${started.exceptionOrNull()?.message})"))
             return ""
         }
         // §3.3 INITIATOR AUTO-SPECTATE (the other half of the hot→cold rebuild above): move the closed
@@ -652,6 +696,19 @@ class SessionRegistry(
                 "${if (plan.dropsTurnUuid != null) ", guarded" else ""})",
         )
         sink.emit(dev.ccpocket.protocol.RewindDone(req.convoId, ok = true, newConvoId = newConvoId))
+    }
+
+    /** Resolve a stale/missing wire agent from the durable transcript id. A positive requested-agent
+     *  match always wins; only a missing transcript permits the unambiguous Claude↔Codex correction. */
+    private fun resolveResumeAgent(requested: AgentKind, workdir: String, sessionId: String): AgentKind {
+        fun hasTranscript(agent: AgentKind): Boolean = runCatching {
+            transcriptResolver(agent, workdir, sessionId)?.exists() == true
+        }.getOrDefault(false)
+
+        if (hasTranscript(requested)) return requested
+        return listOf(AgentKind.CODEX, AgentKind.CLAUDE)
+            .firstOrNull { it != requested && hasTranscript(it) }
+            ?: requested
     }
 
     /** Test hook: is [convoId] still a live observe view? (the issue-107 stale-observer reap) */

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/agent/PermissionBridgeTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/agent/PermissionBridgeTest.kt
@@ -1125,6 +1125,32 @@ class PermissionBridgeTest {
     }
 
     @Test
+    fun codex_style_edit_session_scope_auto_allows_the_next_edit() = runBlocking {
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        val coord = ApprovalCoordinator(scope)
+        val rules = mutableSetOf<String>()
+        val responses = mutableListOf<Resp>()
+        val emitted = mutableListOf<Frame>()
+        val b = PermissionBridge(
+            "c1", PermissionMode.DEFAULT, coord, { emitted += it }, rules,
+            respond = { id, allow, remember, _, upd, deny -> responses += Resp(id, allow, remember, upd, deny) },
+        )
+
+        // Codex file-change approvals are normalized to Edit with a file_path and diff. A session grant
+        // is intentionally tool-family scoped, so the next Edit is silent even when it targets another file.
+        b.onControlRequest(AgentEvent.ControlRequest("e1", "Edit", buildJsonObject { put("file_path", "/repo/A.kt") }, diff = "+ A"))
+        coord.onVerdict(PermissionVerdict("c1", "e1", Decision.ALLOW, grantScope = "session"))
+        assertTrue("Edit" in rules)
+
+        emitted.clear()
+        b.onControlRequest(AgentEvent.ControlRequest("e2", "Edit", buildJsonObject { put("file_path", "/repo/B.kt") }, diff = "+ B"))
+        assertTrue(emitted.filterIsInstance<PermissionAsk>().isEmpty(), "remembered Edit must not ask again in this session")
+        assertTrue(responses.last().allow)
+        assertFalse(responses.last().remember, "automatic replay is local daemon policy, not a second CLI grant")
+        scope.cancel()
+    }
+
+    @Test
     fun retry_safer_deny_reads_as_replan_guidance_not_a_refusal() = runBlocking {
         val scope = CoroutineScope(Dispatchers.Unconfined)
         val coord = ApprovalCoordinator(scope)

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/codex/CodexBackendTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/codex/CodexBackendTest.kt
@@ -58,6 +58,25 @@ class CodexBackendTest {
     }
 
     @Test
+    fun take_over_uses_native_thread_fork_instead_of_a_second_writer_on_resume() = runBlocking {
+        val w = mutableListOf<String>()
+        val b = CodexBackend(null)
+        b.attach(
+            AgentIo(writeLine = { w += it }, emit = {}),
+            AgentSpec(Path.of("/repo"), resumeId = "thr-desktop", forkSession = true),
+        )
+        b.parse(initResponse(1))
+
+        val open = w.last { "thread/" in it }
+        assertTrue("\"method\":\"thread/fork\"" in open, open)
+        assertTrue("\"threadId\":\"thr-desktop\"" in open, open)
+        assertFalse("thread/resume" in open, open)
+
+        val ev = b.parse(threadStartResponse(2, "thr-phone"))
+        assertEquals("thr-phone", assertIs<AgentEvent.SessionInit>(ev.single()).sessionId)
+    }
+
+    @Test
     fun first_prompt_buffers_until_thread_ready_then_turn_start() = runBlocking {
         val w = mutableListOf<String>()
         val b = CodexBackend(null)
@@ -114,6 +133,23 @@ class CodexBackendTest {
     }
 
     @Test
+    fun prompt_sent_during_an_active_turn_uses_native_turn_steer() = runBlocking {
+        val w = mutableListOf<String>()
+        val b = ready(w)
+        b.parse(
+            """{"method":"turn/started","params":{"threadId":"thr-1","turn":{"id":"turn-live","status":"inProgress"}}}""",
+        )
+
+        b.sendPrompt("continue with the next batch", emptyList())
+
+        val request = w.last()
+        assertTrue("\"method\":\"turn/steer\"" in request, request)
+        assertTrue("\"threadId\":\"thr-1\"" in request, request)
+        assertTrue("\"expectedTurnId\":\"turn-live\"" in request, request)
+        assertTrue("continue with the next batch" in request, request)
+    }
+
+    @Test
     fun agent_message_delta_streams_as_text() = runBlocking {
         val w = mutableListOf<String>()
         val b = ready(w)
@@ -128,6 +164,58 @@ class CodexBackendTest {
         b.parse("""{"method":"item/agentMessage/delta","params":{"itemId":"i1","delta":"Hi"}}""")
         val ev = b.parse("""{"method":"item/completed","params":{"item":{"type":"agentMessage","id":"i1","text":"Hi there"}}}""")
         assertTrue(ev.isEmpty(), "final must not re-emit once deltas streamed the message") // text was already streamed
+    }
+
+    @Test
+    fun compact_uses_native_app_server_rpc_when_thread_is_ready() = runBlocking {
+        val w = mutableListOf<String>()
+        val b = ready(w)
+
+        assertTrue(b.compact())
+
+        val request = w.last()
+        assertTrue("\"method\":\"thread/compact/start\"" in request, request)
+        assertTrue("\"threadId\":\"thr-1\"" in request, request)
+    }
+
+    @Test
+    fun compact_queued_during_handshake_runs_once_after_thread_opens() = runBlocking {
+        val w = mutableListOf<String>()
+        val b = CodexBackend(null)
+        b.attach(AgentIo({ w += it }, {}), AgentSpec(Path.of("/repo"), resumeId = "thr-old"))
+
+        assertTrue(b.compact())
+        assertTrue(w.none { "thread/compact/start" in it })
+        b.parse(initResponse(1))
+        b.parse(threadStartResponse(2, "thr-1"))
+
+        assertEquals(1, w.count { "thread/compact/start" in it })
+    }
+
+    @Test
+    fun review_uses_native_app_server_target() = runBlocking {
+        val w = mutableListOf<String>()
+        val b = ready(w)
+
+        assertTrue(b.review())
+
+        val request = w.last()
+        assertTrue("\"method\":\"review/start\"" in request, request)
+        assertTrue("\"type\":\"uncommittedChanges\"" in request, request)
+        assertTrue("\"delivery\":\"inline\"" in request, request)
+    }
+
+    @Test
+    fun simplify_expands_to_a_codex_task_not_an_unknown_slash_command() = runBlocking {
+        val w = mutableListOf<String>()
+        val b = ready(w)
+
+        b.sendPrompt("/simplify keep the public API", emptyList())
+
+        val turn = w.last { "turn/start" in it }
+        assertFalse("/simplify" in turn, turn)
+        assertTrue("simplify the implementation" in turn, turn)
+        assertTrue("keep the public API" in turn, turn)
     }
 
     @Test
@@ -209,6 +297,19 @@ class CodexBackendTest {
         val tr = ev.single()
         assertIs<AgentEvent.TurnResult>(tr)
         assertEquals(null, tr.usage) // zeros would read as "empty window" on the phone's statusline
+    }
+
+    @Test
+    fun failed_turn_surfaces_codex_error_instead_of_generic_turn_failed() = runBlocking {
+        val w = mutableListOf<String>()
+        val b = ready(w)
+        val ev = b.parse(
+            """{"method":"turn/completed","params":{"threadId":"thr-1","turn":{"id":"t1","status":"failed","error":{"message":"Selected model is unavailable"}}}}""",
+        )
+
+        val tr = assertIs<AgentEvent.TurnResult>(ev.single())
+        assertTrue(tr.isError)
+        assertEquals("Selected model is unavailable", tr.finalText)
     }
 
     @Test

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/codex/CodexModelServiceTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/codex/CodexModelServiceTest.kt
@@ -48,7 +48,7 @@ class CodexModelServiceTest {
 
         assertEquals(AgentKind.CODEX, result.agent)
         assertEquals(null, result.error)
-        assertEquals(listOf("gpt-5.5", "gpt-5.6-sol", "gpt-5.1-codex", "gpt-5.1-codex-mini", "gpt-5-codex"), result.models)
+        assertEquals(listOf("gpt-5.5", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"), result.models)
         val sol = result.modelCapabilities.single { it.model == "gpt-5.6-sol" }
         assertEquals(listOf("max", "ultra"), sol.reasoningEfforts)
         assertEquals("max", sol.defaultReasoningEffort)

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/codex/CodexTranscriptTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/codex/CodexTranscriptTest.kt
@@ -16,6 +16,8 @@ class CodexTranscriptTest {
     private val rollout = """
         {"timestamp":"t0","type":"session_meta","payload":{"id":"thr-xyz","cwd":"/repo","cli_version":"0.124.0"}}
         {"timestamp":"t1","type":"event_msg","payload":{"type":"task_started","turn_id":"u1"}}
+        {"timestamp":"t1a","type":"turn_context","payload":{"turn_id":"u1","model":"gpt-5.6-sol","effort":"high"}}
+        {"timestamp":"t1b","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":32123},"model_context_window":258400}}}
         {"timestamp":"t2","type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"<permissions instructions> ..."}]}}
         {"timestamp":"t3","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context> ..."}]}}
         {"timestamp":"t4","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"build the thing"}]}}
@@ -35,6 +37,15 @@ class CodexTranscriptTest {
         assertEquals(1, s.messageCount)
         assertEquals(AgentKind.CODEX, s.agent)
         assertEquals("0.124.0", s.version)
+        assertEquals("gpt-5.6-sol", s.model)
+    }
+
+    @Test
+    fun runtime_state_uses_codex_model_and_context_metadata() {
+        val state = CodexTranscriptScanner.runtimeState(tempRollout())
+        assertEquals("gpt-5.6-sol", state.model)
+        assertEquals(258_400L, state.contextWindow)
+        assertEquals(32_123L, state.contextUsed)
     }
 
     @Test

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/conversation/ConversationClearTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/conversation/ConversationClearTest.kt
@@ -50,7 +50,16 @@ class ConversationClearTest {
         override fun applySettings(mode: PermissionMode?, model: String?, effort: String?) = true
         override suspend fun onProcessEnded(sessionId: String?) {}
         override fun transcriptDir(workdir: String): Path = Path.of(workdir)
-        override fun listSessions(workdir: String): List<SessionSummary> = emptyList()
+        override fun listSessions(workdir: String): List<SessionSummary> = listOf(
+            SessionSummary(
+                sessionId = "resumed-sid",
+                title = "Transcript title",
+                firstPrompt = "first prompt",
+                messageCount = 1,
+                cwd = workdir,
+                lastModified = 1L,
+            ),
+        )
         override fun replayHistory(workdir: String, sessionId: String): List<HistoryMessage> = emptyList()
         override fun resumeContextTokens(workdir: String, sessionId: String): Long? = 80_000L
     }
@@ -91,6 +100,34 @@ class ConversationClearTest {
             } finally {
                 convo.close()
                 scope.cancel()
+            }
+        }
+    }
+
+    @Test
+    fun resumed_session_announces_the_transcript_title() {
+        if (win()) return
+        runBlocking {
+            val dir = Files.createTempDirectory("ccp-title")
+            val frames = ArrayList<Frame>()
+            val scope = CoroutineScope(kotlinx.coroutines.Dispatchers.Default)
+            val convo = Conversation(
+                convoId = "cTitle", initialWorkdir = dir, initialMode = PermissionMode.DEFAULT,
+                initialSink = { f -> synchronized(frames) { frames.add(f) } },
+                parentScope = scope, backend = ResumedBackend(),
+            )
+            try {
+                convo.open(resumeId = "resumed-sid", model = null)
+                withTimeout(10_000) {
+                    while (synchronized(frames) { frames.none { it is SessionLive } }) delay(20)
+                }
+
+                val live = synchronized(frames) { frames.filterIsInstance<SessionLive>().first() }
+                assertEquals("Transcript title", live.title)
+            } finally {
+                convo.close()
+                scope.cancel()
+                dir.toFile().deleteRecursively()
             }
         }
     }

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/disk/DirectoryServiceMergeTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/disk/DirectoryServiceMergeTest.kt
@@ -2,6 +2,7 @@ package dev.ccpocket.daemon.disk
 
 import dev.ccpocket.protocol.ActiveSession
 import dev.ccpocket.protocol.AgentKind
+import dev.ccpocket.protocol.SessionSummary
 import java.nio.file.Files
 import java.nio.file.attribute.FileTime
 import kotlin.io.path.createDirectories
@@ -48,6 +49,8 @@ class DirectoryServiceMergeTest {
         opencode: Map<String, Long> = emptyMap(),
         zcode: Map<String, Long> = emptyMap(),
         liveClaudeCwds: () -> Set<String> = { emptySet() },
+        liveCodex: Set<String> = emptySet(),
+        activeCodexSessions: (Set<String>) -> Map<String, SessionSummary> = { emptyMap() },
         nowMillis: () -> Long = System::currentTimeMillis,
     ) = DirectoryService(
         projectsRoot = { projects },
@@ -59,6 +62,8 @@ class DirectoryServiceMergeTest {
         // ~/.dsh store, so this test would pass or fail depending on whose machine ran it
         dshCwds = { emptyMap() },
         liveClaudeCwds = liveClaudeCwds,
+        liveCodexCwds = { liveCodex },
+        activeCodexSessions = activeCodexSessions,
         nowMillis = nowMillis,
         // the fixture workdirs above live under the REAL system temp — opt out of the #290 noise filter
         // (which has its own dedicated test) or every row here would be hidden as one-shot noise
@@ -175,5 +180,91 @@ class DirectoryServiceMergeTest {
         val expired = svc.listDirectories(null).single().activeSessions.single()
         assertEquals(false, expired.executing)
         assertEquals(false, expired.executingAuthoritative, "expiry remains explicitly non-authoritative")
+    }
+
+    @Test
+    fun external_codex_process_promotes_its_newest_rollout_to_an_active_session() {
+        val summary = SessionSummary(
+            sessionId = "codex-live",
+            title = "External Codex",
+            firstPrompt = "work",
+            messageCount = 2,
+            cwd = work.toString(),
+            lastModified = future,
+            live = true,
+            agent = AgentKind.CODEX,
+        )
+        val row = service(
+            codex = mapOf(work.toString() to future),
+            // The process probe may report a realpath/symlink spelling different from the rollout.
+            liveCodex = setOf(link.toString()),
+            activeCodexSessions = { cwds -> cwds.associateWith { summary } },
+        ).listDirectories(null).single()
+
+        assertTrue(row.open, "an external Codex CLI should put the project in the active section")
+        assertEquals("codex-live", row.activeSessionId)
+        assertEquals("External Codex", row.activeSessionTitle)
+        assertEquals(listOf(AgentKind.CODEX), row.activeSessions.map { it.agent })
+        assertTrue(row.executing, "fresh rollout activity should carry the running state")
+    }
+
+    @Test
+    fun every_external_codex_project_is_reported_not_only_the_newest_one() {
+        val other = Files.createTempDirectory("ccp-codex-other")
+        try {
+            val summaries = mapOf(
+                ProjectPaths.canonicalKey(work.toString()) to SessionSummary(
+                    "codex-a", "A", "work A", 1, work.toString(), future, agent = AgentKind.CODEX,
+                ),
+                ProjectPaths.canonicalKey(other.toString()) to SessionSummary(
+                    "codex-b", "B", "work B", 1, other.toString(), future - 1, agent = AgentKind.CODEX,
+                ),
+            )
+            val rows = service(
+                codex = mapOf(work.toString() to future, other.toString() to future - 1),
+                liveCodex = setOf(work.toString(), other.toString()),
+                activeCodexSessions = { cwds ->
+                    cwds.mapNotNull { cwd ->
+                        summaries[ProjectPaths.canonicalKey(cwd)]?.let { cwd to it }
+                    }.toMap()
+                },
+            ).listDirectories(null)
+
+            assertEquals(setOf("codex-a", "codex-b"), rows.mapNotNull { it.activeSessionId }.toSet())
+            assertTrue(rows.all { it.open })
+        } finally {
+            other.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun daemon_live_state_wins_when_external_codex_probe_finds_the_same_session() {
+        val exact = ActiveSession("same", executing = false, busy = true, agent = AgentKind.CODEX)
+        val heuristic = SessionSummary(
+            sessionId = "same",
+            title = "heuristic",
+            firstPrompt = "work",
+            messageCount = 1,
+            cwd = work.toString(),
+            lastModified = future,
+            live = true,
+            agent = AgentKind.CODEX,
+        )
+        val row = service(
+            codex = mapOf(work.toString() to future),
+            // No external Terminal/Codex Desktop process: the daemon-owned Codex conversation alone
+            // must still trigger a transcript lookup so its project-card title is not null.
+            liveCodex = emptySet(),
+            activeCodexSessions = { cwds -> cwds.associateWith { heuristic } },
+        ).listDirectories(null, liveByCwd = mapOf(work.toString() to listOf(exact))).single()
+
+        assertEquals(1, row.activeSessions.size, "the same session must not appear twice")
+        assertTrue(row.activeSessions.single().busy, "authoritative daemon state must beat the heuristic")
+        assertTrue(!row.activeSessions.single().executing)
+        assertEquals(
+            "heuristic",
+            row.activeSessions.single().title,
+            "authoritative live state must retain the transcript title instead of replacing it with null",
+        )
     }
 }

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/disk/LiveProcessesTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/disk/LiveProcessesTest.kt
@@ -1,0 +1,19 @@
+package dev.ccpocket.daemon.disk
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LiveProcessesTest {
+
+    @Test
+    fun codex_process_match_is_exact_and_platform_separator_agnostic() {
+        assertTrue(LiveProcesses.isCodexExecutable("/opt/homebrew/bin/codex"))
+        assertTrue(LiveProcesses.isCodexExecutable("Codex"))
+        assertTrue(LiveProcesses.isCodexExecutable("C:\\tools\\codex.exe"))
+
+        assertFalse(LiveProcesses.isCodexExecutable("/opt/homebrew/bin/codex-code-mode-host"))
+        assertFalse(LiveProcesses.isCodexExecutable("/Applications/Codex.app/Contents/MacOS/Codex Helper"))
+        assertFalse(LiveProcesses.isCodexExecutable("node"))
+    }
+}

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/disk/SlashCommandScannerTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/disk/SlashCommandScannerTest.kt
@@ -100,6 +100,9 @@ class SlashCommandScannerTest {
         val cmds = SlashCommandScanner.scan(work, home, agent = AgentKind.CODEX)
 
         assertTrue(cmds.none { it.name == "claude-command" || it.name == "claude-skill" })
+        assertTrue(cmds.any { it.name == "compact" })
+        assertTrue(cmds.any { it.name == "clear" })
+        assertTrue(cmds.none { it.name == "init" || it.name == "deep-research" || it.name == "fewer-permission-prompts" })
         assertEquals("user codex", cmds.single { it.name == "user-codex" }.description)
         assertEquals("project codex", cmds.single { it.name == "project-codex" }.description)
     }

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/session/SessionRegistryObserveTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/session/SessionRegistryObserveTest.kt
@@ -5,12 +5,18 @@ import dev.ccpocket.daemon.conversation.ObserveSession
 import dev.ccpocket.daemon.conversation.OutboundSink
 import dev.ccpocket.daemon.disk.LiveProcesses
 import dev.ccpocket.daemon.disk.ProjectPaths
+import dev.ccpocket.protocol.AgentKind
+import dev.ccpocket.protocol.ConvoHistory
+import dev.ccpocket.protocol.Frame
 import dev.ccpocket.protocol.OpenSession
+import dev.ccpocket.protocol.SessionLive
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import java.nio.file.Files
 import java.util.UUID
 import kotlin.test.AfterTest
@@ -98,5 +104,117 @@ class ObserveSessionAttachIdentityTest {
     @Test
     fun session_id_is_readable_for_the_reap_filter() {
         assertEquals("s1", observe(OutboundSink { }).sessionId)
+    }
+}
+
+/** Codex gets the same external-session UX as Claude: read-only tail first, no second writer on tap. */
+class CodexObserveParityTest {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val dir = Files.createTempDirectory("ccp-codex-observe")
+    private val rollout = dir.resolve("rollout-test.jsonl")
+
+    @AfterTest
+    fun tearDown() {
+        scope.cancel()
+        dir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun external_codex_opens_as_a_codex_read_only_observer_and_replays_rollout_history() = runBlocking {
+        val registry = SessionRegistry(
+            scope,
+            backends = emptyMap(),
+            codexProcessProbe = { _, _ -> LiveProcesses.ExternalClaude.PRESENT },
+            transcriptResolver = { agent, _, _ -> if (agent == AgentKind.CODEX) rollout else null },
+        )
+        Files.writeString(
+            rollout,
+            """{"type":"session_meta","payload":{"id":"codex-live","cwd":"/repo"}}""" + "\n" +
+                """{"type":"turn_context","payload":{"turn_id":"t1","model":"gpt-5.6-sol"}}""" + "\n" +
+                """{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":12345},"model_context_window":258400}}}""" + "\n" +
+                """{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}}""" + "\n" +
+                """{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}}""" + "\n",
+        )
+        Files.setLastModifiedTime(rollout, java.nio.file.attribute.FileTime.fromMillis(System.currentTimeMillis()))
+        val frames = java.util.Collections.synchronizedList(mutableListOf<Frame>())
+        fun snapshot(): List<Frame> = synchronized(frames) { frames.toList() }
+
+        val convo = registry.open(
+            OpenSession("/repo", resumeId = "codex-live", agent = AgentKind.CODEX, lastEventSeq = 0),
+            OutboundSink { frames += it },
+        )
+
+        assertTrue(registry.observing(convo))
+        withTimeout(3_000) {
+            while (snapshot().none { it is SessionLive } || snapshot().none { it is ConvoHistory }) delay(20)
+        }
+        val live = snapshot().filterIsInstance<SessionLive>().last()
+        assertTrue(live.observing)
+        assertEquals(AgentKind.CODEX, live.agent)
+        assertEquals("gpt-5.6-sol", live.model)
+        assertEquals(258_400L, live.contextWindow)
+        assertEquals(12_345L, live.contextUsed)
+        assertEquals("hello", live.title, "an external Codex observer must announce its transcript title")
+        val history = snapshot().filterIsInstance<ConvoHistory>().last()
+        assertEquals(listOf("hello", "hi"), history.messages.map { it.text })
+    }
+
+    @Test
+    fun idle_external_codex_holding_an_old_rollout_still_opens_read_only() = runBlocking {
+        val registry = SessionRegistry(
+            scope,
+            backends = emptyMap(),
+            codexProcessProbe = { _, _ -> LiveProcesses.ExternalClaude.PRESENT },
+            transcriptResolver = { agent, _, _ -> if (agent == AgentKind.CODEX) rollout else null },
+        )
+        Files.writeString(
+            rollout,
+            """{"type":"session_meta","payload":{"id":"codex-idle","cwd":"/repo"}}""" + "\n",
+        )
+        // A terminal Codex keeps the rollout open while idle, but may not write it for hours. Its exact
+        // process/FD ownership must outrank the generic transcript freshness window.
+        Files.setLastModifiedTime(
+            rollout,
+            java.nio.file.attribute.FileTime.fromMillis(System.currentTimeMillis() - 60_000),
+        )
+
+        val convo = registry.open(
+            OpenSession("/repo", resumeId = "codex-idle", agent = AgentKind.CODEX, lastEventSeq = 0),
+            OutboundSink { },
+        )
+
+        assertTrue(registry.observing(convo))
+    }
+
+    @Test
+    fun stale_claude_wire_default_is_corrected_from_codex_transcript_and_history_replays() = runBlocking {
+        val registry = SessionRegistry(
+            scope,
+            backends = emptyMap(),
+            codexProcessProbe = { _, _ -> LiveProcesses.ExternalClaude.PRESENT },
+            transcriptResolver = { agent, _, _ -> if (agent == AgentKind.CODEX) rollout else null },
+        )
+        Files.writeString(
+            rollout,
+            """{"type":"session_meta","payload":{"id":"codex-live","cwd":"/repo"}}""" + "\n" +
+                """{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"from codex"}]}}""" + "\n" +
+                """{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"restored"}]}}""" + "\n",
+        )
+        Files.setLastModifiedTime(rollout, java.nio.file.attribute.FileTime.fromMillis(System.currentTimeMillis()))
+        val frames = java.util.Collections.synchronizedList(mutableListOf<Frame>())
+
+        // No agent field on the wire decodes as CLAUDE for compatibility with old Apps.
+        val convo = registry.open(
+            OpenSession("/repo", resumeId = "codex-live", lastEventSeq = 0),
+            OutboundSink { frames += it },
+        )
+
+        assertTrue(registry.observing(convo))
+        withTimeout(3_000) {
+            while (frames.none { it is SessionLive } || frames.none { it is ConvoHistory }) delay(20)
+        }
+        assertEquals(AgentKind.CODEX, frames.filterIsInstance<SessionLive>().last().agent)
+        assertEquals(listOf("from codex", "restored"), frames.filterIsInstance<ConvoHistory>().last().messages.map { it.text })
     }
 }

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -106,18 +106,22 @@ struct iOSApp: App {
 
     init() {
         // Firebase stays in Swift (the only place that imports it); the shared Kotlin Telemetry
-        // calls back through the sink registered below — mirroring cc-dashboard's single seam.
-        FirebaseApp.configure()
-        Analytics.setAnalyticsCollectionEnabled(true) // plist ships IS_ANALYTICS_ENABLED=false; opt in here
-        MainViewControllerKt.setTelemetrySink(
-            onEvent: { event, params in
-                Analytics.logEvent(event, parameters: params)
-            },
-            onError: { message, phase in
-                let info: [String: Any] = [NSLocalizedDescriptionKey: message, "phase": phase ?? ""]
-                Crashlytics.crashlytics().record(error: NSError(domain: "ccpocket", code: 0, userInfo: info))
-            }
-        )
+        // calls back through the sink registered below — mirroring cc-dashboard's single seam. A clean
+        // clone intentionally ships a placeholder plist for local builds; Firebase Installations aborts
+        // the process when that placeholder API key is passed to configure, so telemetry must degrade to
+        // its existing no-op sink until a real Firebase configuration is supplied.
+        if Self.configureFirebaseIfUsable() {
+            Analytics.setAnalyticsCollectionEnabled(true) // plist ships IS_ANALYTICS_ENABLED=false; opt in here
+            MainViewControllerKt.setTelemetrySink(
+                onEvent: { event, params in
+                    Analytics.logEvent(event, parameters: params)
+                },
+                onError: { message, phase in
+                    let info: [String: Any] = [NSLocalizedDescriptionKey: message, "phase": phase ?? ""]
+                    Crashlytics.crashlytics().record(error: NSError(domain: "ccpocket", code: 0, userInfo: info))
+                }
+            )
+        }
         // Push registration lives in Swift (UIKit symbols aren't uniform across Kotlin/Native targets).
         // Kotlin's PushController calls this when registration starts (after pairing), so the prompt
         // follows pairing rather than firing at cold launch.
@@ -127,6 +131,26 @@ struct iOSApp: App {
                 DispatchQueue.main.async { UIApplication.shared.registerForRemoteNotifications() }
             }
         }
+    }
+
+    private static func configureFirebaseIfUsable() -> Bool {
+        guard let path = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
+              let options = FirebaseOptions(contentsOfFile: path),
+              let apiKey = options.apiKey,
+              apiKey.count == 39,
+              apiKey.hasPrefix("A"),
+              apiKey.unicodeScalars.allSatisfy({
+                  CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_")).contains($0)
+              }),
+              let projectID = options.projectID,
+              !projectID.isEmpty,
+              !options.googleAppID.isEmpty
+        else {
+            return false
+        }
+
+        FirebaseApp.configure(options: options)
+        return true
     }
 
     var body: some Scene {

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
@@ -1775,7 +1775,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         pendingOpen = null
         if (convoId.value != null && currentSessionId == t.sessionId) return // already in this session — don't churn it
         sessionsDir.value = null // drop any half-open session list so the chat is what shows
-        openSession(t.workdir, t.sessionId, title = t.title, agent = t.agent ?: sessionDefaultAgent)
+        openSession(t.workdir, t.sessionId, title = t.title, agent = t.agent)
     }
 
     /** Relay control-plane events (not E2E daemon traffic) drive the honest connection phase. */
@@ -3072,6 +3072,10 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
                 migrateDraft(f.sessionId) // before re-keying: composerKey() still reads the old chain
                 convoId.value = f.convoId; workdir.value = f.workdir; observing.value = f.observing; currentSessionId = f.sessionId
                 f.sessionId?.let { sessionKey.value = it }
+                // The opener's title is only an optimistic seed: push/deep-link routes know no title at
+                // all, and a project row can be stale while Codex renames its thread. A new daemon sends
+                // transcript/index truth here; null from an older daemon deliberately keeps the seed.
+                f.title?.takeIf { it.isNotBlank() }?.let { chatTitle.value = it }
                 f.mode?.let { mode.value = it } // daemon is the source of truth — corrects the optimistic badge
                 permissionMode.value = f.permissionMode // unconditional: a normal mode clears a prior `auto`
                 effort.value = f.effort // unconditional: `/effort default` must clear an optimistic explicit level
@@ -5127,7 +5131,9 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         resumeId: String? = null,
         startMode: PermissionMode = defaultMode.value,
         title: String? = null,
-        agent: AgentKind = sessionDefaultAgent,
+        // null means the caller has no backend provenance (old deep link / old daemon). An explicit
+        // list-row agent must outrank a stale SessionParams value persisted by a previous App version.
+        agent: AgentKind? = null,
         startPermissionMode: String? = defaultPermissionMode.value,
         // issue #199: a model picked in the new-session step, for THIS session only. Null = the usual
         // ladder (an existing session's remembered nullable value; a NEW session's per-agent Settings
@@ -5138,9 +5144,9 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         // A resumed session keeps its recorded backend, so gate that effective agent rather than only the
         // caller's seed. This is synchronous like the idempotence refusals below: unsupported ZCode never
         // clears the current chat, flips opening state or reaches the wire.
-        val targetAgent = resumeId?.let { sessionParams[it]?.agent } ?: agent
+        val targetAgent = agent ?: resumeId?.let { sessionParams[it]?.agent } ?: sessionDefaultAgent
         if (!supportsAgent(targetAgent)) return false
-        val attempt = OpenAttempt(wd, resumeId, startMode, title, agent, startPermissionMode, startModel)
+        val attempt = OpenAttempt(wd, resumeId, startMode, title, targetAgent, startPermissionMode, startModel)
         // #235: the two refusals, both decided SYNCHRONOUSLY — the defect they fix is two clicks landing in
         // the same frame, so any check that only ran inside the coroutine below was already too late.
         //  (a) the same target is in flight: a second OpenSession restarts the very session the first is
@@ -5209,7 +5215,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         // (default = the persisted Settings mode), so "continue here" honors what Settings says instead of
         // silently reviving a stale per-session mode (issue #50). Model/effort/agent still restore per-session.
         val openMode = startMode
-        val openAgent = saved?.agent ?: agent // resumed sessions keep their backend; new ones use the picked default
+        val openAgent = agent
         val openPermissionMode =
             startPermissionMode?.takeIf { openAgent == AgentKind.CLAUDE && it == CLAUDE_PERMISSION_MODE_AUTO }
         // Each backend seeds from its own persisted default. The compatibility guard is the final defence against
@@ -6487,7 +6493,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         // the authoritative id right after (a fork or lock-heal can hand back a different one), so a
         // wrong guess self-corrects instead of sticking in the MRU.
         rememberOpenedSession(item.dirKey, item.sessionId, item.title, item.agent, markSeen = false)
-        openSession(item.dirKey, item.sessionId, title = item.title, agent = item.agent ?: sessionDefaultAgent)
+        openSession(item.dirKey, item.sessionId, title = item.title, agent = item.agent)
     }
 
     /** Leaving the chat or losing the connection invalidates any in-flight capture. */
@@ -6537,8 +6543,8 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
                     // default. Other backends keep their established fallback to the Settings effort.
                     effort = takeoverEffort,
                     takeOver = true,
-                    lastEventSeq = lastEventSeqFor(sid),
                     agent = agent,
+                    lastEventSeq = lastEventSeqFor(sid),
                     permissionMode = permissionMode.value,
                     serviceTier = serviceTier.value,
                 ),

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/App.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/App.kt
@@ -453,6 +453,7 @@ fun App(scope: CoroutineScope) {
                 // Secure Approval renderer stays a pure function of what the daemon actually said
                 val approvalUi = dev.ccpocket.app.ui.approval.approvalUi(
                     ask = ask,
+                    agent = repo.sessionAgent.value ?: AgentKind.CLAUDE,
                     workdir = repo.workdir.value,
                     risk = repo.riskDetailFor(ask), // M3: the FULL event (level + reason + codes + assessed)
                     queueProgress = repo.askQueueProgress.value, // "n of m" while a burst is queued (design M1)
@@ -1846,13 +1847,31 @@ private fun SharedProjectCell(repo: PocketRepository, e: DirectoryEntry, onLongP
 }
 
 /** Long-press a project → pin it to the top, or unpin it, or share it. Small sheet, mirrors the app's other actions. */
+internal fun projectActionAgents(e: DirectoryEntry): List<AgentKind> {
+    val active = e.activeSessions.map { it.agent }.distinct()
+    return (if (active.isNotEmpty()) active else e.sessionAgents)
+        .distinct()
+        .sortedBy { it.ordinal }
+}
+
 @Composable
 private fun ProjectActionsSheet(repo: PocketRepository, e: DirectoryEntry, onShare: () -> Unit, onDismiss: () -> Unit) {
     val pinned = repo.isPinned(e.path)
+    val agents = remember(e.activeSessions, e.sessionAgents) { projectActionAgents(e) }
     PocketSheet(onDismiss) {
         Column(Modifier.padding(horizontal = 16.dp).padding(bottom = 14.dp, top = 4.dp)) {
             Text(e.name.ifBlank { e.path }, color = Tok.tx, fontSize = 18.sp, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
             TailPathText(e.path, fontSize = 12.sp, modifier = Modifier.padding(top = 2.dp))
+            if (agents.isNotEmpty()) {
+                Row(
+                    Modifier.padding(top = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(stringResource(Res.string.label_agent), color = Tok.muted, fontSize = 12.sp)
+                    agents.forEach { AgentTag(it) }
+                }
+            }
             Row(
                 Modifier.padding(top = 14.dp).fillMaxWidth().clip(RoundedCornerShape(12.dp)).background(Tok.surface)
                     .clickable { repo.togglePin(e.path); onDismiss() }.padding(horizontal = 14.dp, vertical = 14.dp),

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/Permissions.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/Permissions.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -41,6 +42,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -52,9 +54,12 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -82,6 +87,8 @@ data class ModeInfo(
 
 // same hue as the semantic info token — a getter so it tracks the light/dark palette (#63)
 private val Indigo get() = Tok.info
+
+internal const val POCKET_SHEET_DRAG_HANDLE_TAG = "pocket-sheet-drag-handle"
 
 /** Trims a single line's leading and centers the glyph in it — fixes text riding high when vertically centered. */
 internal val TightCenter = TextStyle(
@@ -115,12 +122,15 @@ fun PocketSheet(onDismiss: () -> Unit, dropKeyboard: Boolean = true, content: @C
     // opens focused on purpose, and a blanket clearFocus here would race its own focus request. That sheet
     // owns the keyboard from the first frame, so the inset fight above never starts.
     val focus = LocalFocusManager.current
+    val dismissThresholdPx = with(LocalDensity.current) { 64.dp.toPx() }
+    var dragY by remember { mutableFloatStateOf(0f) }
     LaunchedEffect(dropKeyboard) { if (dropKeyboard) focus.clearFocus() }
     dev.ccpocket.app.SystemBackHandler(enabled = true) { onDismiss() } // Android back = scrim tap
     Box(Modifier.fillMaxSize()) {
         Box(Modifier.fillMaxSize().background(Color(0x94000000)).pointerInput(Unit) { detectTapGestures { onDismiss() } })
         Column(
             Modifier.align(Alignment.BottomCenter).fillMaxWidth()
+                .graphicsLayer { translationY = dragY }
                 .clip(RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp))
                 .background(Tok.raised)
                 .pointerInput(Unit) { detectTapGestures { } } // swallow taps so they don't dismiss via the scrim
@@ -128,7 +138,26 @@ fun PocketSheet(onDismiss: () -> Unit, dropKeyboard: Boolean = true, content: @C
                 .imePadding() // sheets render outside the app's ime-padded Box — never hide behind the keyboard
                 .padding(bottom = 10.dp),
         ) {
-            Box(Modifier.align(Alignment.CenterHorizontally).padding(vertical = 8.dp).size(width = 38.dp, height = 5.dp).clip(CircleShape).background(Tok.hair))
+            // The visible handle owns a full-width gesture target, so even a sheet that reaches nearly to
+            // the status bar can always be dismissed without competing with its scrollable content.
+            Box(
+                Modifier.fillMaxWidth().height(36.dp)
+                    .testTag(POCKET_SHEET_DRAG_HANDLE_TAG)
+                    .pointerInput(onDismiss, dismissThresholdPx) {
+                        detectVerticalDragGestures(
+                            onVerticalDrag = { _, delta -> dragY = (dragY + delta).coerceAtLeast(0f) },
+                            onDragEnd = {
+                                val dismiss = dragY >= dismissThresholdPx
+                                dragY = 0f
+                                if (dismiss) onDismiss()
+                            },
+                            onDragCancel = { dragY = 0f },
+                        )
+                    },
+                contentAlignment = Alignment.Center,
+            ) {
+                Box(Modifier.size(width = 38.dp, height = 5.dp).clip(CircleShape).background(Tok.hair))
+            }
             content()
         }
     }
@@ -165,14 +194,28 @@ fun ModeSheet(
                         Text(stringResource(Res.string.mode_switching), color = Tok.tx2, fontSize = 12.5.sp)
                     }
                 }
-                Column(
-                    Modifier.padding(top = 8.dp).alpha(if (switching) 0.55f else 1f),
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
-                    (MODES + if (agent == AgentKind.CLAUDE && autoAvailable) listOf(AUTO_MODE) else emptyList()).forEach { m ->
-                        ModeRow(m, selected = current == m.key && nativeMode == m.nativeMode, enabled = !switching) {
-                            if (m.key == PermissionMode.BYPASS_PERMISSIONS && current != PermissionMode.BYPASS_PERMISSIONS) confirmBypass = true
-                            else onSelect(m.key, m.nativeMode)
+                if (agent == AgentKind.CODEX) {
+                    Column(
+                        Modifier.padding(top = 8.dp).alpha(if (switching) 0.55f else 1f),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        CODEX_PRESETS.forEach { p ->
+                            PresetRow(p, selected = current == p.mode) {
+                                if (p.danger && current != PermissionMode.BYPASS_PERMISSIONS) confirmBypass = true
+                                else onSelect(p.mode, null)
+                            }
+                        }
+                    }
+                } else {
+                    Column(
+                        Modifier.padding(top = 8.dp).alpha(if (switching) 0.55f else 1f),
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        (MODES + if (agent == AgentKind.CLAUDE && autoAvailable) listOf(AUTO_MODE) else emptyList()).forEach { m ->
+                            ModeRow(m, selected = current == m.key && nativeMode == m.nativeMode, enabled = !switching) {
+                                if (m.key == PermissionMode.BYPASS_PERMISSIONS && current != PermissionMode.BYPASS_PERMISSIONS) confirmBypass = true
+                                else onSelect(m.key, m.nativeMode)
+                            }
                         }
                     }
                 }
@@ -334,6 +377,39 @@ fun MonoChip(text: String, c: Color = Tok.tx2) {
         modifier = Modifier.background(Tok.surface, RoundedCornerShape(6.dp))
             .border(1.dp, Tok.hair, RoundedCornerShape(6.dp)).padding(horizontal = 6.dp, vertical = 2.dp),
     )
+}
+
+/** One Codex preset row: a named approval/sandbox combination instead of Claude's mode vocabulary. */
+@Composable
+private fun PresetRow(p: CodexPreset, selected: Boolean, onClick: () -> Unit) {
+    val shape = RoundedCornerShape(12.dp)
+    val outline = if (p.danger) Tok.danger else if (selected) Tok.codex else Tok.hair
+    val fill = when {
+        !selected -> Tok.surface
+        p.danger -> Tok.danger.copy(alpha = 0.07f)
+        else -> Tok.codex.copy(alpha = 0.12f)
+    }
+    Column(
+        Modifier.fillMaxWidth().clip(shape).background(fill).border(1.5.dp, outline, shape)
+            .clickable(onClick = onClick).padding(12.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(stringResource(p.name), color = if (p.danger) Tok.danger else Tok.tx, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+            if (p.danger) Icon(Icons.Rounded.WarningAmber, null, tint = Tok.danger, modifier = Modifier.size(14.dp))
+            if (p.recommended) Text(
+                stringResource(Res.string.recommended_badge), color = Tok.codex, fontSize = 9.5.sp, fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.border(1.dp, Tok.codex.copy(alpha = 0.42f), RoundedCornerShape(999.dp)).padding(horizontal = 7.dp, vertical = 1.dp),
+            )
+            Spacer(Modifier.weight(1f))
+            if (selected) Icon(Icons.Rounded.Check, null, tint = if (p.danger) Tok.danger else Tok.codex, modifier = Modifier.size(15.dp))
+        }
+        Text(stringResource(p.desc), color = Tok.tx2, fontSize = 12.sp, modifier = Modifier.padding(top = 5.dp, bottom = 8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            val chipColor = if (p.danger) Tok.danger else Tok.tx2
+            MonoChip(stringResource(p.askChip), chipColor)
+            MonoChip(stringResource(p.fsChip), chipColor)
+        }
+    }
 }
 
 @Composable

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/SessionSheets.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/SessionSheets.kt
@@ -389,7 +389,9 @@ fun QuickActionsSheet(
                                 // more thing crowding the top bar for a setting touched a few times per session)
                                 ActionRow(
                                     stringResource(Res.string.label_mode),
-                                    value = stringResource(
+                                    value = if (repo.sessionAgent.value == AgentKind.CODEX) {
+                                        stringResource(sessionDefaultsLabel(AgentKind.CODEX, repo.mode.value))
+                                    } else stringResource(
                                         if (repo.permissionMode.value == CLAUDE_PERMISSION_MODE_AUTO) AUTO_MODE.short
                                         else MODE_BY[repo.mode.value]?.short ?: MODES[0].short,
                                     ),

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/approval/ApprovalUi.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/approval/ApprovalUi.kt
@@ -1,5 +1,6 @@
 package dev.ccpocket.app.ui.approval
 
+import dev.ccpocket.protocol.AgentKind
 import dev.ccpocket.app.ui.isShellTool
 import dev.ccpocket.protocol.PermissionAsk
 import dev.ccpocket.protocol.PermissionRiskUpdated
@@ -86,6 +87,8 @@ data class ApprovalUi(
     val timer: ApprovalTimer,
     /** The daemon's authoritative `AskWithdrawn(TIMED_OUT)`. The only remote path into the terminal state. */
     val timedOutSignal: Boolean,
+    /** Backend that produced this ask; used only for honest provider attribution in the header. */
+    val agent: AgentKind = AgentKind.CLAUDE,
 ) {
     /**
      * Whether the sheet shows its read-only terminal state.
@@ -113,6 +116,7 @@ fun approvalUi(
     queueProgress: Pair<Int, Int>? = null,
     handoffReview: Boolean = false,
     timedOutSignal: Boolean = false,
+    agent: AgentKind = AgentKind.CLAUDE,
 ): ApprovalUi {
     require(!ask.isQuestion) { "AskUserQuestion belongs in the conversation card, not Secure Approval" }
     val recordedShell = handoffReview && isShellTool(ask.tool)
@@ -159,5 +163,6 @@ fun approvalUi(
             ApprovalTimer.Countdown((ask.timeoutSec ?: LEGACY_TIMEOUT_SEC).coerceAtLeast(0))
         },
         timedOutSignal = timedOutSignal,
+        agent = agent,
     )
 }

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/approval/SecureApprovalSheet.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/approval/SecureApprovalSheet.kt
@@ -55,7 +55,7 @@ import dev.ccpocket.app.resources.ap_legacy_note
 import dev.ccpocket.app.resources.ap_project
 import dev.ccpocket.app.resources.ap_queue
 import dev.ccpocket.app.resources.ap_recorded_title
-import dev.ccpocket.app.resources.ap_required
+import dev.ccpocket.app.resources.agent_needs_permission
 import dev.ccpocket.app.resources.ap_waiting_sub
 import dev.ccpocket.app.resources.ap_waiting_title
 import dev.ccpocket.app.resources.diff_more_lines
@@ -65,6 +65,7 @@ import dev.ccpocket.app.theme.Tok
 import dev.ccpocket.app.theme.TypeRole
 import dev.ccpocket.app.ui.MarkdownText
 import dev.ccpocket.app.ui.RiskBadge
+import dev.ccpocket.app.ui.agentName
 import dev.ccpocket.app.ui.relativeTime
 import dev.ccpocket.app.ui.tilde
 import kotlinx.coroutines.delay
@@ -195,7 +196,7 @@ private fun ApprovalHeader(ui: ApprovalUi, seconds: Int, terminal: Boolean) {
             // a diamond for warning, a square for danger: the states differ by SHAPE, not only by hue
             Box(Modifier.size(8.dp).rotate(if (ui.ask.danger) 0f else 45f).background(accent))
             Text(
-                stringResource(Res.string.ap_required), color = accent,
+                stringResource(Res.string.agent_needs_permission, agentName(ui.agent)), color = accent,
                 style = TypeRole.action, modifier = Modifier.weight(1f),
             )
             // never a fabricated "1 of 1": the counter exists only while a burst really is queued

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/data/SessionCapabilitiesTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/data/SessionCapabilitiesTest.kt
@@ -710,4 +710,59 @@ class SessionCapabilitiesTest {
             scope.cancel()
         }
     }
+
+    @Test
+    fun session_live_authoritative_title_repairs_a_titleless_open() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val repo = repo(scope, mutableListOf())
+        try {
+            // Push/deep-link opens know only workdir + session id, so the header starts on its generic fallback.
+            repo.openSession("/tmp/project", "codex-session", title = null, agent = AgentKind.CODEX)
+            assertNull(repo.chatTitle.value)
+
+            repo.receiveForTest(
+                SessionLive(
+                    "c1",
+                    "/tmp/project",
+                    "codex-session",
+                    agent = AgentKind.CODEX,
+                    title = "codex 会话 cc pocket",
+                ),
+            )
+
+            assertEquals("codex 会话 cc pocket", repo.chatTitle.value)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun explicit_codex_row_overrides_stale_claude_session_cache() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val sent = mutableListOf<Frame>()
+        val repo = repo(scope, sent)
+        try {
+            // Simulate the bad value persisted by an older build after mis-opening this Codex id.
+            repo.receiveForTest(
+                SessionLive(
+                    "old-convo",
+                    "/tmp/project",
+                    "codex-session-agent-precedence",
+                    agent = AgentKind.CLAUDE,
+                ),
+            )
+            repo.backToBrowse() // keep the remembered row, but leave the old conversation before reopening it
+            sent.clear()
+
+            repo.openSession(
+                "/tmp/project",
+                "codex-session-agent-precedence",
+                agent = AgentKind.CODEX,
+            )
+
+            assertEquals(AgentKind.CODEX, sent.filterIsInstance<OpenSession>().single().agent)
+        } finally {
+            scope.cancel()
+        }
+    }
 }

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/DesktopUiTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/DesktopUiTest.kt
@@ -645,12 +645,12 @@ class DesktopUiTest {
         // option (issue #204), so the bare text is ambiguous — target the agent card explicitly
         onNodeWithTag("agent-card-CODEX").performScrollTo().performClick()
         waitForIdle()
-        assertPresent("GPT 5.1 Codex")
+        assertPresent("gpt-5.6-sol")
         assertTrue(!present("Fable"), "Codex must not show Claude model choices")
-        onAllNodes(hasText("GPT 5.1 Codex")).onFirst().performScrollTo().performClick()
+        onAllNodes(hasText("gpt-5.6-sol")).onFirst().performScrollTo().performClick()
         waitForIdle()
 
-        assertEquals("gpt-5.1-codex", model.defaultModelFor(AgentKind.CODEX))
+        assertEquals("gpt-5.6-sol", model.defaultModelFor(AgentKind.CODEX))
         assertEquals("opus", model.defaultModelFor(AgentKind.CLAUDE), "each agent keeps its own default")
     }
 

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/ui/DirListTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/ui/DirListTest.kt
@@ -131,4 +131,18 @@ class DirListTest {
     fun the_collapsed_default_is_closed_and_empty() {
         assertEquals(ProjectSearch(open = false, query = ""), ProjectSearch())
     }
+
+    @Test
+    fun project_action_sheet_prefers_live_agents_and_falls_back_to_history_agents() {
+        val liveCodex = d("/p/live").copy(
+            sessionAgents = listOf(AgentKind.CLAUDE, AgentKind.CODEX),
+            activeSessions = listOf(ActiveSession("codex-live", agent = AgentKind.CODEX)),
+        )
+        assertEquals(listOf(AgentKind.CODEX), projectActionAgents(liveCodex))
+
+        val historical = d("/p/history").copy(
+            sessionAgents = listOf(AgentKind.CODEX, AgentKind.CLAUDE, AgentKind.CODEX),
+        )
+        assertEquals(listOf(AgentKind.CLAUDE, AgentKind.CODEX), projectActionAgents(historical))
+    }
 }

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/ui/HandoffUiStateTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/ui/HandoffUiStateTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import dev.ccpocket.app.present
 import dev.ccpocket.app.resources.Res
+import dev.ccpocket.app.resources.agent_needs_permission
 import dev.ccpocket.app.resources.always_allow
 import dev.ccpocket.app.resources.cancel
 import dev.ccpocket.app.resources.co_both_ways
@@ -51,6 +52,7 @@ import dev.ccpocket.protocol.HandoffAccess
 import dev.ccpocket.protocol.HandoffKind
 import dev.ccpocket.protocol.SessionHandoff
 import dev.ccpocket.protocol.HandoffStatus
+import dev.ccpocket.protocol.AgentKind
 import dev.ccpocket.protocol.collaboratorFingerprint
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.compose.resources.getString
@@ -318,6 +320,25 @@ class HandoffUiStateTest {
         )
         approvalSheet(ask, handoffReview = true)
         assertTrue(present(str(Res.string.always_allow)), "only the command runner loses the standing rule")
+    }
+
+    @Test
+    fun permissionSheet_codexApprovalNamesCodexInsteadOfClaude() = runComposeUiTest {
+        mainClock.autoAdvance = false
+        val ask = dev.ccpocket.protocol.PermissionAsk(
+            askId = "codex-edit", convoId = "c1", tool = "Edit", title = "Edit file",
+            inputPreview = "src/App.kt", rule = "Edit", diff = "+ fixed",
+        )
+        setContent {
+            PocketTheme {
+                dev.ccpocket.app.ui.approval.SecureApprovalSheet(
+                    dev.ccpocket.app.ui.approval.approvalUi(ask, workdir = "/w", agent = AgentKind.CODEX),
+                    onDeny = {}, onAllowOnce = {},
+                )
+            }
+        }
+        assertTrue(present(str(Res.string.agent_needs_permission, "Codex")))
+        assertFalse(present(str(Res.string.agent_needs_permission, "Claude")))
     }
 
     // ── Frame 9: Mark reviewed is the one COMPLETED transition on the result card ──

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/ui/MobileNewSessionUiTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/ui/MobileNewSessionUiTest.kt
@@ -10,8 +10,11 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.swipe
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -129,6 +132,28 @@ class MobileNewSessionUiTest {
         waitForIdle()
         assertTrue(present(configureStart), "the defaults chip must open the full picker")
         assertNull(repo.convoId.value, "opening the picker must not start a session yet")
+    }
+
+    @Test
+    fun newSessionPickerDismissesByDraggingTheTopHandleDown() = runComposeUiTest {
+        val repo = composeSessionsScreen()
+        val chipLabel = runBlocking { getString(sessionDefaultsLabel(repo.defaultAgent.value, repo.defaultMode.value)) }
+        val pickerSubtitle = runBlocking { getString(Res.string.cfg_start) }
+        onAllNodes(hasText(chipLabel)).onFirst().performClick()
+        waitForIdle()
+        assertTrue(present(pickerSubtitle))
+
+        onNodeWithTag(POCKET_SHEET_DRAG_HANDLE_TAG).performTouchInput {
+            swipe(
+                start = center,
+                end = center.copy(y = center.y + 180f),
+                durationMillis = 350,
+            )
+        }
+        waitForIdle()
+
+        assertFalse(present(pickerSubtitle), "dragging the top handle down must dismiss the picker")
+        assertNull(repo.convoId.value, "dismissing the picker must not start a session")
     }
 
     @Test

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/ui/SwitchScrollLandingTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/ui/SwitchScrollLandingTest.kt
@@ -142,7 +142,10 @@ class SwitchScrollLandingTest {
         waitForIdle()
         repo.receiveForTest(live("c2", "/w/beta"))
         repo.receiveForTest(history("c2", "beta"))
-        waitForIdle()
+        // The landing is performed by a LaunchedEffect. Under the full 500+ test suite the Skiko scene
+        // can report idle just before that coroutine gets its frame; wait for the user-visible condition
+        // rather than treating one scheduler-idle edge as completion.
+        waitUntil(timeoutMillis = 3_000) { listState.firstVisibleItemIndex >= tail }
 
         assertTrue(
             listState.firstVisibleItemIndex >= tail,

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/ui/approval/SecureApprovalSheetUiTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/ui/approval/SecureApprovalSheetUiTest.kt
@@ -27,7 +27,7 @@ import dev.ccpocket.app.resources.ap_fail_closed
 import dev.ccpocket.app.resources.ap_authority_wait_title
 import dev.ccpocket.app.resources.ap_legacy_note
 import dev.ccpocket.app.resources.ap_more_options
-import dev.ccpocket.app.resources.ap_required
+import dev.ccpocket.app.resources.agent_needs_permission
 import dev.ccpocket.app.resources.ap_waiting_title
 import dev.ccpocket.app.resources.auto_denied_title
 import dev.ccpocket.app.resources.deny
@@ -98,7 +98,7 @@ class SecureApprovalSheetUiTest {
         onRoot().performTouchInput { click(Offset(4f, 4f)) }
         assertEquals(0, decisions, "a scrim tap must never answer for the user")
         assertEquals(0, dismissed, "…and must not close the sheet either")
-        assertPresent(str(Res.string.ap_required), substring = true)
+        assertPresent(str(Res.string.agent_needs_permission, "Claude"), substring = true)
 
         // positive control: the same harness DOES deliver a tap to a real decision, so the assertion
         // above is about the scrim swallowing it — not about clicks being inert in this test
@@ -119,7 +119,7 @@ class SecureApprovalSheetUiTest {
             }
         }
         // pinned header and pinned decisions both stay on screen; only the body scrolled
-        onAllNodes(hasText(str(Res.string.ap_required))).onFirst().assertIsDisplayed()
+        onAllNodes(hasText(str(Res.string.agent_needs_permission, "Claude"))).onFirst().assertIsDisplayed()
         onAllNodes(hasText(str(Res.string.deny))).onFirst().assertIsDisplayed()
         onAllNodes(hasText(str(Res.string.allow_once))).onFirst().assertIsDisplayed()
         onAllNodes(hasText(str(Res.string.allow_for_task))).onFirst().assertIsDisplayed()

--- a/protocol/src/commonMain/kotlin/dev/ccpocket/protocol/Messages.kt
+++ b/protocol/src/commonMain/kotlin/dev/ccpocket/protocol/Messages.kt
@@ -840,6 +840,8 @@ data class SessionLive(
     val permissionMode: String? = null,
     /** Backend-native service tier (Codex `"priority"` = Fast); null means account/default tier. */
     val serviceTier: String? = null,
+    /** Daemon-authoritative display title. Additive so older peers ignore it and older daemons decode as null. */
+    val title: String? = null,
 ) : ToPhone
 
 /** A streamed assistant content piece. seq is monotonic per convo for ordering. */

--- a/protocol/src/commonMain/kotlin/dev/ccpocket/protocol/Models.kt
+++ b/protocol/src/commonMain/kotlin/dev/ccpocket/protocol/Models.kt
@@ -80,8 +80,9 @@ val DAEMON_SUPPORTED_AGENT_WIRES = listOf(
     AGENT_WIRE_DSH,
 )
 
-/** Codex model ids the app exposes as first-class presets. */
-val CODEX_MODEL_IDS = listOf("gpt-5.1-codex", "gpt-5.1-codex-mini", "gpt-5-codex")
+/** Last-resort Codex presets when the daemon cannot read Codex's own model cache. The normal picker is
+ * populated dynamically; these current family ids only prevent an empty picker on a fresh/offline install. */
+val CODEX_MODEL_IDS = listOf("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna")
 
 /** Claude alias set — the ONE id family that is meaningless to the other backends. */
 val CLAUDE_MODEL_ALIAS_IDS = setOf("fable", "opus", "sonnet", "haiku")

--- a/protocol/src/commonTest/kotlin/dev/ccpocket/protocol/SerializationRoundTripTest.kt
+++ b/protocol/src/commonTest/kotlin/dev/ccpocket/protocol/SerializationRoundTripTest.kt
@@ -69,12 +69,15 @@ class SerializationRoundTripTest {
             "c1",
             "/x",
             "sid",
+            title = "Authoritative session title",
             mode = PermissionMode.DEFAULT,
             effort = "max",
             permissionMode = CLAUDE_PERMISSION_MODE_AUTO,
             serviceTier = "priority",
         )
-        assertEquals(live, PocketJson.decodeFromString<SessionLive>(PocketJson.encodeToString(live)))
+        val liveJson = PocketJson.encodeToString(live)
+        assertTrue("\"title\":\"Authoritative session title\"" in liveJson, liveJson)
+        assertEquals(live, PocketJson.decodeFromString<SessionLive>(liveJson))
 
         // Frames sent before #183 omit both native fields and continue to decode to null.
         val legacy = """{"workdir":"/x","mode":"default","effort":"high"}"""


### PR DESCRIPTION
## 变更概述

- 基于最新 upstream/main（v1.9.1）重新集成，保留 Kimi、ZCode、DSH、rewind/fork、新版安全审批等上游能力
- 补齐 Codex 活跃/历史会话发现、标题与模型恢复、原生 steer/compact/review/clear 能力
- 手机端以显式会话来源和 SessionLive 权威状态识别 Codex，修正标题、权限提示、模型、思考深度与执行模式交互
- 支持普通底部弹层从顶部拖拽条下滑关闭，并避免占位 Firebase 配置导致 iOS 启动崩溃
- 补充 daemon、protocol 与 mobile 回归测试

## 验证

- `bash scripts/check-all.sh`
- protocol + daemon + relay + mobile Desktop：全绿
- 定向覆盖 Codex 会话来源优先级、活跃外部会话、原生控制、审批智能体归属与弹层拖拽
- iOS 临时开发签名配置未提交

替代因 fork main 落后上游 207 个提交而产生冲突的 #296。