### PR TITLE
Codex 基础设施收敛：#300 单遍解析 / #301 契约下沉 / #302 Windows cwd / #303 Claude 对称

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,21 @@ jobs:
           name: test-reports
           path: '**/build/reports/tests/**'
           retention-days: 7
+
+  # issue #302: the Windows external-writer cwd probe (ProcessCwd's PEB walk) is a BLIND port — no
+  # Windows machine was available while writing it. This job runs the daemon's Windows-only tests on a
+  # real windows-latest runner so the PEB offsets self-verify (ProcessCwd.selfCheck reads THIS process's
+  # cwd and compares user.dir). A red here is the "user feedback" loop, mechanized: it means the blind
+  # offsets are wrong and the fallback must stay UNKNOWN. Non-blocking on the required `test` job.
+  windows-cwd-probe:
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+      - name: Daemon Windows cwd-probe self-check
+        run: ./gradlew --no-daemon :daemon:test --tests "*WinCwd*"

--- a/daemon/build.gradle.kts
+++ b/daemon/build.gradle.kts
@@ -24,6 +24,11 @@ tasks.processResources {
 dependencies {
     implementation(project(":protocol"))
 
+    // Windows-only external-process cwd read (issue #302). Already on the runtime classpath transitively
+    // via mordant; declared explicitly so it's visible at compile time. Pinned to the transitive version
+    // to avoid a second JNA on the classpath.
+    implementation("net.java.dev.jna:jna:5.14.0")
+
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.cryptography.core)          // E2ECrypto / E2ESession (protocol's e2e API)

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/agent/AgentBackend.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/agent/AgentBackend.kt
@@ -41,12 +41,26 @@ interface AgentBackend {
     /** Encode + write an interrupt for the in-flight turn; no-op if the process isn't ready. */
     suspend fun interrupt()
 
+    /** True routes /compact to [compact] as a control-plane op; false lets the slash token pass through
+     *  to the agent as an ordinary prompt (Claude's prompt-backed builtin). This is the ONE switch —
+     *  Conversation must not re-derive it from [kind] (issue #301: the kind-gate made the capability
+     *  unreachable for every future backend and its fallback replies dead code). */
+    val supportsNativeCompact: Boolean get() = false
+
+    /** /review counterpart of [supportsNativeCompact]. */
+    val supportsNativeReview: Boolean get() = false
+
     /** Compact the backend's native conversation context. True means the request was accepted (it may
      * complete asynchronously); false means this backend has no native compaction API. */
     suspend fun compact(): Boolean = false
 
     /** Start the backend's native code-review flow. Null/blank means review all uncommitted changes. */
     suspend fun review(instructions: String? = null): Boolean = false
+
+    /** Rewrite a slash prompt this backend's CLI wouldn't understand into something it does (Codex:
+     *  /simplify → an explicit task). Identity by default. Conversation applies it at the prompt
+     *  boundary so the transport layer ([sendPrompt]) stays string-matching-free (issue #301). */
+    fun expandSlashPrompt(text: String): String = text
 
     /** Ask the LIVE agent process to rename its session (issue #158) — Claude: a `rename_session`
      *  control_request; the CLI appends its own `custom-title` record and acks, so the daemon never
@@ -99,6 +113,28 @@ interface AgentBackend {
 
     /** The on-disk transcript directory for [workdir] (Claude: ~/.claude/projects/<key>; Codex: ~/.codex/sessions). */
     fun transcriptDir(workdir: String): Path
+
+    /**
+     * The durable transcript FILE for [sessionId], or null when this backend keeps no per-session file
+     * the daemon may read (SQLite stores, unverified formats). Non-null is the capability that admits a
+     * session to read-only observe, the external-writer safety checks, and stale-agent correction —
+     * SessionRegistry derives all three from THIS instead of naming kinds (issue #301). Implementations
+     * must treat [sessionId] as wire input: reject separators/dot-dot before building a path from it.
+     */
+    fun transcriptPath(workdir: String, sessionId: String): Path? = null
+
+    /**
+     * Probe whether a process OUTSIDE the daemon currently owns [transcript] (see LiveProcesses).
+     * UNKNOWN is the safe default: callers treat "can't tell" as "assume held" where a wrong ABSENT
+     * would mint a second writer. Backends with no external-CLI story never reach the gate anyway
+     * (their [transcriptPath] is null).
+     */
+    fun externalWriterProbe(workdir: String, transcript: Path): dev.ccpocket.daemon.disk.LiveProcesses.ExternalClaude =
+        dev.ccpocket.daemon.disk.LiveProcesses.ExternalClaude.UNKNOWN
+
+    /** True when this backend's CLI holds its transcript fd even while idle (Codex): the registry must
+     *  then run [externalWriterProbe] BEFORE any mtime-freshness shortcut — an idle holder's file is old. */
+    val holdsTranscriptWhileIdle: Boolean get() = false
 
     /** Resumable sessions for [workdir], newest first (reads transcript headers; no process launch). */
     fun listSessions(workdir: String): List<SessionSummary>

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/claude/ClaudeBackend.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/claude/ClaudeBackend.kt
@@ -224,6 +224,15 @@ class ClaudeBackend(
 
     override fun transcriptDir(workdir: String): Path = ProjectPaths.dirFor(workdir)
 
+    override fun transcriptPath(workdir: String, sessionId: String): Path? {
+        // sessionId is wire input interpolated into a filename — same guard as SessionFilesService
+        if (sessionId.contains('/') || sessionId.contains('\\') || sessionId.contains("..")) return null
+        return ProjectPaths.dirFor(workdir).resolve("$sessionId.jsonl")
+    }
+
+    override fun externalWriterProbe(workdir: String, transcript: Path) =
+        dev.ccpocket.daemon.disk.LiveProcesses.externalClaudeAt(workdir, transcript)
+
     override fun listSessions(workdir: String): List<SessionSummary> =
         TranscriptScanner.scan(ProjectPaths.dirFor(workdir)).map { it.copy(agent = AgentKind.CLAUDE) }
 
@@ -237,14 +246,20 @@ class ClaudeBackend(
     override fun replayPage(workdir: String, sessionId: String, beforeSeq: Long, limit: Int): dev.ccpocket.daemon.disk.ReplaySlice =
         TranscriptReplay.page(ProjectPaths.dirFor(workdir).resolve("$sessionId.jsonl"), beforeSeq, limit)
 
+    // All three resume seeds come from ONE memoized single-pass read (issue #303): Conversation.open
+    // calls them back-to-back, and resumeSeed's (path, mtime) memo turns what were three full-transcript
+    // parses into one. Field semantics are pinned equal to the old lastContextTokens/lastModel/summarize
+    // by ResumeSeedParityTest.
+    private fun seedFile(workdir: String, sessionId: String) = ProjectPaths.dirFor(workdir).resolve("$sessionId.jsonl")
+
     override fun resumeContextTokens(workdir: String, sessionId: String): Long? =
-        TranscriptScanner.lastContextTokens(ProjectPaths.dirFor(workdir).resolve("$sessionId.jsonl"))
+        TranscriptScanner.resumeSeed(seedFile(workdir, sessionId))?.contextTokens
 
     override fun resumeModel(workdir: String, sessionId: String): String? =
-        TranscriptScanner.lastModel(ProjectPaths.dirFor(workdir).resolve("$sessionId.jsonl"))
+        TranscriptScanner.resumeSeed(seedFile(workdir, sessionId))?.model
 
     override fun resumeTitle(workdir: String, sessionId: String): String? =
-        TranscriptScanner.summarize(ProjectPaths.dirFor(workdir).resolve("$sessionId.jsonl"))?.title
+        TranscriptScanner.resumeSeed(seedFile(workdir, sessionId))?.title
 
     // issue #96: read the configured default (settings.json `model` / $ANTHROPIC_MODEL) so a brand-new
     // session's header shows the real model before the first turn. configDir = the daemon's isolated

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/codex/CodexBackend.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/codex/CodexBackend.kt
@@ -91,6 +91,10 @@ class CodexBackend(
 
     override val kind: AgentKind = AgentKind.CODEX
 
+    // app-server exposes compaction and review as control-plane RPCs (thread/compact/start, review/start)
+    override val supportsNativeCompact: Boolean get() = true
+    override val supportsNativeReview: Boolean get() = true
+
     override fun processBuilder(spec: AgentSpec): ProcessBuilder = CodexLauncher.processBuilder(exe(), spec)
 
     /** Resolve the codex binary lazily — only a launch needs it, so listing/replay work even without codex installed. */
@@ -422,7 +426,7 @@ class CodexBackend(
     // ---- outbound (called by Conversation) ----
 
     override suspend fun sendPrompt(text: String, images: List<ImageData>) {
-        val promptText = codexPrompt(text)
+        val promptText = text // expansion happens at Conversation's prompt boundary (expandSlashPrompt)
         val ready = bootstrap.withLock {
             if (threadId == null) { pendingPrompt = Prompt(promptText, images); false } else true
         }
@@ -448,8 +452,9 @@ class CodexBackend(
     }
 
     /** `/simplify` is a Claude built-in skill, not an app-server method. Keep CC Pocket's action useful
-     * for Codex by expanding it into an explicit, stable task instead of sending an unknown slash token. */
-    private fun codexPrompt(text: String): String {
+     * for Codex by expanding it into an explicit, stable task instead of sending an unknown slash token.
+     * Applied by Conversation at the prompt boundary (issue #301) — one rewrite, ledgered as sent. */
+    override fun expandSlashPrompt(text: String): String {
         val trimmed = text.trim()
         if (trimmed.substringBefore(' ').substringBefore('\n') != "/simplify") return text
         val extra = trimmed.removePrefix("/simplify").trim()
@@ -590,6 +595,17 @@ class CodexBackend(
     // ---- disk: ~/.codex/sessions rollout scanning + replay (filtered by recorded cwd) ----
 
     override fun transcriptDir(workdir: String): Path = CodexPaths.sessionsRoot()
+
+    override fun transcriptPath(workdir: String, sessionId: String): Path? {
+        // findSession is a suffix match against real filenames, but keep the wire-input guard uniform
+        if (sessionId.contains('/') || sessionId.contains('\\') || sessionId.contains("..")) return null
+        return CodexPaths.findSession(sessionId)
+    }
+
+    override fun externalWriterProbe(workdir: String, transcript: Path) =
+        dev.ccpocket.daemon.disk.LiveProcesses.externalCodexAt(workdir, transcript)
+
+    override val holdsTranscriptWhileIdle: Boolean get() = true
     override fun listSessions(workdir: String): List<SessionSummary> = CodexTranscriptScanner.scan(workdir)
     override fun replayHistory(workdir: String, sessionId: String): List<HistoryMessage> =
         CodexPaths.findSession(sessionId)?.let { CodexTranscriptReplay.read(it) } ?: emptyList()

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/codex/CodexTranscriptScanner.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/codex/CodexTranscriptScanner.kt
@@ -42,9 +42,10 @@ object CodexTranscriptScanner {
 
     /**
      * The newest resumable Codex session for each externally-live cwd. Unlike [scan], this is called by
-     * the 10-second project-list refresh, so it walks the rollout tree ONCE and stops reading each matching
-     * file after the first real user prompt (messageCount is intentionally only a lower bound here). A
-     * full session list still uses [scan]; the active row only needs id/title/mtime/agent.
+     * the 10-second project-list refresh, so it walks the rollout tree ONCE, skips every file whose
+     * (memoized) cwd isn't wanted without opening it, and reads at most one file per requested cwd — a read
+     * the shared [scanCache] then hands to the observe/resume paths for free. A full session list still uses
+     * [scan]; the active row only needs id/title/mtime/agent.
      *
      * Returned keys preserve the caller's cwd spelling; matching itself uses [ProjectPaths.canonicalKey].
      *
@@ -66,47 +67,35 @@ object CodexTranscriptScanner {
         val titles = threadNames()
         for (file in files) {
             if (remaining.isEmpty()) break
-            val hit = runCatching { summarizeActive(file, remaining, titles) }.getOrNull() ?: continue
-            val requestedCwd = requested[hit.first] ?: continue
-            out[requestedCwd] = hit.second
-            remaining.remove(hit.first)
+            // Prefilter on the memoized first-line cwd (issue #300): the same 10-second refresh has just
+            // called [cwdsByNewest] over this very list, so every unchanged file's cwd is already in
+            // [cwdCache] — a stat, no open. Opening each of the N newer other-project rollouts that sit
+            // ahead of a live project's newest one, only to discard them on their first line, is what this
+            // costs otherwise, every tick, forever.
+            val key = cwdOf(file)?.let(ProjectPaths::canonicalKey) ?: continue
+            if (key !in remaining) continue
+            val summary = runCatching { summarizeActive(file, titles) }.getOrNull() ?: continue
+            val requestedCwd = requested[key] ?: continue
+            out[requestedCwd] = summary
+            remaining.remove(key)
         }
         return out
     }
 
-    /** Canonical cwd key + lightweight summary, or null when this rollout is not a requested live cwd.
-     *  Only the cwd decides that: a matching rollout with no real user turn yet still answers for its cwd,
-     *  with a blank title (the index title when Codex already named the thread) — see [activeSummaries]. */
-    private fun summarizeActive(
-        file: Path,
-        wantedKeys: Set<String>,
-        titles: Map<String, String>,
-    ): Pair<String, SessionSummary>? {
-        var id: String? = null
-        var cwd: String? = null
-        var version: String? = null
-        var firstPrompt: String? = null
-        file.bufferedReader().use { r ->
-            val meta = metaPayload(r) ?: return null
-            id = meta.str("id"); cwd = meta.str("cwd"); version = meta.str("cli_version")
-            val recorded = cwd ?: return null
-            val key = ProjectPaths.canonicalKey(recorded)
-            if (key !in wantedKeys) return null
-            var line = r.readLine()
-            while (line != null && firstPrompt == null) {
-                val obj = runCatching { json.parseToJsonElement(line.trim()) }.getOrNull() as? JsonObject
-                val p = obj?.takeIf { it.str("type") == "response_item" }?.obj("payload")
-                if (p != null && p.str("type") == "message" && p.str("role") == "user") {
-                    codexMessageText(p)?.takeIf { !isSyntheticUserText(it) }?.let { firstPrompt = it }
-                }
-                line = r.readLine()
-            }
-        }
-        val sid = id ?: return null
-        val recorded = cwd ?: return null
-        val fp = firstPrompt
-        val mtime = file.getLastModifiedTime().toMillis()
-        return ProjectPaths.canonicalKey(recorded) to SessionSummary(
+    /** Lightweight summary of a rollout already known (by [activeSummaries]' cwd prefilter) to belong to a
+     *  requested live cwd, or null when it has no usable `session_meta`. A matching rollout with no real user
+     *  turn yet still answers for its cwd, with a blank title (the index title when Codex already named the
+     *  thread) — see [activeSummaries]. The read itself goes through the shared [scanCache], so the observe
+     *  tick and this refresh pay for at most one parse of the file per mtime between them. */
+    private fun summarizeActive(file: Path, titles: Map<String, String>): SessionSummary? {
+        val stamp = stampOf(file)
+        val parsed = scanned(file, stamp, workdir = null)?.parsed ?: return null
+        val sid = parsed.id ?: return null
+        val recorded = parsed.cwd ?: return null
+        val fp = parsed.firstPrompt
+        val version = parsed.version
+        val mtime = stamp?.toMillis() ?: file.getLastModifiedTime().toMillis()
+        return SessionSummary(
             sessionId = sid,
             // Blank rather than the session UUID when there is no prompt AND no index title: the phone
             // renders its generic session label for a blank title, while a raw UUID would be shown as-is.
@@ -114,7 +103,7 @@ object CodexTranscriptScanner {
                 ?: fp?.let { it.lineSequence().firstOrNull { l -> l.isNotBlank() }?.trim()?.take(60) ?: sid }
                 ?: "",
             firstPrompt = fp ?: "",
-            messageCount = if (fp != null) 1 else 0,
+            messageCount = parsed.userCount,
             cwd = recorded,
             lastModified = mtime,
             version = version,
@@ -164,13 +153,18 @@ object CodexTranscriptScanner {
         val out = HashMap<String, Long>()
         for (file in files) {
             val mtime = runCatching { file.getLastModifiedTime().toMillis() }.getOrDefault(0L)
-            val cached = cwdCache[file]
-            val cwd = if (cached != null && cached.first == mtime) cached.second else {
-                runCatching { readCwd(file) }.getOrNull().also { cwdCache[file] = mtime to it }
-            }
+            val cwd = cwdOf(file, mtime)
             if (cwd != null) out.merge(cwd, mtime, ::maxOf)
         }
         return out
+    }
+
+    /** The rollout's recorded cwd, memoized by (path, mtime) — a first-line read at most once per version of
+     *  the file. Shared by [cwdsByNewest] and [activeSummaries]' prefilter, which run back-to-back on the
+     *  same file list every 10 seconds, so the second of them pays a stat and nothing more. */
+    private fun cwdOf(file: Path, mtime: Long = runCatching { file.getLastModifiedTime().toMillis() }.getOrDefault(0L)): String? {
+        cwdCache[file]?.let { if (it.first == mtime) return it.second }
+        return runCatching { readCwd(file) }.getOrNull().also { cwdCache[file] = mtime to it }
     }
 
     private fun readCwd(file: Path): String? = file.bufferedReader().use { metaPayload(it)?.str("cwd") }
@@ -178,7 +172,7 @@ object CodexTranscriptScanner {
     /**
      * A bounded LRU keyed by file path and stamped with that file's mtime. Rollouts are append-only, so a
      * moved mtime is the ONLY way a parse of one can go stale — the same reasoning [cwdCache] already used,
-     * generalized here for the two full-file parses below.
+     * generalized here for the full-file parse below.
      *
      * The stamp is the raw [java.nio.file.attribute.FileTime] rather than millis: nanosecond precision where
      * the filesystem has it makes a same-millisecond rewrite visible instead of silently cached.
@@ -204,25 +198,18 @@ object CodexTranscriptScanner {
     private fun stampOf(file: Path): java.nio.file.attribute.FileTime? =
         runCatching { file.getLastModifiedTime() }.getOrNull()
 
-    private val runtimeCache = MtimeMemo<RuntimeState>(MEMO_MAX)
-
     /** Read the newest Codex model and token metadata from a rollout. Model settings are written in
      * `turn_context`; token counts are `event_msg/token_count`. Older rollouts simply return null fields.
      *
-     * Memoized by (path, mtime): a Codex session open asks for this twice (resumeContextTokens +
-     * resumeModel) and an observe tick asks again, each time re-parsing a file that can reach megabytes. */
+     * Served by the same (path, mtime) memo as [summarize] — one read answers both (issue #300). A Codex
+     * session open asks three accessors (title, model, contextTokens) about the same megabyte-sized file,
+     * and every observe tick asks again; before the merge, the summary pass computed this state line by
+     * line and then threw everything but the model away, so each open cost two full parses. */
     fun runtimeState(file: Path): RuntimeState {
         val stamp = stampOf(file)
-        runtimeCache.get(file, stamp)?.let { return it }
-        var state = RuntimeState()
-        file.bufferedReader().useLines { lines ->
-            for (raw in lines) {
-                val obj = runCatching { json.parseToJsonElement(raw.trim()) }.getOrNull() as? JsonObject ?: continue
-                state = mergeRuntimeState(state, obj)
-            }
-        }
-        runtimeCache.put(file, stamp, state)
-        return state
+        // No workdir filter and no session_meta requirement: a header-less rollout has no summary, but its
+        // turn_context/token_count lines are still the truth about the model and context in use.
+        return scanned(file, stamp, workdir = null, requireMeta = false)?.runtime ?: RuntimeState()
     }
 
     private fun mergeRuntimeState(current: RuntimeState, obj: JsonObject): RuntimeState {
@@ -261,30 +248,58 @@ object CodexTranscriptScanner {
         val version: String?,
         val firstPrompt: String?,
         val userCount: Int,
-        val model: String?,
     )
 
-    private val parseCache = MtimeMemo<Parsed>(MEMO_MAX)
+    /** Everything ONE read of a rollout yields: the summary material ([parsed], null when the file has no
+     *  `session_meta` header) and the runtime settings that were being merged line by line anyway. Keeping
+     *  them together is the whole of issue #300: the summary path and the model/context path used to be two
+     *  separate full parses of the same bytes, always requested within the same session open or tick. */
+    private data class Scanned(val parsed: Parsed?, val runtime: RuntimeState)
 
-    /** Full-file parse behind [summarize], keeping its cheap first-line cwd filter: a rollout for another
-     *  project must still cost one line, not a whole read (a session listing runs this over ~800 files).
-     *  Returns null for those, and for a file without a session_meta header — neither is worth caching. */
-    private fun parseRollout(file: Path, workdir: String?): Parsed? {
+    private val scanCache = MtimeMemo<Scanned>(MEMO_MAX)
+
+    /** Cached [scanRollout]. Null (and nothing cached) only for the early exits that never read the body. */
+    private fun scanned(
+        file: Path,
+        stamp: java.nio.file.attribute.FileTime?,
+        workdir: String?,
+        requireMeta: Boolean = true,
+    ): Scanned? = scanCache.get(file, stamp)
+        ?: scanRollout(file, workdir, requireMeta)?.also { scanCache.put(file, stamp, it) }
+
+    /** The single full read of a rollout, keeping the cheap first-line filters it always had: a rollout for
+     *  another project (or, when [requireMeta], one with no session_meta header) must still cost one line,
+     *  not a whole read — a session listing runs this over ~800 files. Returns null for those, uncached:
+     *  what a one-line read decided must not be remembered as if the body had been seen. */
+    private fun scanRollout(file: Path, workdir: String?, requireMeta: Boolean): Scanned? {
         var id: String? = null
         var cwd: String? = null
         var version: String? = null
         var firstPrompt: String? = null
         var userCount = 0
+        var hasMeta = false
         var runtime = RuntimeState()
         file.bufferedReader().use { r ->
-            val meta = metaPayload(r) ?: return null
-            id = meta.str("id"); cwd = meta.str("cwd"); version = meta.str("cli_version")
-            // Canonical-key compare (slashes / trailing sep / Windows case / symlinks / tilde): codex records
-            // the cwd its own way, and an exact string compare silently dropped sessions on Windows (issue
-            // #19's sibling). Since #184 merges spelling variants into ONE project row, the row's realpath'd
-            // workdir must still match a variant-spelled rollout — same key DirectoryService merges by.
-            val recorded = cwd
-            if (workdir != null && (recorded == null || ProjectPaths.canonicalKey(recorded) != ProjectPaths.canonicalKey(workdir))) return null
+            val first = r.readLine()
+            val firstObj = first?.let { runCatching { json.parseToJsonElement(it.trim()) }.getOrNull() as? JsonObject }
+            val meta = firstObj?.takeIf { it.str("type") == "session_meta" }?.obj("payload")
+            if (meta == null) {
+                // No header: nothing to summarize and no cwd to match, so a caller that needs either stops
+                // here. [runtimeState] needs neither and reads on — including this very first line.
+                if (requireMeta || workdir != null) return null
+            } else {
+                hasMeta = true
+                id = meta.str("id"); cwd = meta.str("cwd"); version = meta.str("cli_version")
+                // Canonical-key compare (slashes / trailing sep / Windows case / symlinks / tilde): codex records
+                // the cwd its own way, and an exact string compare silently dropped sessions on Windows (issue
+                // #19's sibling). Since #184 merges spelling variants into ONE project row, the row's realpath'd
+                // workdir must still match a variant-spelled rollout — same key DirectoryService merges by.
+                val recorded = cwd
+                if (workdir != null && (recorded == null || ProjectPaths.canonicalKey(recorded) != ProjectPaths.canonicalKey(workdir))) return null
+            }
+            // The first line is merged like any other — the runtime pass this replaced merged every line,
+            // and only a line's own `type` decides whether it carries settings. Header or not, same rule.
+            if (firstObj != null) runtime = mergeRuntimeState(runtime, firstObj)
             var line = r.readLine()
             while (line != null) {
                 val obj = runCatching { json.parseToJsonElement(line.trim()) }.getOrNull() as? JsonObject
@@ -302,16 +317,18 @@ object CodexTranscriptScanner {
                 line = r.readLine()
             }
         }
-        return Parsed(id, cwd, version, firstPrompt, userCount, runtime.model)
+        return Scanned(
+            parsed = if (hasMeta) Parsed(id, cwd, version, firstPrompt, userCount) else null,
+            runtime = runtime,
+        )
     }
 
     /** Returns null if [file] isn't a rollout for [workdir] (cheap first-line cwd filter) or has no real turn.
      *  [titles] (id → Codex thread title) supplies the session name; a listing passes one shared map. */
     fun summarize(file: Path, workdir: String?, titles: Map<String, String> = threadNames()): SessionSummary? {
         val stamp = stampOf(file)
-        val parsed = parseCache.get(file, stamp)
-            ?: parseRollout(file, workdir)?.also { parseCache.put(file, stamp, it) }
-            ?: return null
+        val scan = scanned(file, stamp, workdir) ?: return null
+        val parsed = scan.parsed ?: return null
         // A cached parse still re-checks the caller's workdir: the memo is keyed by the FILE, and the same
         // rollout is summarized by both a project-scoped listing and the observe/resume paths.
         val recorded = parsed.cwd
@@ -337,14 +354,13 @@ object CodexTranscriptScanner {
             version = version,
             live = System.currentTimeMillis() - mtime < LIVE_WINDOW_MS,
             agent = AgentKind.CODEX,
-            model = parsed.model,
+            model = scan.runtime.model,
         )
     }
 
     /** Cross-test isolation: every memo here is process-wide state on an object singleton. */
     internal fun clearForTest() {
-        parseCache.clear()
-        runtimeCache.clear()
+        scanCache.clear()
         cwdCache.clear()
         titleCache.set(null)
     }

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/Conversation.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/Conversation.kt
@@ -2171,6 +2171,11 @@ class Conversation(
         if (sessionTitle == null && text.isNotBlank()) {
             sessionTitle = text.lineSequence().firstOrNull { it.isNotBlank() }?.trim()?.take(60)
         }
+        // Backend-specific slash rewriting (Codex /simplify → an explicit task): applied HERE, after the
+        // title seed (which should keep the user's own words) and before the ledger — so what we record
+        // is exactly what a redelivery re-sends, and the transport layer (sendPrompt/steer) stays free of
+        // prompt string-matching (issue #301).
+        val outgoing = backend.expandSlashPrompt(text)
         // approval design M2 §5.4 / §18.1 P1-4: EVERY top-level user prompt begins a new task — the
         // previous task's grants die right here, whether or not the CLI folds the message into a running
         // turn. A new instruction never inherits an old authorization; task identity is decoupled from
@@ -2214,7 +2219,7 @@ class Conversation(
         // send arms it here, where no new pump can race it.
         // the launch's own prompt, LEDGERED inside launchProcess before its pump starts (issue #122
         // record-vs-replay race); the queued-send branch below records it inline instead (no new pump).
-        val initialSend = InitialSend(promptId, text, images, bridgeGrantToken)
+        val initialSend = InitialSend(promptId, outgoing, images, bridgeGrantToken)
         if (relaunching) {
             reemitLive = true // the post-relaunch init re-announces SessionLive with the fresh sessionId + model
             val relaunched = runCatching { relaunch(sessionId ?: openedResumeId, armExecuting = true, initialSend = initialSend) }
@@ -2244,7 +2249,7 @@ class Conversation(
                     AgentSpec(
                         workdir, anchor, model, mode, effort = effort,
                         permissionMode = permissionMode, serviceTier = serviceTier,
-                        forkSession = fork, initialPrompt = text,
+                        forkSession = fork, initialPrompt = outgoing,
                     ),
                     armExecuting = true,
                     initialSend = initialSend,
@@ -2264,18 +2269,18 @@ class Conversation(
             // into the next spawn (one prompt per process). recordPromptWritten stamps the CURRENT
             // generation, so a client resend while this turn runs is a plain re-ack (#122 ④: an entry
             // owned by the live process is queued, not lost).
-            recordPromptWritten(promptId, text, images, bridgeGrantToken, queuedWork = true)
+            recordPromptWritten(promptId, outgoing, images, bridgeGrantToken, queuedWork = true)
         } else {
             // queued send onto the already-live process (mid-turn queue, or a steady-state next turn):
             // no new pump is starting, so there is no death-branch to race. Ledger FIRST, then arm the turn:
             // if the old turn's result races this enqueue, either executing or pendingPromptWork remains true.
             // The write comes only after both, and only the CLI's consumption replay settles the ledger.
-            recordPromptWritten(promptId, text, images, bridgeGrantToken, inferQueuedWork = true)
+            recordPromptWritten(promptId, outgoing, images, bridgeGrantToken, inferQueuedWork = true)
             markExecuting() // cleared by TurnResult (also covers cancelTurn — the agent still emits a result)
         }
         lastActivityMs = System.currentTimeMillis()
         lockForkRetried = false // each user prompt re-arms one heal
-        backend.sendPrompt(text, images)
+        backend.sendPrompt(outgoing, images)
         promptId?.let {
             sink.emit(PromptAck(convoId, it)) // the turn is in the agent's hands — receipt (issue #66)
             // (issue #104) an ack is NOT a started turn. If the client later reports turnStalled for this prompt,
@@ -2295,8 +2300,10 @@ class Conversation(
         val handler: suspend () -> Unit = when (trimmed.substringBefore(' ').substringBefore('\n')) {
             "/model" -> ({ handleModelCommand(trimmed) })
             "/effort" -> ({ handleEffortCommand(trimmed) })
-            "/compact" -> if (backend.kind == AgentKind.CODEX) ({ handleCodexCompactCommand() }) else return false
-            "/review" -> if (backend.kind == AgentKind.CODEX) ({ handleCodexReviewCommand(trimmed) }) else return false
+            // capability-routed, not kind-gated (issue #301): a backend that answers false keeps today's
+            // passthrough (Claude's /compact is a prompt-backed builtin the CLI itself runs)
+            "/compact" -> if (backend.supportsNativeCompact) ({ handleNativeCompactCommand() }) else return false
+            "/review" -> if (backend.supportsNativeReview) ({ handleNativeReviewCommand(trimmed) }) else return false
             "/clear" -> ({ handleClearCommand() })
             else -> return false
         }
@@ -2309,10 +2316,16 @@ class Conversation(
 
     /** Codex exposes compaction as app-server control-plane RPC, not a slash prompt. The process must be
      * ready because compact applies to its opened thread; a cold resume is launched without creating a turn. */
-    private suspend fun handleCodexCompactCommand() {
+    /**
+     * Shared guard + cold start for a control-plane op (/compact, /review): the op applies to the
+     * backend's OPEN conversation, so a cold session is launched first — without creating a turn.
+     * One copy on purpose (issue #301: this block existed three times and the anchor/fork subtleties
+     * below must never drift apart). Returns false when the op cannot proceed (already replied).
+     */
+    private suspend fun ensureProcessForControlOp(opLabel: String): Boolean {
         if (isExecuting()) {
-            reply("Wait for the current Codex turn to finish before compacting context.")
-            return
+            reply("Wait for the current turn to finish before $opLabel.")
+            return false
         }
         if (proc == null) {
             val anchor = sessionId ?: openedResumeId
@@ -2326,40 +2339,26 @@ class Conversation(
                 )
             }
             if (launched.isFailure) {
-                reply("Could not start Codex to compact this session: ${launched.exceptionOrNull()?.message ?: "unknown error"}")
-                return
+                reply("Could not start the agent for $opLabel: ${launched.exceptionOrNull()?.message ?: "unknown error"}")
+                return false
             }
         }
-        // CodexBackend queues this across an in-flight thread resume/fork handshake, so a cold session's
-        // first Compact tap still becomes exactly one native thread/compact/start request.
-        if (!backend.compact()) reply("This Codex version does not expose native context compaction.")
+        return true
     }
 
-    /** Codex code review is another app-server control-plane operation. `/review` defaults to all working
-     * tree changes; text after the command becomes the native custom review target. */
-    private suspend fun handleCodexReviewCommand(text: String) {
-        if (isExecuting()) {
-            reply("Wait for the current Codex turn to finish before starting a review.")
-            return
-        }
-        if (proc == null) {
-            val anchor = sessionId ?: openedResumeId
-            val fork = if (sessionId == null) openedWithFork else false
-            val launched = runCatching {
-                launchProcess(
-                    AgentSpec(
-                        workdir, anchor, model, mode, effort = effort,
-                        permissionMode = permissionMode, serviceTier = serviceTier, forkSession = fork,
-                    ),
-                )
-            }
-            if (launched.isFailure) {
-                reply("Could not start Codex review: ${launched.exceptionOrNull()?.message ?: "unknown error"}")
-                return
-            }
-        }
+    private suspend fun handleNativeCompactCommand() {
+        if (!ensureProcessForControlOp("compacting context")) return
+        // the backend queues this across an in-flight open handshake, so a cold session's first Compact
+        // tap still becomes exactly one native request; a rejection surfaces via its error path
+        backend.compact()
+    }
+
+    /** Native code review. `/review` defaults to all working tree changes; trailing text becomes the
+     * custom review target. */
+    private suspend fun handleNativeReviewCommand(text: String) {
+        if (!ensureProcessForControlOp("starting a review")) return
         val instructions = text.removePrefix("/review").trim().takeIf { it.isNotEmpty() }
-        if (!backend.review(instructions)) reply("This Codex version does not expose native code review.")
+        backend.review(instructions)
     }
 
     /** Handle the phone's `/model [name]` — the agent `-p` ignores it, so the daemon honors it. */

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/ObserveSession.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/ObserveSession.kt
@@ -44,6 +44,11 @@ class ObserveSession(
     // the appended delta instead of re-sending the whole 100-row window on every write (issue #147)
     private var sentCursor: Long? = sinceSeq?.takeIf { it > 0 }
 
+    // ONE dispatch point (issue #301): slice/page/state/title all route through the reader picked here,
+    // instead of four separately-maintained `when (agent)` blocks that had to stay consistent by hand.
+    // A future observable backend adds one Reader implementation and one factory arm.
+    private val reader: Reader = Reader.forAgent(agent)
+
     fun start() {
         scope.launch {
             runCatching {
@@ -53,10 +58,7 @@ class ObserveSession(
                     if (mtime != lastMtime) {
                         lastMtime = mtime
                         emitLive() // model/window/occupancy move as the observed terminal writes turns
-                        val slice = when (agent) {
-                            AgentKind.CODEX -> CodexTranscriptReplay.slice(file, sinceSeq = sentCursor)
-                            else -> TranscriptReplay.slice(file, sinceSeq = sentCursor)
-                        }
+                        val slice = reader.slice(file, sentCursor)
                         // an empty DELTA = the client is already caught up (noise-only appends) — nothing
                         // to send. An empty FULL still goes out: that's today's "file gone/empty" wipe.
                         if (slice.messages.isNotEmpty() || !slice.delta) {
@@ -80,10 +82,7 @@ class ObserveSession(
 
     /** Older-history page for an observed session (issue #147) — same shape as Conversation's. */
     suspend fun fetchHistoryPage(beforeSeq: Long, limit: Int, to: OutboundSink) {
-        val slice = when (agent) {
-            AgentKind.CODEX -> CodexTranscriptReplay.page(file, beforeSeq, limit.coerceIn(1, 200))
-            else -> TranscriptReplay.page(file, beforeSeq, limit.coerceIn(1, 200))
-        }
+        val slice = reader.page(file, beforeSeq, limit.coerceIn(1, 200))
         to.emit(dev.ccpocket.protocol.ConvoHistoryPage(convoId, slice.messages, firstSeq = slice.firstSeq, hasMore = slice.hasMore))
     }
 
@@ -91,18 +90,14 @@ class ObserveSession(
      *  model, its usage as occupancy, and the window derived the same way live sessions derive it —
      *  including the observed-usage upgrade for beta-gated 1M models (occupancy > 200k proves 1M). */
     private suspend fun emitLive() {
-        val codex = if (agent == AgentKind.CODEX) runCatching { CodexTranscriptScanner.runtimeState(file) }.getOrNull() else null
+        val state = reader.state(file)
         val title = titleFor(runCatching { file.getLastModifiedTime().toMillis() }.getOrDefault(-1L))
-        val model = codex?.model
-            ?: if (agent == AgentKind.CLAUDE) runCatching { TranscriptScanner.lastModel(file) }.getOrNull() else null
-        val used = codex?.contextUsed
-            ?: if (agent == AgentKind.CLAUDE) runCatching { TranscriptScanner.lastContextTokens(file) }.getOrNull() else null
-        val declaredWindow = codex?.contextWindow ?: model?.let(::contextWindowFor)
-        val window = dev.ccpocket.protocol.provenWindow(declaredWindow, used)
+        val declaredWindow = state.contextWindow ?: state.model?.let(::contextWindowFor)
+        val window = dev.ccpocket.protocol.provenWindow(declaredWindow, state.contextUsed)
         sink.emit(
             SessionLive(
                 convoId, workdir, sessionId, observing = true,
-                model = model, contextWindow = window, contextUsed = used, agent = agent, title = title,
+                model = state.model, contextWindow = window, contextUsed = state.contextUsed, agent = agent, title = title,
             ),
         )
     }
@@ -111,21 +106,64 @@ class ObserveSession(
      * The observed transcript's title, memoized by the file's mtime (PR #296 review). Deriving it re-reads
      * the transcript — a Codex thread with no index title falls all the way back to a full `summarize` — and
      * an announce for an unchanged file must not pay for that twice. Confined to this instance and to the
-     * single tail coroutine, so no locking: the Claude branch's shared [TranscriptScanner] is deliberately
-     * left alone (far wider blast radius than one observer's title).
+     * single tail coroutine, so no locking.
      */
     private var titleMemo: Pair<Long, String?>? = null
 
     private fun titleFor(mtime: Long): String? {
         titleMemo?.let { if (it.first == mtime) return it.second }
-        val title = when (agent) {
-            AgentKind.CODEX -> CodexTranscriptScanner.threadNames()[sessionId]?.takeIf { it.isNotBlank() }
-                ?: runCatching { CodexTranscriptScanner.summarize(file, workdir)?.title }.getOrNull()
-            AgentKind.CLAUDE -> runCatching { TranscriptScanner.summarize(file)?.title }.getOrNull()
-            else -> null // OpenCode/Kimi/ZCode/DSH sessions are never opened through ObserveSession.
-        }
+        val title = reader.title(file, workdir, sessionId)
         titleMemo = mtime to title
         return title
+    }
+
+    /** What one observable backend knows how to read off its transcript file. */
+    internal data class ObservedState(val model: String?, val contextUsed: Long?, val contextWindow: Long?)
+
+    internal interface Reader {
+        fun slice(file: Path, sinceSeq: Long?): dev.ccpocket.daemon.disk.ReplaySlice
+        fun page(file: Path, beforeSeq: Long, limit: Int): dev.ccpocket.daemon.disk.ReplaySlice
+        fun state(file: Path): ObservedState
+        fun title(file: Path, workdir: String, sessionId: String): String?
+
+        companion object {
+            fun forAgent(agent: AgentKind): Reader = when (agent) {
+                AgentKind.CODEX -> CodexReader
+                AgentKind.CLAUDE -> ClaudeReader
+                else -> InertReader // no per-session file → never admitted to observe (SessionRegistry)
+            }
+        }
+    }
+
+    private object CodexReader : Reader {
+        override fun slice(file: Path, sinceSeq: Long?) = CodexTranscriptReplay.slice(file, sinceSeq = sinceSeq)
+        override fun page(file: Path, beforeSeq: Long, limit: Int) = CodexTranscriptReplay.page(file, beforeSeq, limit)
+        override fun state(file: Path): ObservedState {
+            val rt = runCatching { CodexTranscriptScanner.runtimeState(file) }.getOrNull()
+            return ObservedState(rt?.model, rt?.contextUsed, rt?.contextWindow)
+        }
+        override fun title(file: Path, workdir: String, sessionId: String): String? =
+            CodexTranscriptScanner.threadNames()[sessionId]?.takeIf { it.isNotBlank() }
+                ?: runCatching { CodexTranscriptScanner.summarize(file, workdir)?.title }.getOrNull()
+    }
+
+    private object ClaudeReader : Reader {
+        override fun slice(file: Path, sinceSeq: Long?) = TranscriptReplay.slice(file, sinceSeq = sinceSeq)
+        override fun page(file: Path, beforeSeq: Long, limit: Int) = TranscriptReplay.page(file, beforeSeq, limit)
+        override fun state(file: Path) = ObservedState(
+            model = runCatching { TranscriptScanner.lastModel(file) }.getOrNull(),
+            contextUsed = runCatching { TranscriptScanner.lastContextTokens(file) }.getOrNull(),
+            contextWindow = null, // derived from the model by the caller
+        )
+        override fun title(file: Path, workdir: String, sessionId: String): String? =
+            runCatching { TranscriptScanner.summarize(file)?.title }.getOrNull()
+    }
+
+    private object InertReader : Reader {
+        override fun slice(file: Path, sinceSeq: Long?) = dev.ccpocket.daemon.disk.ReplaySlice.EMPTY
+        override fun page(file: Path, beforeSeq: Long, limit: Int) = dev.ccpocket.daemon.disk.ReplaySlice.EMPTY
+        override fun state(file: Path) = ObservedState(null, null, null)
+        override fun title(file: Path, workdir: String, sessionId: String): String? = null
     }
 
     /** True while this observer still streams to [s] — key identity, like Conversation.isAttachedTo:

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/disk/LiveProcesses.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/disk/LiveProcesses.kt
@@ -10,23 +10,31 @@ import java.util.concurrent.TimeUnit
  * whenever a claude is actually running in it, not only while it streams.
  */
 object LiveProcesses {
-    fun claudeCwds(): Set<String> {
-        val pids = runCatching {
-            ProcessHandle.allProcesses()
-                .filter { it.info().command().orElse("").contains("/claude") } // .../bin/claude or .../share/claude/versions/<v>
-                .map { it.pid().toString() }
-                .toList()
-        }.getOrDefault(emptyList())
-        if (pids.isEmpty()) return emptySet()
-        return runCatching {
-            val proc = ProcessBuilder("lsof", "-a", "-d", "cwd", "-p", pids.joinToString(","), "-Fn")
-                .redirectErrorStream(true).start()
-            val cwds = proc.inputStream.bufferedReader().readLines()
-                .filter { it.startsWith("n") }.map { it.substring(1) }.toSet()
-            proc.waitFor(3, TimeUnit.SECONDS)
-            cwds
-        }.getOrDefault(emptySet())
-    }
+    /**
+     * Memoized for [CWD_TTL_MS] like [codexCwds], and for the same reason: the ~10s project refresh paid a
+     * full process enumeration plus an lsof fork every tick.
+     *
+     * Unlike Codex's, this set does NOT exclude the daemon's own claude children — a daemon-owned session's
+     * project is live too, and [SessionRegistry.liveByCwd] is merged on top rather than substituted here.
+     * That is pre-existing behavior, kept deliberately (see [externalPids]'s `excludeDaemonDescendants`).
+     *
+     * Its second consumer, GitService's worktree-in-use guard, tolerates the TTL: the worktree list the user
+     * confirms against is itself a refresh old, and a daemon-owned agent still arrives fresh via liveByCwd.
+     */
+    fun claudeCwds(): Set<String> = claudeCwdMemo.get(System.currentTimeMillis(), ::claudePids, ::claudeCwdsOf)
+
+    /** [claudeCwds]'s memo, with its clock and both probes injected so the TTL is testable. */
+    internal fun claudeCwds(nowMs: Long, pids: () -> Set<Long>, cwdsOf: (Set<Long>) -> Set<String>): Set<String> =
+        claudeCwdMemo.get(nowMs, pids, cwdsOf)
+
+    /** Every `claude` pid, daemon-owned ones INCLUDED — see [claudeCwds]. The substring match (rather than
+     *  [isClaudeCommand]'s separator-agnostic form) is the historical one and stays: on Windows there is no
+     *  lsof, so a wider pid match could not change the answer, only the work done to reach the same empty set. */
+    private fun claudePids(): Set<Long> =
+        externalPids(excludeDaemonDescendants = false) { it.contains("/claude") } // .../bin/claude or .../share/claude/versions/<v>
+            ?.toSet().orEmpty()
+
+    private fun claudeCwdsOf(pids: Set<Long>): Set<String> = cwdsOf(pids).orEmpty()
 
     /**
      * Working directories of `codex` CLI processes that are NOT children of this daemon. Codex keeps its
@@ -39,62 +47,101 @@ object LiveProcesses {
      * children are excluded because [SessionRegistry.liveByCwd] already reports them with authoritative
      * turn state.
      *
-     * Memoized for [CODEX_CWD_TTL_MS] because the project list refreshes every ~10 seconds and this is a
+     * Memoized for [CWD_TTL_MS] because the project list refreshes every ~10 seconds and this is a
      * full OS process enumeration plus an lsof fork (PR #296 review). This is a DISPLAY signal — a project
      * row lighting up a few seconds late is invisible; see the never-cache rule on [externalAgentAt] for
      * the probes where the same staleness would be a correctness bug.
      */
     fun codexCwds(): Set<String> {
-        if (System.getProperty("os.name").lowercase().contains("win")) return emptySet() // no lsof
-        return codexCwds(System.currentTimeMillis(), ::codexPids, ::codexCwdsOf)
+        // Windows has no lsof; read each codex pid's cwd via the PEB instead (issue #302). This is the
+        // DISPLAY probe — best-effort is fine, an unreadable pid just doesn't light its row up.
+        val readCwds: (Set<Long>) -> Set<String> =
+            if (isWindows()) { pids -> pids.mapNotNull(ProcessCwd::of).toSet() } else ::codexCwdsOf
+        return codexCwdMemo.get(System.currentTimeMillis(), ::codexPids, readCwds)
     }
+
+    private fun isWindows() = System.getProperty("os.name").lowercase().contains("win")
 
     /** [codexCwds]'s memo, with its clock and both probes injected so the TTL is testable. */
-    internal fun codexCwds(nowMs: Long, pids: () -> Set<Long>, cwdsOf: (Set<Long>) -> Set<String>): Set<String> {
-        val cached = codexCwdMemo.get()
-        if (cached != null && nowMs - cached.atMs < CODEX_CWD_TTL_MS) return cached.cwds
-        val live = pids()
-        if (live.isEmpty()) {
-            codexCwdMemo.set(CodexCwdMemo(nowMs, emptySet(), emptySet()))
-            return emptySet()
+    internal fun codexCwds(nowMs: Long, pids: () -> Set<Long>, cwdsOf: (Set<Long>) -> Set<String>): Set<String> =
+        codexCwdMemo.get(nowMs, pids, cwdsOf)
+
+    /**
+     * One agent's "which cwds are live" answer, remembered for [CWD_TTL_MS]. Shared by the Claude and Codex
+     * project-list signals — each holds its OWN instance, so one agent's churn never invalidates the other's.
+     *
+     * Legal ONLY for display signals; never wrap [externalAgentAt] in one (iron rule there).
+     */
+    private class CwdMemo {
+        private class Snapshot(val atMs: Long, val pids: Set<Long>, val cwds: Set<String>)
+
+        private val ref = java.util.concurrent.atomic.AtomicReference<Snapshot?>(null)
+
+        fun get(nowMs: Long, pids: () -> Set<Long>, cwdsOf: (Set<Long>) -> Set<String>): Set<String> {
+            val cached = ref.get()
+            if (cached != null && nowMs - cached.atMs < CWD_TTL_MS) return cached.cwds
+            val live = pids()
+            if (live.isEmpty()) {
+                ref.set(Snapshot(nowMs, emptySet(), emptySet()))
+                return emptySet()
+            }
+            // Same processes as last time ⇒ same cwds: a running CLI does not chdir. Re-enumerating pids is
+            // cheap and in-process; the lsof fork is what this skips.
+            if (cached != null && cached.pids == live) {
+                ref.set(Snapshot(nowMs, live, cached.cwds))
+                return cached.cwds
+            }
+            val cwds = cwdsOf(live)
+            ref.set(Snapshot(nowMs, live, cwds))
+            return cwds
         }
-        // Same processes as last time ⇒ same cwds: a running CLI does not chdir. Re-enumerating pids is
-        // cheap and in-process; the lsof fork is what this skips.
-        if (cached != null && cached.pids == live) {
-            codexCwdMemo.set(CodexCwdMemo(nowMs, live, cached.cwds))
-            return cached.cwds
-        }
-        val cwds = cwdsOf(live)
-        codexCwdMemo.set(CodexCwdMemo(nowMs, live, cwds))
-        return cwds
+
+        fun clear() = ref.set(null)
     }
 
-    private class CodexCwdMemo(val atMs: Long, val pids: Set<Long>, val cwds: Set<String>)
+    private val codexCwdMemo = CwdMemo()
+    private val claudeCwdMemo = CwdMemo()
 
-    private val codexCwdMemo = java.util.concurrent.atomic.AtomicReference<CodexCwdMemo?>(null)
+    /** External (non-daemon-descendant) `codex` pids; empty when the walk fails. */
+    private fun codexPids(): Set<Long> =
+        externalPids(excludeDaemonDescendants = true, matches = ::isCodexExecutable)?.toSet().orEmpty()
 
-    /** External (non-daemon-descendant) `codex` pids, in enumeration order; empty when the walk fails. */
-    private fun codexPids(): Set<Long> {
+    private fun codexCwdsOf(pids: Set<Long>): Set<String> = cwdsOf(pids).orEmpty()
+
+    /**
+     * pids whose executable [matches], in enumeration order, or null when the process walk itself failed
+     * (callers distinguish "none running" from "couldn't look").
+     *
+     * [excludeDaemonDescendants] drops this daemon's own children by pid lineage. It is a SAFETY filter for
+     * the take-over probes — a daemon-owned agent must never be mistaken for a foreign writer — and true
+     * everywhere except [claudeCwds], whose project-level liveness has always counted them.
+     */
+    private fun externalPids(excludeDaemonDescendants: Boolean, matches: (String) -> Boolean): List<Long>? {
         val selfPid = ProcessHandle.current().pid()
         return runCatching {
             ProcessHandle.allProcesses()
-                .filter { isCodexExecutable(it.info().command().orElse("")) }
-                .filter { !hasAncestor(it, selfPid) }
+                .filter { matches(it.info().command().orElse("")) }
+                .filter { !excludeDaemonDescendants || !hasAncestor(it, selfPid) }
                 .map { it.pid() }
                 .toList()
-                .toSet()
-        }.getOrDefault(emptySet())
+        }.getOrNull()
     }
 
-    private fun codexCwdsOf(pids: Set<Long>): Set<String> =
-        lsofLines(listOf("lsof", "-a", "-d", "cwd", "-p", pids.joinToString(","), "-Fn"))
+    /** Working directories of [pids] via one lsof, or null when lsof fails/times out (Windows included:
+     *  there is no such binary, so the start throws and every caller degrades to its own "unknown"). */
+    private fun cwdsOf(pids: Collection<Long>): Set<String>? {
+        if (pids.isEmpty()) return emptySet()
+        return lsofLines(listOf("lsof", "-a", "-d", "cwd", "-p", pids.joinToString(","), "-Fn"))
             ?.filter { it.startsWith("n") }
             ?.map { it.substring(1) }
             ?.toSet()
-            .orEmpty()
+    }
 
-    /** Cross-test isolation: the memo is process-wide state on an object singleton. */
-    internal fun clearForTest() = codexCwdMemo.set(null)
+    /** Cross-test isolation: the memos are process-wide state on an object singleton. */
+    internal fun clearForTest() {
+        codexCwdMemo.clear()
+        claudeCwdMemo.clear()
+    }
 
     /** Exact basename match, separator-agnostic so the process probe behaves on Unix and Windows paths. */
     internal fun isCodexExecutable(command: String): Boolean {
@@ -115,7 +162,8 @@ object LiveProcesses {
      * Windows (no lsof), enumeration failure, or an lsof failure/timeout all return UNKNOWN.
      */
     fun externalClaudeAt(workdir: String, transcript: Path): ExternalClaude {
-        return externalAgentAt(workdir, transcript, matchesCommand = ::isClaudeCommand)
+        // fdFirst = false: claude's fd is rarely held, so the cwd probe is the one that usually decides.
+        return externalAgentAt(workdir, transcript, matchesCommand = ::isClaudeCommand, fdFirst = false)
     }
 
     /** Separator-agnostic like [isCodexExecutable]: a slash-only match can never see `C:\...\claude.exe`,
@@ -141,52 +189,131 @@ object LiveProcesses {
             System.currentTimeMillis() - java.nio.file.Files.getLastModifiedTime(transcript).toMillis() <
                 dev.ccpocket.daemon.codex.CodexTranscriptScanner.LIVE_WINDOW_MS
         }.getOrDefault(false)
-        return externalAgentAt(workdir, transcript, ::isCodexExecutable, allowCwdMatch = recent)
+        // fdFirst = true: an idle Codex holds its rollout open, so the fd probe is the one that usually decides.
+        return externalAgentAt(workdir, transcript, ::isCodexExecutable, allowCwdMatch = recent, fdFirst = true)
     }
 
     /**
      * IRON RULE — this probe and its two callers ([externalClaudeAt] / [externalCodexAt]) must NEVER be
      * cached or given a TTL, however hot they get. Their verdict is what decides whether we may take over
      * or write into a transcript another process owns; answering it from a world that is even a few seconds
-     * old is exactly how you manufacture a silent two-writer clobber. The nearby [codexCwds] memo is safe
-     * only because it feeds a project-list badge, not a write gate. If this needs to be faster, make the
-     * probe itself cheaper — do not remember its answer.
+     * old is exactly how you manufacture a silent two-writer clobber.
+     *
+     * The nearby [codexCwds] / [claudeCwds] memos are safe because neither answers that question: they are
+     * coarse project-level LIVENESS, and the worst a stale one does is show a badge (or refuse/allow one
+     * user-confirmed worktree removal) a beat late, against a list that was already a refresh old. Nothing
+     * downstream of them writes a transcript on their word.
+     *
+     * If this needs to be faster, make the probe itself CHEAPER — do not remember its answer. The `fdFirst`
+     * ordering below is what that looks like: one lsof instead of two on the common hit, same verdict on
+     * every input (issue #303).
      */
     private fun externalAgentAt(
         workdir: String,
         transcript: Path,
         matchesCommand: (String) -> Boolean,
         allowCwdMatch: Boolean = true,
+        fdFirst: Boolean = true,
     ): ExternalClaude {
         // Process ENUMERATION is cross-platform; only the fd/cwd probes below need lsof. Answering ABSENT
         // when no matching process exists at all keeps Windows verdicts sharp instead of a blanket UNKNOWN —
         // which matters since the Codex caller treats UNKNOWN as "assume the rollout is still held".
         val noLsof = System.getProperty("os.name").lowercase().contains("win")
-        val selfPid = ProcessHandle.current().pid()
-        val external = runCatching {
-            ProcessHandle.allProcesses()
-                .filter { matchesCommand(it.info().command().orElse("")) }
-                .filter { !hasAncestor(it, selfPid) }
-                .map { it.pid() }
-                .toList()
-        }.getOrNull() ?: return ExternalClaude.UNKNOWN
-        if (external.isEmpty()) return ExternalClaude.ABSENT // no matching agent outside the daemon at all
-        if (noLsof) return ExternalClaude.UNKNOWN // processes exist but ownership can't be probed
-        // Exact transcript ownership outranks age and cwd: an idle agent can hold a rollout for hours
-        // without touching its mtime, and that writer must never be resumed by a second process.
-        val holders = lsofLines(listOf("lsof", "-t", "--", transcript.toString()))
-            ?.mapNotNull { it.trim().toLongOrNull() }
-            ?.toSet()
-        val externalPids = external.toSet()
-        if (holders?.any { it in externalPids } == true) return ExternalClaude.PRESENT
-        if (!allowCwdMatch) return if (holders == null) ExternalClaude.UNKNOWN else ExternalClaude.ABSENT
+        val external = externalPids(excludeDaemonDescendants = true, matches = matchesCommand)
+        val pids = external.orEmpty() // only read once [agentVerdict] has ruled out the null/empty cases
+        return agentVerdict(
+            external = external,
+            noLsof = noLsof,
+            allowCwdMatch = allowCwdMatch,
+            fdFirst = fdFirst,
+            // Exact transcript ownership: an idle agent can hold a rollout for hours without touching its
+            // mtime, and that writer must never be resumed by a second process.
+            holdsTranscript = {
+                val owners = pids.toSet()
+                lsofLines(listOf("lsof", "-t", "--", transcript.toString()))
+                    ?.mapNotNull { it.trim().toLongOrNull() }
+                    ?.any { it in owners }
+            },
+            cwdMatches = { cwdMatchesWorkdir(pids, workdir) },
+        )
+    }
 
-        val cwdLines = lsofLines(listOf("lsof", "-a", "-d", "cwd", "-p", external.joinToString(","), "-Fn"))
-            ?: return ExternalClaude.UNKNOWN
+    /**
+     * Does any of [pids] have [workdir] as its cwd? Three-valued (issue #302/#303): true = a match,
+     * false = every pid read AND none matched, null = at least one pid's cwd could not be read.
+     *
+     * The null case is the safety invariant on Windows: an unreadable pid could be the very process
+     * sitting in [workdir], so a single read miss forces "unknown" (→ the caller's assume-held), NEVER
+     * ABSENT. macOS/Linux resolve all cwds in one lsof — that failing is already null.
+     */
+    private fun cwdMatchesWorkdir(pids: Collection<Long>, workdir: String): Boolean? {
+        if (pids.isEmpty()) return false
         // match raw AND canonical forms: lsof reports resolved real paths, the workdir may arrive symlinked
         val targets = pathForms(workdir)
-        if (cwdLines.filter { it.startsWith("n") }.any { it.substring(1) in targets }) return ExternalClaude.PRESENT
-        return ExternalClaude.ABSENT
+        if (isWindows()) {
+            fun norm(p: String) = p.replace('\\', '/').trimEnd('/').lowercase() // Windows paths: case-insensitive
+            val winTargets = targets.map(::norm).toSet()
+            var anyUnread = false
+            for (pid in pids) {
+                val cwd = ProcessCwd.of(pid)
+                if (cwd == null) { anyUnread = true; continue }
+                if (norm(cwd) in winTargets) return true
+            }
+            return if (anyUnread) null else false
+        }
+        return cwdsOf(pids)?.any { it in targets }
+    }
+
+    /**
+     * The pure decision behind [externalAgentAt], with both lsof probes as lazy suppliers (null = the probe
+     * failed / timed out) so the ORDER they run in is itself testable.
+     *
+     * [fdFirst] only changes which probe is asked first, never the verdict: the fd hit and the cwd hit are
+     * both sufficient for PRESENT, so with `allowCwdMatch` the answer is a symmetric
+     * "PRESENT if either hits; UNKNOWN if the ones that could still have said PRESENT failed; else ABSENT".
+     * Claude's fd is rarely held while its cwd almost always matches, so asking cwd first spares that agent
+     * one lsof fork per probe on the common PRESENT path (issue #303). Codex is the mirror image and keeps
+     * fd first — and when `allowCwdMatch` is false, only the fd probe may speak at all.
+     */
+    internal fun agentVerdict(
+        external: List<Long>?,
+        noLsof: Boolean,
+        allowCwdMatch: Boolean,
+        fdFirst: Boolean,
+        holdsTranscript: () -> Boolean?,
+        cwdMatches: () -> Boolean?,
+    ): ExternalClaude {
+        if (external == null) return ExternalClaude.UNKNOWN // the walk failed: we know nothing
+        if (external.isEmpty()) return ExternalClaude.ABSENT // no matching agent outside the daemon at all
+        if (noLsof) {
+            // Windows: the lsof fd-ownership probe can't run, but ProcessCwd can read cwd (issue #302).
+            // An fd-ONLY decision (allowCwdMatch=false — an OLD codex rollout judged purely by who holds
+            // the file) therefore stays UNKNOWN → the safe "assume held". Otherwise defer to the cwd
+            // matcher, whose three-valued answer keeps a read miss as UNKNOWN, never ABSENT.
+            if (!allowCwdMatch) return ExternalClaude.UNKNOWN
+            return when (cwdMatches()) {
+                true -> ExternalClaude.PRESENT
+                false -> ExternalClaude.ABSENT
+                null -> ExternalClaude.UNKNOWN
+            }
+        }
+
+        if (fdFirst || !allowCwdMatch) {
+            val holders = holdsTranscript()
+            if (holders == true) return ExternalClaude.PRESENT
+            if (!allowCwdMatch) return if (holders == null) ExternalClaude.UNKNOWN else ExternalClaude.ABSENT
+            return when (cwdMatches()) {
+                true -> ExternalClaude.PRESENT
+                false -> ExternalClaude.ABSENT
+                null -> ExternalClaude.UNKNOWN
+            }
+        }
+
+        val cwd = cwdMatches()
+        if (cwd == true) return ExternalClaude.PRESENT // one fork was enough — the fd probe could only agree
+        // cwd said no (or couldn't look): the fd is still sufficient on its own, so it gets the last word.
+        if (holdsTranscript() == true) return ExternalClaude.PRESENT
+        return if (cwd == null) ExternalClaude.UNKNOWN else ExternalClaude.ABSENT
     }
 
     /** True when [pid] appears in [p]'s ancestor chain (bounded walk — no cycles, but be paranoid). */
@@ -220,5 +347,5 @@ object LiveProcesses {
 
     /** Shorter than the ~10s project refresh it serves, so a normal tick still sees a fresh-enough world
      *  while bursts (several refresh triggers landing together) collapse into one probe. */
-    private const val CODEX_CWD_TTL_MS = 5_000L
+    private const val CWD_TTL_MS = 5_000L
 }

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/disk/ProcessCwd.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/disk/ProcessCwd.kt
@@ -1,0 +1,111 @@
+package dev.ccpocket.daemon.disk
+
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+import com.sun.jna.Memory
+import com.sun.jna.ptr.IntByReference
+
+/**
+ * The working directory of ANOTHER process, on the platforms where an in-process read is possible.
+ *
+ * On macOS/Linux the caller already has `lsof -d cwd` (see [LiveProcesses]); this exists for Windows,
+ * which has no lsof, so the pre-#302 code returned a blanket UNKNOWN for every Windows external-writer
+ * probe. That verdict is safe but coarse — with ONE terminal codex anywhere on the machine, every
+ * Codex session degraded to read-only/fork-only (issue #302). Reading the target's PEB narrows the
+ * probe from "any codex exists" to "a codex in THIS workdir exists".
+ *
+ * ── The one iron rule for callers ──
+ * A null return means "could not determine" and MUST keep the caller's safe fallback (assume held /
+ * UNKNOWN). This is a BLIND port (issue #302: no Windows machine was available to test it), so it is
+ * built to fail only in the safe direction: every failure path returns null, never a wrong path that
+ * could be read as "not here → ABSENT → take over → second writer". A caller may use a NON-null,
+ * confidently-mismatched cwd to EXCLUDE a process, but must never turn an unread pid into ABSENT.
+ * [selfCheck] lets a Windows CI run prove the read actually works (see LiveProcessesWinCwdSelfCheck).
+ */
+object ProcessCwd {
+
+    private val isWindows = System.getProperty("os.name").lowercase().contains("win")
+
+    /** The current directory of [pid], or null if it can't be read (non-Windows, access denied, a bitness
+     *  we don't decode, or any error). Null is "unknown", never "no cwd". */
+    fun of(pid: Long): String? {
+        if (!isWindows) return null
+        return runCatching { windowsCwd(pid) }.getOrNull()?.takeIf { it.isNotBlank() }
+    }
+
+    /** Self-verification for a Windows CI: read OUR OWN pid's cwd and confirm it matches `user.dir`.
+     *  Returns null on non-Windows (nothing to check). A false here means the blind PEB offsets are wrong
+     *  on the runner — the signal issue #302 asks CI to surface. Path compare is case-insensitive and
+     *  separator-normalized (Windows). */
+    fun selfCheck(): Boolean? {
+        if (!isWindows) return null
+        val mine = of(ProcessHandle.current().pid()) ?: return false
+        val expected = System.getProperty("user.dir") ?: return false
+        fun norm(p: String) = p.replace('/', '\\').trimEnd('\\').lowercase()
+        return norm(mine) == norm(expected)
+    }
+
+    // ── Windows PEB walk (x64 only; a WOW64/32-bit target returns null → caller stays safe) ──
+    //
+    // Offsets are the documented x64 layout, stable across NT versions:
+    //   PROCESS_BASIC_INFORMATION.PebBaseAddress            @ +0x08
+    //   PEB.ProcessParameters                               @ +0x20
+    //   RTL_USER_PROCESS_PARAMETERS.CurrentDirectory.DosPath (UNICODE_STRING):
+    //       .Length (USHORT)                                @ +0x38
+    //       .Buffer (PWSTR)                                 @ +0x40
+    private const val PROCESS_QUERY_INFORMATION = 0x0400
+    private const val PROCESS_VM_READ = 0x0010
+    private const val OFF_PEB_IN_PBI = 0x08L
+    private const val OFF_PARAMS_IN_PEB = 0x20L
+    private const val OFF_CURDIR_LEN = 0x38L
+    private const val OFF_CURDIR_BUF = 0x40L
+    private const val PTR = 8 // x64 pointer width
+
+    private interface Kernel32 : com.sun.jna.Library {
+        fun OpenProcess(access: Int, inherit: Boolean, pid: Int): Pointer?
+        fun ReadProcessMemory(proc: Pointer, addr: Pointer, buf: Pointer, size: Int, read: IntByReference?): Boolean
+        fun CloseHandle(h: Pointer): Boolean
+    }
+
+    private interface NtDll : com.sun.jna.Library {
+        // NtQueryInformationProcess(handle, ProcessBasicInformation=0, buf, len, retLen) → NTSTATUS
+        fun NtQueryInformationProcess(proc: Pointer, cls: Int, buf: Pointer, len: Int, ret: IntByReference?): Int
+    }
+
+    private val k32 by lazy { Native.load("kernel32", Kernel32::class.java) }
+    private val nt by lazy { Native.load("ntdll", NtDll::class.java) }
+
+    private fun windowsCwd(pid: Long): String? {
+        val handle = k32.OpenProcess(PROCESS_QUERY_INFORMATION or PROCESS_VM_READ, false, pid.toInt()) ?: return null
+        try {
+            // 1) PROCESS_BASIC_INFORMATION → PebBaseAddress
+            val pbi = Memory(48)
+            if (nt.NtQueryInformationProcess(handle, 0, pbi, 48, null) != 0) return null
+            val pebBase = pbi.getPointer(OFF_PEB_IN_PBI) ?: return null
+
+            // 2) PEB.ProcessParameters
+            val params = readPointer(handle, pebBase, OFF_PARAMS_IN_PEB) ?: return null
+
+            // 3) CurrentDirectory.DosPath: length (bytes) + buffer pointer
+            val lenBuf = Memory(2)
+            if (!k32.ReadProcessMemory(handle, params.share(OFF_CURDIR_LEN), lenBuf, 2, null)) return null
+            val len = lenBuf.getShort(0).toInt() and 0xFFFF
+            if (len <= 0 || len > 0x8000) return null // sanity bound — a real DosPath is short
+            val bufPtr = readPointer(handle, params, OFF_CURDIR_BUF) ?: return null
+
+            // 4) the UTF-16LE path itself
+            val strBuf = Memory(len.toLong())
+            if (!k32.ReadProcessMemory(handle, bufPtr, strBuf, len, null)) return null
+            return String(strBuf.getByteArray(0, len), Charsets.UTF_16LE)
+        } finally {
+            runCatching { k32.CloseHandle(handle) }
+        }
+    }
+
+    /** Read a pointer-sized value from the target at [base]+[offset]. */
+    private fun readPointer(handle: Pointer, base: Pointer, offset: Long): Pointer? {
+        val buf = Memory(PTR.toLong())
+        if (!k32.ReadProcessMemory(handle, base.share(offset), buf, PTR, null)) return null
+        return buf.getPointer(0)
+    }
+}

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/disk/TranscriptScanner.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/disk/TranscriptScanner.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.attribute.FileTime
 import kotlin.io.path.bufferedReader
 import kotlin.io.path.exists
 import kotlin.io.path.getLastModifiedTime
@@ -95,6 +96,107 @@ object TranscriptScanner {
     }
 
     /**
+     * Everything a COLD RESUME needs from a transcript, in the shapes the three single-purpose readers
+     * below produce: [title] as [summarize] computes it (null exactly when summarize returns null, i.e. the
+     * file carries no prompt and no title record), [gitBranch] from the first real user turn, [model] as
+     * [lastModel], [contextTokens] as [lastContextTokens].
+     */
+    data class ResumeSeed(
+        val title: String? = null,
+        val gitBranch: String? = null,
+        val model: String? = null,
+        val contextTokens: Long? = null,
+    )
+
+    /**
+     * All four resume fields in ONE pass, memoized by (path, mtime). Opening a Claude session used to parse
+     * the same .jsonl three times over (summarize → title, [lastModel], [lastContextTokens]) — three full
+     * reads of a file that reaches megabytes, back to back on the open path (issue #303).
+     *
+     * The single-purpose readers stay: they have many other callers, and they remain the SPEC this must
+     * match — `ResumeSeedParityTest` pins the four fields against them line by line.
+     *
+     * Null only when [file] is absent or unreadable. Transcripts are append-only, so a moved mtime is the
+     * only way a parse of one goes stale (the same reasoning CodexTranscriptScanner's memo uses).
+     */
+    fun resumeSeed(file: Path): ResumeSeed? {
+        if (!file.exists()) return null
+        val stamp = runCatching { file.getLastModifiedTime() }.getOrNull()
+        seedCache.get(file, stamp)?.let { return it }
+        val seed = runCatching { readResumeSeed(file) }.getOrNull() ?: return null
+        seedCache.put(file, stamp, seed)
+        return seed
+    }
+
+    private fun readResumeSeed(file: Path): ResumeSeed {
+        val sessionId = file.fileName.toString().removeSuffix(".jsonl")
+        var firstPrompt: String? = null
+        var gitBranch: String? = null
+        var aiTitle: String? = null
+        var customTitle: String? = null
+        var model: String? = null
+        var contextTokens: Long? = null
+
+        file.bufferedReader().useLines { lines ->
+            for (raw in lines) {
+                val line = raw.trim()
+                if (line.isEmpty()) continue
+                val obj = runCatching { json.parseToJsonElement(line) }.getOrNull() as? JsonObject ?: continue
+                when (obj.str("type")) {
+                    "user" -> if (isRealUserTurn(obj) && firstPrompt == null) {
+                        firstPrompt = extractUserText(obj)
+                        gitBranch = obj.str("gitBranch")
+                    }
+                    "assistant" -> {
+                        assistantModel(obj)?.let { model = it } // skips sidechain + <synthetic>, last wins
+                        contextOf(obj)?.let { contextTokens = it } // last MAIN-chain turn carrying usage wins
+                    }
+                    "ai-title" -> aiTitle = obj.str("aiTitle")
+                    "custom-title" -> customTitle = obj.str("customTitle")
+                }
+            }
+        }
+
+        // summarize's guard: without any of the three, that reader answers null and there is no title to seed
+        val title = if (firstPrompt == null && aiTitle == null && customTitle == null) null else {
+            customTitle?.takeIf { it.isNotBlank() }
+                ?: aiTitle?.takeIf { it.isNotBlank() }
+                ?: firstPrompt.orEmpty().lineSequence().firstOrNull()?.take(60)?.takeIf { it.isNotBlank() }
+                ?: sessionId
+        }
+        return ResumeSeed(title = title, gitBranch = gitBranch, model = model, contextTokens = contextTokens)
+    }
+
+    private val seedCache = MtimeMemo<ResumeSeed>(SEED_MEMO_MAX)
+
+    /** A bounded LRU keyed by file path and stamped with that file's mtime — the append-only-file memo
+     *  CodexTranscriptScanner already uses, kept as a local twin rather than shared across two scanners that
+     *  otherwise know nothing about each other. The raw FileTime (not millis) makes a same-millisecond
+     *  rewrite visible instead of silently cached. */
+    private class MtimeMemo<V : Any>(private val max: Int) {
+        private val map = object : LinkedHashMap<Path, Pair<FileTime, V>>(64, 0.75f, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Path, Pair<FileTime, V>>) = size > max
+        }
+
+        @Synchronized
+        fun get(file: Path, stamp: FileTime?): V? =
+            if (stamp == null) null else map[file]?.takeIf { it.first == stamp }?.second
+
+        @Synchronized
+        fun put(file: Path, stamp: FileTime?, value: V) {
+            if (stamp != null) map[file] = stamp to value
+        }
+
+        @Synchronized
+        fun clear() = map.clear()
+    }
+
+    /** Cross-test isolation: the memo is process-wide state on an object singleton. */
+    internal fun clearSeedCacheForTest() = seedCache.clear()
+
+    private const val SEED_MEMO_MAX = 800
+
+    /**
      * Context tokens the LAST completed assistant turn left in the window — its `message.usage` summed
      * through [TokenUsage.contextTokens], i.e. `input + output + cache_read + cache_creation`. Mirrors
      * the live TurnDone sum so the phone's usage statusline reads the same on resume as mid-session.
@@ -170,6 +272,22 @@ object TranscriptScanner {
             }
         }
         return streak
+    }
+
+    /** Context occupancy an assistant line leaves in the window, or null when it doesn't count: a
+     *  Task-subagent turn (isSidechain — that usage describes the SUBAGENT's window), a line with no
+     *  `message.usage`, or a zero sum. Same rules as [lastContextTokens], which is deliberately left
+     *  untouched (many callers); `ResumeSeedParityTest` pins the two against each other. */
+    private fun contextOf(obj: JsonObject): Long? {
+        if (obj.bool("isSidechain") == true) return null
+        val usage = (obj["message"] as? JsonObject)?.get("usage") as? JsonObject ?: return null
+        val total = TokenUsage(
+            inputTokens = usage.long("input_tokens") ?: 0,
+            outputTokens = usage.long("output_tokens") ?: 0,
+            cacheCreationInputTokens = usage.long("cache_creation_input_tokens"),
+            cacheReadInputTokens = usage.long("cache_read_input_tokens"),
+        ).contextTokens
+        return total.takeIf { it > 0 }
     }
 
     /** `message.model` of a MAIN-chain assistant line — null for Task-subagent turns (isSidechain: they share

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/session/SessionRegistry.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/session/SessionRegistry.kt
@@ -65,16 +65,12 @@ class SessionRegistry(
         LiveProcesses::externalCodexAt,
     // Resolve an agent's durable transcript. Injectable so Codex observe tests use a temp rollout rather
     // than the developer's real ~/.codex tree.
+    // Derived from the registered backends (issue #301): "which file owns this session id" is a backend
+    // capability, not registry knowledge — a new backend gets observe/take-over safety by overriding
+    // AgentBackend.transcriptPath, no registry edit. The wire-input guard (separators/dot-dot) lives in
+    // each implementation. Injectable so Codex observe tests use a temp rollout.
     private val transcriptResolver: (agent: AgentKind, workdir: String, sessionId: String) -> Path? = { agent, workdir, sessionId ->
-        // sessionId arrives on the wire (OpenSession.resumeId, including guest/collaborator opens) and is
-        // interpolated into a filename — forbid separators/dot-dot exactly like SessionFilesService.transcriptFor,
-        // or a crafted id escapes the project dir (existence/mtime probing at minimum).
-        if (sessionId.contains('/') || sessionId.contains('\\') || sessionId.contains("..")) null
-        else when (agent) {
-            AgentKind.CLAUDE -> ProjectPaths.dirFor(workdir).resolve("$sessionId.jsonl")
-            AgentKind.CODEX -> CodexPaths.findSession(sessionId)
-            else -> null
-        }
+        backends[agent]?.create()?.transcriptPath(workdir, sessionId)
     },
     // Claude transcript root — injectable ONLY so [renameSession]'s disk write is unit-testable against
     // a temp dir instead of the user's real ~/.claude/projects (every other path resolves via the
@@ -149,26 +145,37 @@ class SessionRegistry(
     ): Boolean {
         // one stat serves both the freshness gate and the ownership checks below
         val mtime = runCatching { if (file.exists()) file.getLastModifiedTime().toMillis() else null }.getOrNull() ?: return false
-        // Codex keeps the exact active rollout open while idle. Probe before the generic freshness and
-        // restart-amnesia gates so an hours-old but still-owned rollout remains read-only. The production
-        // Codex probe only permits cwd matching for fresh rollouts, so this cannot promote unrelated old
-        // sessions from the same project.
-        val earlyCodexProbe = if (agent == AgentKind.CODEX) {
-            runCatching { withContext(Dispatchers.IO) { codexProcessProbe(workdir, file) } }
+        // Which probe answers for this agent: the two named params stay as the historical test seams for
+        // Claude/Codex; any OTHER backend brings its own via AgentBackend.externalWriterProbe (issue #301).
+        val probeFor: (String, Path) -> LiveProcesses.ExternalClaude = when (agent) {
+            AgentKind.CLAUDE -> processProbe
+            AgentKind.CODEX -> codexProcessProbe
+            else -> { wd, f ->
+                backends[agent]?.create()?.externalWriterProbe(wd, f) ?: LiveProcesses.ExternalClaude.UNKNOWN
+            }
+        }
+        // A backend whose CLI holds its transcript fd even while idle (Codex; declared via
+        // holdsTranscriptWhileIdle) is probed BEFORE the freshness and restart-amnesia gates: an
+        // hours-old but still-owned rollout must remain read-only. The production Codex probe only
+        // permits cwd matching for fresh rollouts, so this cannot promote unrelated old sessions.
+        val holdsWhileIdle = agent == AgentKind.CODEX || backends[agent]?.create()?.holdsTranscriptWhileIdle == true
+        val earlyProbe = if (holdsWhileIdle) {
+            runCatching { withContext(Dispatchers.IO) { probeFor(workdir, file) } }
                 .getOrDefault(LiveProcesses.ExternalClaude.UNKNOWN)
         } else null
-        if (earlyCodexProbe == LiveProcesses.ExternalClaude.PRESENT) {
-            log.info("externallyActive(${sessionId.take(8)}…): Codex holds exact rollout → true")
+        if (earlyProbe == LiveProcesses.ExternalClaude.PRESENT) {
+            log.info("externallyActive(${sessionId.take(8)}…): $agent holds exact transcript → true")
             return true
         }
-        if (earlyCodexProbe == LiveProcesses.ExternalClaude.UNKNOWN) {
-            // UNKNOWN from the Codex probe means external codex processes EXIST but rollout ownership could
-            // not be verified (lsof failure/timeout, or Windows where fd probing is impossible — "no codex
-            // at all" reports ABSENT, not UNKNOWN). An idle holder keeps an OLD mtime, so the freshness gate
-            // below would answer false — the exact wrong direction for the one backend with no session lock
-            // (a silent double-writer, probed on codex app-server). Take the safe verdict instead: observe /
-            // fork-on-take-over. A spurious fork is recoverable; a clobbered rollout is not (PR #296 review).
-            log.info("externallyActive(${sessionId.take(8)}…): Codex rollout ownership unverifiable → assume held")
+        if (earlyProbe == LiveProcesses.ExternalClaude.UNKNOWN) {
+            // UNKNOWN from an idle-holder probe means external processes EXIST but transcript ownership
+            // could not be verified (lsof failure/timeout, or Windows where fd probing is impossible —
+            // "none at all" reports ABSENT, not UNKNOWN). An idle holder keeps an OLD mtime, so the
+            // freshness gate below would answer false — the exact wrong direction for a backend with no
+            // session lock (a silent double-writer, probed on codex app-server). Take the safe verdict
+            // instead: observe / fork-on-take-over. A spurious fork is recoverable; a clobbered
+            // transcript is not (PR #296 review).
+            log.info("externallyActive(${sessionId.take(8)}…): $agent transcript ownership unverifiable → assume held")
             return true
         }
         if (System.currentTimeMillis() - mtime >= TranscriptScanner.LIVE_WINDOW_MS) return false
@@ -184,11 +191,11 @@ class SessionRegistry(
             log.info("externallyActive(${sessionId.take(8)}…): mtime ${now - mtime}ms ago is our own close tail (selfClosed ${now - closedAt}ms ago) → false")
             return false
         }
-        // mtime alone can't tell "terminal claude still running" from "user quit it seconds ago" — ask the
+        // mtime alone can't tell "terminal agent still running" from "user quit it seconds ago" — ask the
         // OS. Only reached on a fresh foreign-looking mtime, so the lsof cost stays off every ordinary open.
         // UNKNOWN (Windows / lsof failure / timeout) keeps the old mtime verdict: a wrongly forked session
         // is recoverable, two writers clobbering one transcript is not.
-        val probe = earlyCodexProbe ?: runCatching { withContext(Dispatchers.IO) { processProbe(workdir, file) } }
+        val probe = earlyProbe ?: runCatching { withContext(Dispatchers.IO) { probeFor(workdir, file) } }
             .getOrDefault(LiveProcesses.ExternalClaude.UNKNOWN)
         val verdict = probe != LiveProcesses.ExternalClaude.ABSENT
         log.info(
@@ -464,11 +471,13 @@ class SessionRegistry(
                 log.info("open ${resume.take(8)}… → live candidate ${attach.convoId.take(8)}… expired before reattach claim; resuming cold")
                 live = null
             }
-            // Observe a Claude/Codex session running OUTSIDE the daemon (e.g. a terminal) — read-only,
-            // no second writer. Each backend supplies its own transcript resolver/replay and process probe.
-            // externallyActive requires a LIVE external process, not just a fresh mtime — a terminal claude
-            // the user quit seconds ago falls through to an ordinary in-place resume, not read-only observe.
-            if (effectiveAgent in setOf(AgentKind.CLAUDE, AgentKind.CODEX) && !open.takeOver) {
+            // Observe a session running OUTSIDE the daemon (e.g. a terminal) — read-only, no second
+            // writer. Admission is the transcript capability itself (issue #301): a backend that resolves
+            // no per-session file (OpenCode's SQLite, Kimi/ZCode/DSH) never reaches the gate — by
+            // declaration, not by a kind list here. externallyActive still requires a LIVE external
+            // process, not just a fresh mtime — a terminal claude the user quit seconds ago falls through
+            // to an ordinary in-place resume, not read-only observe.
+            if (!open.takeOver) {
                 val file = transcriptResolver(effectiveAgent, open.workdir, resume)
                 val recent = file != null && externallyActive(resume, open.workdir, file, effectiveAgent)
                 if (recent) {
@@ -579,7 +588,9 @@ class SessionRegistry(
         }.getOrDefault(false)
 
         if (hasTranscript(requested)) return requested
-        return listOf(AgentKind.CODEX, AgentKind.CLAUDE)
+        // candidates derive from the registered backends (issue #301); the legacy pair stays appended so
+        // test registries built with an empty/partial backends map keep the historical probe order
+        return (backends.keys + listOf(AgentKind.CODEX, AgentKind.CLAUDE)).distinct()
             .firstOrNull { it != requested && hasTranscript(it) }
             ?: requested
     }

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/codex/CodexBackendTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/codex/CodexBackendTest.kt
@@ -210,7 +210,9 @@ class CodexBackendTest {
         val w = mutableListOf<String>()
         val b = ready(w)
 
-        b.sendPrompt("/simplify keep the public API", emptyList())
+        // Conversation applies expandSlashPrompt at its prompt boundary (issue #301); this pins the
+        // backend's rewrite AND that the expanded form is what actually reaches the wire.
+        b.sendPrompt(b.expandSlashPrompt("/simplify keep the public API"), emptyList())
 
         val turn = w.last { "turn/start" in it }
         assertFalse("/simplify" in turn, turn)

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/codex/CodexScanCacheTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/codex/CodexScanCacheTest.kt
@@ -99,6 +99,64 @@ class CodexScanCacheTest {
         assertEquals("gpt-5.6-mini", CodexTranscriptScanner.runtimeState(f).model)
     }
 
+    @Test
+    fun one_read_answers_both_the_summary_and_the_runtime_state() {
+        // issue #300: the summary parse merges the runtime state on every line anyway, so asking for the
+        // model/context after summarizing must not cost a second full parse of a megabyte-sized rollout.
+        val f = tmp.resolve("rollout-2026-08-25T00-00-03-thr-memo.jsonl")
+        write(f, rollout("first prompt", "gpt-5.6-sol"), stamp)
+
+        val summary = CodexTranscriptScanner.summarize(f, "/repo", emptyMap())!!
+        assertEquals("gpt-5.6-sol", summary.model)
+
+        // Same handle as everywhere else here: changed bytes under a pinned mtime are invisible to a MEMO
+        // and glaringly visible to a re-read. A second parse would report gpt-5.6-mini.
+        write(f, rollout("first prompt", "gpt-5.6-mini"), stamp)
+        assertEquals(
+            "gpt-5.6-sol",
+            CodexTranscriptScanner.runtimeState(f).model,
+            "runtimeState after summarize is answered by that same scan, never by a second read",
+        )
+    }
+
+    @Test
+    fun the_shared_scan_works_in_either_order() {
+        // the observe tick asks for runtime first, a session listing asks for the summary first — one cache
+        val f = tmp.resolve("rollout-2026-08-25T00-00-04-thr-memo.jsonl")
+        write(f, rollout("first prompt", "gpt-5.6-sol"), stamp)
+
+        assertEquals("gpt-5.6-sol", CodexTranscriptScanner.runtimeState(f).model)
+
+        write(f, rollout("second prompt", "gpt-5.6-sol"), stamp)
+        assertEquals(
+            "first prompt",
+            CodexTranscriptScanner.summarize(f, "/repo", emptyMap())?.firstPrompt,
+            "summarize after runtimeState reuses that scan's parse instead of reading again",
+        )
+    }
+
+    @Test
+    fun runtimeState_still_reads_a_rollout_that_has_no_session_meta_header() {
+        // A header-less rollout has no summary at all, but its turn_context/token_count lines are still the
+        // truth about the model and context in use — merging the two caches must not lose that, and the
+        // FIRST line (which the summary path spends on the header) has to be merged too.
+        val f = tmp.resolve("rollout-2026-08-25T00-00-05-thr-nometa.jsonl")
+        write(
+            f,
+            """
+            {"timestamp":"t0","type":"turn_context","payload":{"model":"gpt-5.6-sol"}}
+            {"timestamp":"t1","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":4242},"model_context_window":258400}}}
+            """.trimIndent(),
+            stamp,
+        )
+
+        val state = CodexTranscriptScanner.runtimeState(f)
+        assertEquals("gpt-5.6-sol", state.model, "the first line counts when it isn't a session_meta")
+        assertEquals(4242L, state.contextUsed)
+        assertEquals(258_400L, state.contextWindow)
+        assertNull(CodexTranscriptScanner.summarize(f, "/repo", emptyMap()), "no header → no summary, cached or not")
+    }
+
     // ---- CodexPaths: directory listings + id index -------------------------------------------------
 
     /** `sessions/YYYY/MM/DD/rollout-<ts>-<id>.jsonl`, the real on-disk layout. */

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/codex/CodexTranscriptActiveSummariesTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/codex/CodexTranscriptActiveSummariesTest.kt
@@ -98,6 +98,51 @@ class CodexTranscriptActiveSummariesTest {
     }
 
     @Test
+    fun a_rollout_whose_cwd_is_already_known_to_be_unwanted_is_never_opened() {
+        // issue #300: a live project's newest rollout sits behind every other project's newer ones, and each
+        // of those used to be OPENED (just to be discarded on its first line) on every 10-second tick. They
+        // are prefiltered on the cwd the same tick's cwdsByNewest already memoized by (path, mtime).
+        val other = Files.createTempDirectory("ccp-codex-decoy").toString()
+        try {
+            val decoy = rollout("thr-decoy", other, prompt = "elsewhere", mtime = now)
+            val wanted = rollout("thr-wanted", work, prompt = "the live one", mtime = now - 1_000)
+            val files = listOf(decoy, wanted) // decoy first, exactly where the other-project files sit
+
+            // what the refresh does first in production — this is what fills the cwd memo
+            CodexTranscriptScanner.cwdsByNewest(files)
+
+            // Now make the decoy CLAIM the wanted cwd, with its mtime pinned. Only an actual open of its
+            // first line can see that: if activeSummaries opened it, the decoy — being first in the list —
+            // would answer for `work` and thr-wanted would never be reached.
+            Files.writeString(
+                decoy,
+                """{"timestamp":"t0","type":"session_meta","payload":{"id":"thr-decoy","cwd":"$work","cli_version":"0.124.0"}}""" + "\n" +
+                    """{"timestamp":"t1","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"decoy"}]}}""",
+            )
+            Files.setLastModifiedTime(decoy, FileTime.fromMillis(now))
+
+            assertEquals(
+                "thr-wanted",
+                CodexTranscriptScanner.activeSummaries(setOf(work), files).getValue(work).sessionId,
+                "an unwanted cwd costs a stat, not an open",
+            )
+
+            // …and the flip side of that memo, so this test can't pass for the wrong reason (e.g. the decoy
+            // being skipped by something other than the cache): with a cold cache the file IS opened and its
+            // new cwd is seen.
+            CodexTranscriptScanner.clearForTest()
+            assertEquals(
+                "thr-decoy",
+                CodexTranscriptScanner.activeSummaries(setOf(work), files).getValue(work).sessionId,
+                "cold cache → the first line is read, and it now says this file is the wanted cwd's newest",
+            )
+        } finally {
+            java.io.File(other).deleteRecursively()
+            CodexTranscriptScanner.clearForTest()
+        }
+    }
+
+    @Test
     fun a_newest_rollout_that_does_have_a_prompt_still_titles_itself_from_it() {
         val files = listOf(rollout("thr-titled", work, prompt = "build the thing", mtime = now))
 

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/disk/LiveProcessesClaudeCwdCacheTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/disk/LiveProcessesClaudeCwdCacheTest.kt
@@ -1,0 +1,79 @@
+package dev.ccpocket.daemon.disk
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Issue #303: [LiveProcesses.claudeCwds] carried the same cost [LiveProcesses.codexCwds] was memoized for
+ * in PR #296 — a full OS process enumeration plus an lsof fork on every ~10s project refresh — and got the
+ * same 5s memo. This pins the Claude instance's policy and, above all, that the two memos are INDEPENDENT:
+ * one agent's process churn must never expire (or answer for) the other's.
+ *
+ * (Still deliberately absent, and must stay absent: any cache on externalClaudeAt/externalCodexAt. See the
+ * iron rule on `LiveProcesses.externalAgentAt`.)
+ */
+class LiveProcessesClaudeCwdCacheTest {
+    private var pidCalls = 0
+    private var lsofCalls = 0
+
+    @BeforeTest
+    fun reset() {
+        LiveProcesses.clearForTest()
+        pidCalls = 0
+        lsofCalls = 0
+    }
+
+    @AfterTest
+    fun cleanup() = LiveProcesses.clearForTest()
+
+    private fun probe(nowMs: Long, pids: Set<Long>, cwds: Set<String> = setOf("/repo")) =
+        LiveProcesses.claudeCwds(
+            nowMs,
+            { pidCalls++; pids },
+            { lsofCalls++; cwds },
+        )
+
+    @Test
+    fun within_the_ttl_nothing_is_probed_at_all() {
+        assertEquals(setOf("/repo"), probe(10_000, setOf(1L, 2L)))
+        assertEquals(1, pidCalls)
+        assertEquals(1, lsofCalls)
+
+        assertEquals(setOf("/repo"), probe(14_999, setOf(1L, 2L)), "cached answer")
+        assertEquals(1, pidCalls, "not even the process walk runs inside the TTL")
+        assertEquals(1, lsofCalls)
+    }
+
+    @Test
+    fun an_expired_memo_with_the_same_pids_skips_the_lsof_fork() {
+        probe(10_000, setOf(1L, 2L))
+        assertEquals(setOf("/repo"), probe(15_000, setOf(1L, 2L)), "same processes ⇒ same cwds")
+        assertEquals(2, pidCalls, "pids are re-enumerated — that part is in-process and cheap")
+        assertEquals(1, lsofCalls, "the fork is what gets skipped")
+    }
+
+    @Test
+    fun a_changed_pid_set_re_runs_lsof() {
+        probe(10_000, setOf(1L, 2L))
+        assertEquals(setOf("/other"), probe(15_000, setOf(1L, 3L), cwds = setOf("/other")))
+        assertEquals(2, lsofCalls)
+    }
+
+    @Test
+    fun a_terminal_claude_exiting_is_reflected_once_the_ttl_expires() {
+        assertEquals(setOf("/repo"), probe(10_000, setOf(1L, 2L)))
+        assertEquals(emptySet<String>(), probe(16_000, emptySet()), "liveness must still drop away, just a beat later")
+    }
+
+    @Test
+    fun the_two_agents_memos_do_not_share_state() {
+        assertEquals(setOf("/claude-repo"), probe(10_000, setOf(1L), cwds = setOf("/claude-repo")))
+        // a Codex probe at the same instant answers from its OWN (empty) memo, and leaves Claude's alone
+        assertEquals(setOf("/codex-repo"), LiveProcesses.codexCwds(10_000, { setOf(9L) }, { setOf("/codex-repo") }))
+        assertEquals(setOf("/claude-repo"), probe(11_000, setOf(1L), cwds = setOf("/claude-repo")))
+        assertEquals(1, pidCalls, "the Codex probe must not have expired the Claude memo")
+        assertEquals(1, lsofCalls)
+    }
+}

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/disk/LiveProcessesProbeOrderTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/disk/LiveProcessesProbeOrderTest.kt
@@ -1,0 +1,152 @@
+package dev.ccpocket.daemon.disk
+
+import dev.ccpocket.daemon.disk.LiveProcesses.ExternalClaude
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Issue #303: the take-over probe used to fork an fd-holder lsof unconditionally, even for Claude, whose fd
+ * is rarely held and whose cwd almost always answers on the first try. It now asks cwd first for Claude
+ * (`fdFirst = false`) and keeps fd first for Codex.
+ *
+ * This is a SAFETY path — it decides whether a second process may write someone else's transcript — so the
+ * bar for the reordering is not "looks equivalent" but "equivalent on every input". `fdFirst = true` IS the
+ * old code path, so the table below drives both orders through all 3×3 probe outcomes (hit / miss / lsof
+ * failed) and demands the same verdict, then pins the fork actually saved.
+ */
+class LiveProcessesProbeOrderTest {
+    private val outcomes = listOf<Boolean?>(true, false, null) // hit / miss / probe failed
+
+    private fun verdict(
+        fdFirst: Boolean,
+        holders: Boolean?,
+        cwd: Boolean?,
+        external: List<Long>? = listOf(42L),
+        noLsof: Boolean = false,
+        allowCwdMatch: Boolean = true,
+        onHolders: () -> Unit = {},
+        onCwd: () -> Unit = {},
+    ) = LiveProcesses.agentVerdict(
+        external = external,
+        noLsof = noLsof,
+        allowCwdMatch = allowCwdMatch,
+        fdFirst = fdFirst,
+        holdsTranscript = { onHolders(); holders },
+        cwdMatches = { onCwd(); cwd },
+    )
+
+    @Test
+    fun cwd_first_and_fd_first_agree_on_every_probe_outcome() {
+        for (holders in outcomes) for (cwd in outcomes) {
+            assertEquals(
+                verdict(fdFirst = true, holders = holders, cwd = cwd),
+                verdict(fdFirst = false, holders = holders, cwd = cwd),
+                "holders=$holders cwd=$cwd — reordering the probes must not move the verdict",
+            )
+        }
+    }
+
+    @Test
+    fun the_verdict_table_itself_is_what_it_always_was() {
+        // either signal alone is sufficient for PRESENT; UNKNOWN only when a probe that could still have
+        // said PRESENT failed; ABSENT when both looked and neither found anything
+        for (fdFirst in listOf(true, false)) {
+            assertEquals(ExternalClaude.PRESENT, verdict(fdFirst, holders = true, cwd = false))
+            assertEquals(ExternalClaude.PRESENT, verdict(fdFirst, holders = false, cwd = true))
+            assertEquals(ExternalClaude.PRESENT, verdict(fdFirst, holders = true, cwd = null))
+            assertEquals(ExternalClaude.PRESENT, verdict(fdFirst, holders = null, cwd = true))
+            assertEquals(ExternalClaude.ABSENT, verdict(fdFirst, holders = false, cwd = false))
+            assertEquals(ExternalClaude.ABSENT, verdict(fdFirst, holders = null, cwd = false))
+            assertEquals(ExternalClaude.UNKNOWN, verdict(fdFirst, holders = false, cwd = null))
+            assertEquals(ExternalClaude.UNKNOWN, verdict(fdFirst, holders = null, cwd = null))
+        }
+    }
+
+    @Test
+    fun a_cwd_hit_spares_claude_the_fd_fork() {
+        var fdForks = 0
+        assertEquals(
+            ExternalClaude.PRESENT,
+            verdict(fdFirst = false, holders = false, cwd = true, onHolders = { fdForks++ }),
+        )
+        assertEquals(0, fdForks, "the common terminal-claude case must cost ONE lsof, not two")
+    }
+
+    @Test
+    fun a_cwd_miss_still_consults_the_fd_holder() {
+        // the strengthener is not optional: an agent that moved cwd but still holds the transcript owns it
+        var fdForks = 0
+        assertEquals(
+            ExternalClaude.PRESENT,
+            verdict(fdFirst = false, holders = true, cwd = false, onHolders = { fdForks++ }),
+        )
+        assertEquals(1, fdForks)
+    }
+
+    @Test
+    fun codex_keeps_asking_the_fd_first() {
+        var cwdForks = 0
+        assertEquals(
+            ExternalClaude.PRESENT,
+            verdict(fdFirst = true, holders = true, cwd = true, onCwd = { cwdForks++ }),
+        )
+        assertEquals(0, cwdForks, "an idle Codex is found by its held rollout — no cwd fork needed")
+    }
+
+    @Test
+    fun an_old_codex_rollout_still_ignores_cwd_entirely() {
+        // allowCwdMatch = false: one unrelated Codex in the same project must not make every old rollout
+        // there look live. Only the fd may speak, and its failure is UNKNOWN ("assume it is still held").
+        var cwdForks = 0
+        for (fdFirst in listOf(true, false)) {
+            assertEquals(
+                ExternalClaude.ABSENT,
+                verdict(fdFirst, holders = false, cwd = true, allowCwdMatch = false, onCwd = { cwdForks++ }),
+            )
+            assertEquals(
+                ExternalClaude.UNKNOWN,
+                verdict(fdFirst, holders = null, cwd = true, allowCwdMatch = false, onCwd = { cwdForks++ }),
+            )
+            assertEquals(
+                ExternalClaude.PRESENT,
+                verdict(fdFirst, holders = true, cwd = false, allowCwdMatch = false, onCwd = { cwdForks++ }),
+            )
+        }
+        assertEquals(0, cwdForks, "the cwd probe must never even run when cwd may not decide")
+    }
+
+    @Test
+    fun nothing_is_probed_before_the_process_walk_has_spoken() {
+        var probes = 0
+        val count: () -> Unit = { probes++ }
+        // enumeration failed ⇒ we know nothing
+        assertEquals(ExternalClaude.UNKNOWN, verdict(false, true, true, external = null, onHolders = count, onCwd = count))
+        // no matching agent outside the daemon at all ⇒ ABSENT without touching lsof (keeps Windows sharp)
+        assertEquals(ExternalClaude.ABSENT, verdict(false, true, true, external = emptyList(), onHolders = count, onCwd = count))
+        // no lsof AND an fd-only decision (old codex rollout): no probe can speak → UNKNOWN, no fork
+        assertEquals(ExternalClaude.UNKNOWN, verdict(false, true, true, noLsof = true, allowCwdMatch = false, onHolders = count, onCwd = count))
+        assertEquals(0, probes, "these three answers are decided before any fork, in both orders")
+        assertTrue(
+            listOf(true, false).all { fd ->
+                verdict(fd, true, true, external = null) == ExternalClaude.UNKNOWN &&
+                    verdict(fd, true, true, external = emptyList()) == ExternalClaude.ABSENT &&
+                    verdict(fd, true, true, noLsof = true, allowCwdMatch = false) == ExternalClaude.UNKNOWN
+            },
+        )
+    }
+
+    @Test
+    fun no_lsof_but_cwd_eligible_defers_to_the_cwd_probe_and_never_forks_the_fd_probe() {
+        // Windows (issue #302): the fd/lsof probe can't run, but ProcessCwd can read cwd. When cwd matching
+        // is allowed the cwd probe alone decides — three-valued, so a read miss stays UNKNOWN, never ABSENT.
+        for (fdFirst in listOf(true, false)) {
+            var fdProbes = 0
+            val fdCount: () -> Unit = { fdProbes++ }
+            assertEquals(ExternalClaude.PRESENT, verdict(fdFirst, holders = true, cwd = true, noLsof = true, onHolders = fdCount))
+            assertEquals(ExternalClaude.ABSENT, verdict(fdFirst, holders = true, cwd = false, noLsof = true, onHolders = fdCount))
+            assertEquals(ExternalClaude.UNKNOWN, verdict(fdFirst, holders = true, cwd = null, noLsof = true, onHolders = fdCount))
+            assertEquals(0, fdProbes, "no lsof means the fd probe must never be forked — cwd alone answers")
+        }
+    }
+}

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/disk/ProcessCwdWinCwdSelfCheckTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/disk/ProcessCwdWinCwdSelfCheckTest.kt
@@ -1,0 +1,36 @@
+package dev.ccpocket.daemon.disk
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Self-verification for the BLIND Windows cwd probe (issue #302). [ProcessCwd] was ported without a
+ * Windows machine to test on, so the PEB offsets are unproven until a real windows-latest runner runs
+ * this — the "have CI/user feedback surface it" half of "盲修先行，有反馈再精修".
+ *
+ * On non-Windows the probe returns null by design (lsof handles those platforms), so these are no-ops
+ * — the assertions only bite on the Windows CI job (`*WinCwd*`).
+ */
+class ProcessCwdWinCwdSelfCheckTest {
+
+    private val isWindows = System.getProperty("os.name").lowercase().contains("win")
+
+    @Test
+    fun reading_our_own_cwd_matches_user_dir_on_windows() {
+        val result = ProcessCwd.selfCheck()
+        if (!isWindows) {
+            assertEquals(null, result, "non-Windows must opt out of the PEB read (null), leaving lsof in charge")
+            return
+        }
+        // On a real Windows runner this MUST hold, or the blind PEB offsets are wrong for this NT build
+        // and every external-writer verdict on Windows must stay UNKNOWN (never ABSENT).
+        assertTrue(result == true, "ProcessCwd read our own cwd but it did not match user.dir — offsets are off")
+    }
+
+    @Test
+    fun non_windows_never_reads_a_cwd() {
+        if (isWindows) return
+        assertEquals(null, ProcessCwd.of(ProcessHandle.current().pid()))
+    }
+}

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/disk/ResumeSeedParityTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/disk/ResumeSeedParityTest.kt
@@ -1,0 +1,154 @@
+package dev.ccpocket.daemon.disk
+
+import java.nio.file.Files
+import java.nio.file.attribute.FileTime
+import kotlin.io.path.getLastModifiedTime
+import kotlin.io.path.setLastModifiedTime
+import kotlin.io.path.writeText
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Issue #303: opening a Claude session parsed the same transcript THREE times (summarize → title,
+ * [TranscriptScanner.lastModel], [TranscriptScanner.lastContextTokens]) — three full reads of a file that
+ * reaches megabytes, back to back on the open path. [TranscriptScanner.resumeSeed] does it in one.
+ *
+ * The three readers keep their many other callers and stay the SPEC: every fixture here is asserted field
+ * by field against them, so a rule that drifts in one place (the sidechain skip, the `<synthetic>` skip, the
+ * title precedence, the first-user-turn capture) turns this red instead of quietly seeding a wrong resume.
+ */
+class ResumeSeedParityTest {
+
+    @BeforeTest
+    fun reset() = TranscriptScanner.clearSeedCacheForTest()
+
+    @AfterTest
+    fun cleanup() = TranscriptScanner.clearSeedCacheForTest()
+
+    /** The load-bearing assertion of this file: one pass must equal the three it replaces. */
+    private fun assertParity(name: String, lines: List<String>) {
+        val f = Files.createTempDirectory("ccp-seed").resolve("$name.jsonl")
+        f.writeText(lines.joinToString("\n"))
+        val seed = assertNotNull(TranscriptScanner.resumeSeed(f), "$name: a readable transcript always seeds")
+        val summary = TranscriptScanner.summarize(f)
+        assertEquals(summary?.title, seed.title, "$name: title")
+        assertEquals(summary?.gitBranch, seed.gitBranch, "$name: gitBranch")
+        assertEquals(TranscriptScanner.lastModel(f), seed.model, "$name: model")
+        assertEquals(TranscriptScanner.lastContextTokens(f), seed.contextTokens, "$name: contextTokens")
+    }
+
+    @Test
+    fun a_full_transcript_seeds_exactly_what_the_three_readers_say() {
+        assertParity(
+            "sess-full",
+            listOf(
+                """{"type":"mode","mode":"normal"}""",
+                """{"type":"user","message":{"role":"user","content":"first real prompt"},"cwd":"/repo","gitBranch":"main","version":"2.1.165"}""",
+                """{"type":"assistant","message":{"model":"claude-sonnet-4-5","usage":{"input_tokens":100,"output_tokens":5},"content":[]}}""",
+                """{"type":"user","toolUseResult":{"x":1},"message":{"role":"user","content":[{"type":"tool_result","content":"r"}]}}""",
+                """{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"input_tokens":1000,"output_tokens":10,"cache_read_input_tokens":500},"content":[]}}""",
+                """{"type":"ai-title","aiTitle":"My Title"}""",
+                """{"type":"custom-title","customTitle":"cc-renamed"}""",
+            ),
+        )
+    }
+
+    @Test
+    fun sidechain_and_synthetic_records_are_skipped_the_same_way() {
+        // a Task subagent's turn shares the file but ran the SUBAGENT's model against the SUBAGENT's window;
+        // `<synthetic>` is an API-error placeholder. Neither may win the model, and the sidechain's usage
+        // must not become this session's occupancy.
+        assertParity(
+            "sess-sc",
+            listOf(
+                """{"type":"user","message":{"role":"user","content":"hi"},"gitBranch":"feat/x"}""",
+                """{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"input_tokens":1000,"output_tokens":10,"cache_read_input_tokens":500},"content":[]}}""",
+                """{"type":"assistant","isSidechain":true,"message":{"model":"claude-haiku-4-5","usage":{"input_tokens":99999,"output_tokens":10},"content":[]}}""",
+                """{"type":"assistant","message":{"model":"<synthetic>","content":[{"type":"text","text":"api error"}]}}""",
+            ),
+        )
+    }
+
+    @Test
+    fun title_falls_back_the_same_way_at_every_step() {
+        assertParity(
+            "sess-ai-title",
+            listOf(
+                """{"type":"user","message":{"role":"user","content":"prompt"},"gitBranch":"main"}""",
+                """{"type":"ai-title","aiTitle":"guessed"}""",
+            ),
+        )
+        assertParity(
+            "sess-first-prompt", // no title record at all ⇒ first line of the first prompt, capped at 60
+            listOf(
+                """{"type":"user","message":{"role":"user","content":"${"x".repeat(80)}\nsecond line"}}""",
+            ),
+        )
+        assertParity(
+            "sess-blank", // blank prompt, no titles ⇒ the sessionId itself
+            listOf("""{"type":"user","message":{"role":"user","content":""}}"""),
+        )
+        assertParity(
+            "sess-renamed-only", // a rename with nothing else still surfaces
+            listOf("""{"type":"custom-title","customTitle":"My Renamed Session"}"""),
+        )
+    }
+
+    @Test
+    fun the_first_user_turn_wins_the_branch_in_both_readers() {
+        // a session that outlived a branch switch: the header is captured once, at the first REAL user turn
+        assertParity(
+            "sess-branch",
+            listOf(
+                """{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"r"}]}}""",
+                """{"type":"user","message":{"role":"user","content":"real"},"gitBranch":"first"}""",
+                """{"type":"user","message":{"role":"user","content":"later"},"gitBranch":"second"}""",
+            ),
+        )
+    }
+
+    @Test
+    fun a_transcript_with_no_title_at_all_still_seeds_model_and_tokens() {
+        // summarize answers null here (no prompt, no title record) — the seed must mirror that in `title`
+        // WITHOUT losing the two fields that come from assistant lines, or a resume would show no model.
+        val f = Files.createTempDirectory("ccp-seed").resolve("sess-headless.jsonl")
+        f.writeText("""{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"input_tokens":7,"output_tokens":3},"content":[]}}""")
+        assertNull(TranscriptScanner.summarize(f))
+        val seed = assertNotNull(TranscriptScanner.resumeSeed(f))
+        assertNull(seed.title)
+        assertNull(seed.gitBranch)
+        assertEquals("claude-opus-4-8", seed.model)
+        assertEquals(10L, seed.contextTokens)
+    }
+
+    @Test
+    fun an_absent_transcript_seeds_nothing() {
+        val dir = Files.createTempDirectory("ccp-seed")
+        assertNull(TranscriptScanner.resumeSeed(dir.resolve("nope.jsonl")))
+    }
+
+    @Test
+    fun the_memo_is_keyed_by_mtime_not_by_path() {
+        // Transcripts are append-only, so a moved mtime is the only way a parse of one goes stale. Proven
+        // both ways: content rewritten UNDER the same stamp keeps the old seed (⇒ the file was not re-read),
+        // and moving the stamp re-reads.
+        val f = Files.createTempDirectory("ccp-seed").resolve("sess-memo.jsonl")
+        f.writeText("""{"type":"assistant","message":{"model":"first-model","usage":{"input_tokens":10,"output_tokens":0},"content":[]}}""")
+        val stamp = f.getLastModifiedTime()
+        val first = assertNotNull(TranscriptScanner.resumeSeed(f))
+        assertEquals("first-model", first.model)
+
+        f.writeText("""{"type":"assistant","message":{"model":"second-model","usage":{"input_tokens":20,"output_tokens":0},"content":[]}}""")
+        f.setLastModifiedTime(stamp)
+        assertEquals(first, TranscriptScanner.resumeSeed(f), "same (path, mtime) ⇒ the memoized parse")
+
+        f.setLastModifiedTime(FileTime.fromMillis(stamp.toMillis() + 2_000))
+        val second = assertNotNull(TranscriptScanner.resumeSeed(f))
+        assertEquals("second-model", second.model, "a moved mtime must re-read")
+        assertEquals(20L, second.contextTokens)
+    }
+}

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/session/SessionRegistryObserveTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/session/SessionRegistryObserveTest.kt
@@ -49,7 +49,14 @@ class SessionRegistryObserveReapTest {
 
     @Test
     fun reopen_same_client_reaps_the_stale_observer_but_not_other_clients() = runBlocking {
-        val registry = SessionRegistry(scope, backends = emptyMap(), processProbe = { _, _ -> LiveProcesses.ExternalClaude.PRESENT })
+        val registry = SessionRegistry(
+            scope,
+            backends = emptyMap(),
+            processProbe = { _, _ -> LiveProcesses.ExternalClaude.PRESENT },
+            // the default resolver now derives from registered backends (issue #301); this test's subject
+            // is observer reaping, so pin the Claude path shape directly
+            transcriptResolver = { _, wd, s -> ProjectPaths.dirFor(wd).resolve("$s.jsonl") },
+        )
         // a fresh transcript written AFTER the registry booted → externallyActive gate passes (probe stubbed PRESENT)
         Files.createDirectories(projectDir)
         val transcript = Files.writeString(projectDir.resolve("$sid.jsonl"), "{}")


### PR DESCRIPTION
叠在 #299 之上（全部建立在 #299 的缓存层与 AgentBackend 契约钩子上）。**#299 合并后本 PR retarget main。** 逐一交付评审确认的四个大项。

## #300 rollout 单遍解析
`parseRollout` 的完整 RuntimeState 并入 `Scanned(parsed, runtime)`，`scanCache` 统一——一次 Codex 会话 open 从双遍全文件解析降为一遍，observe/resume 共享。`activeSummaries` 改走 `cwdCache` 预筛（`readCwd` 命中=一次 stat 零 IO），非 wanted cwd 的 rollout 不再每 10 秒白开。

## #301 AgentBackend 契约下沉
消灭四处共享基础设施里的 `AgentKind.CODEX` 点名分支——它们本该是 backend 能力：
- 新契约：`transcriptPath` / `externalWriterProbe` / `holdsTranscriptWhileIdle` / `supportsNativeCompact` / `supportsNativeReview` / `expandSlashPrompt`
- **Conversation**：/compact //review 改能力路由（kind-gate 与「不支持」死代码回复删除）；`/simplify` 展开从 CodexBackend.sendPrompt（也是 steer 路径，会误改中途消息）上移到 Conversation 的 prompt 边界；三份冷启动块抽 `ensureProcessForControlOp`
- **ObserveSession**：slice/page/state/title 四处 `when(agent)` 收敛成单一 `Reader` 接口＋三实现
- **SessionRegistry**：transcriptResolver、observe 门、resolveResumeAgent、探针分发四处点名改从注册 backend 派生——下一个 backend（OpenCode 有 session DB）覆写契约即获得 observe/接管安全，零 registry 编辑
- 保留两个 legacy 探针注入缝，既有 SessionRegistry/Observe/Rewind 测试原样绿

## #302 Windows 外部写者 cwd 探测（⚠️ 盲修）
**本机无 Windows，PEB 偏移是 x64 已知常量但未在真机验证。** 安全底线卡死：任何读取失败保持今天的 UNKNOWN→假定持有，**绝不下降到 ABSENT**（那是双写）——最坏是「没改善」，不会比现状更不安全。
- `ProcessCwd.kt`：JNA 读进程 PEB 取 cwd（x64；WOW64/失败→null）
- `LiveProcesses`：`codexCwds` 的 Windows 分支与 `externalAgentAt` 的 noLsof 分支接 ProcessCwd，cwd 匹配三值（任一 pid 读不到→UNKNOWN）；老 rollout 的 fd-only 判定仍 UNKNOWN
- **Windows CI job + `ProcessCwd.selfCheck`**：真 windows-latest runner 读自身 cwd 对比 `user.dir`，PEB 偏移错即红——「有反馈再精修」的机制化闭环
- JNA 显式声明（对齐 mordant transitive 的 5.14.0）

## #303 Claude 侧对称优化
- 三份 lsof/pid 枚举拷贝抽 `externalPids`/`cwdsOf` 共享 helper（daemon 后代排除按参数保 `claudeCwds` 现状语义）
- `claudeCwds` 接同款 5s TTL memo
- 探针 **cwd-first**（Claude fd 罕持，省一次 lsof fork）——`agentVerdict` 抽纯函数，3×3 探针结果两序对拍等价
- `TranscriptScanner.resumeSeed`：单遍记忆化提取 title/gitBranch/model/contextTokens；ClaudeBackend 三 accessor 切它（open 三遍→一遍）

## 验证
- protocol / daemon / mobile desktopTest 三端全量绿（daemon 1721+；clean 重跑避开并行干扰）
- 新增/扩展测试：ResumeSeedParity（对拍旧函数）、LiveProcessesProbeOrder（含 Windows cwd 裁决＋两序等价）、LiveProcessesClaudeCwdCache、ProcessCwdWinCwdSelfCheck、CodexScanCache 扩展
- **未做**：#302 的真机验证（等 Windows CI job 首跑）；真机实弹链路仍在 #299 的发版闸上

## 合并顺序
1. 先合 #299
2. 本 PR retarget main
3. #302 的 Windows CI job 首跑结果决定是否需要精修

🤖 Generated with [Claude Code](https://claude.com/claude-code)