### PR TITLE
docs: align public baseline with v1.9.3

### DIFF
--- a/scripts/check-public-content.py
+++ b/scripts/check-public-content.py
@@ -11,7 +11,7 @@ It fails non-zero when:
      alt text, the AI index files and the web manifest;
   2. the agent matrix is not exactly six rows x four capability columns, or any cell disagrees with
      the frozen expectation below;
-  3. the v1.8.0 baseline, the source commit, the Preview label, OpenCode's Full-access statement or
+  3. the v1.9.3 baseline, the source commit, the Preview label, OpenCode's Full-access statement or
      DeepSeek's Limited state drift;
   4. an official Linux DESKTOP binary is implied;
   5. the generated-asset manifest is missing, incomplete, or points at a file that is absent, empty
@@ -109,8 +109,22 @@ EXPECTED_AGENTS = [
 BASELINE_VERSION = "1.9.3"
 SOURCE_COMMIT = "4016673b"
 # Files that must state the baseline and must not carry the previous public version.
-BASELINE_TARGETS = ["README.md", "README.zh-CN.md", "site/index.html", "site/llms.txt"]
+BASELINE_TARGETS = ["README.md", "README.zh-CN.md", "site/index.html", "site/zh/index.html", "site/llms.txt"]
 PREVIOUS_VERSION = r"\b1\.9\.0\b"
+STALE_SOURCE_COMMITS = ["6162816a"]
+BASELINE_PHRASES = {
+    "site/index.html": [
+        f"Capability claims for v{BASELINE_VERSION} were audited against commit",
+        f"v{BASELINE_VERSION} 的公开能力已对照",
+        f"Agent backend capability matrix for v{BASELINE_VERSION}",
+        f"v{BASELINE_VERSION} 的 agent 后端能力矩阵",
+    ],
+    "site/zh/index.html": [
+        f'"softwareVersion": "{BASELINE_VERSION}"',
+        f"<span>v{BASELINE_VERSION}</span>",
+        f"能力核验基线 main @ {SOURCE_COMMIT}",
+    ],
+}
 
 # Release-asset name shapes that would imply an official Linux desktop build.
 LINUX_DESKTOP_ARTIFACTS = r"cc-pocket-desktop-linux|desktop-linux-(?:x86_64|amd64|arm64)|cc-pocket[-_]desktop[^\s\"'<>]*\.(?:AppImage|deb|rpm)"
@@ -287,6 +301,17 @@ def check_facts(sources: dict[str, str]) -> None:
         stale = re.findall(PREVIOUS_VERSION, text)
         if stale:
             fail("baseline", f"{rel} still carries the previous public version 1.9.0 ({len(stale)}x)")
+        for commit in STALE_SOURCE_COMMITS:
+            if commit in text:
+                fail("baseline", f"{rel} still carries stale baseline source commit {commit}")
+
+    for rel, phrases in BASELINE_PHRASES.items():
+        text = sources.get(rel)
+        if text is None:
+            continue
+        for phrase in phrases:
+            if phrase not in text:
+                fail("baseline", f"{rel} is missing required baseline phrase {phrase!r}")
 
     # OpenCode's limitation must be stated where it is claimed, not only in the contract.
     for rel in ("README.md", "site/index.html", "site/llms.txt"):

--- a/site/index.html
+++ b/site/index.html
@@ -347,14 +347,14 @@
       <p class="eyebrow"><span class="i18n-en">Agent support</span><span class="i18n-zh">Agent 支持</span></p>
       <h2><span class="i18n-en">Six backends. Not the same six capabilities.</span><span class="i18n-zh">六个后端，能力并不一样。</span></h2>
       <p>
-        <span class="i18n-en">Capability claims for v1.8.0 were audited against commit <a href="https://github.com/heypandax/cc-pocket/commit/6162816a" class="mono" target="_blank" rel="noopener">6162816a</a> on <span class="mono">main</span>. Machine-readable: <a href="public-capabilities.json" class="mono">public-capabilities.json</a>.</span>
-        <span class="i18n-zh">v1.8.0 的公开能力已对照 <span class="mono">main</span> 分支的 <a href="https://github.com/heypandax/cc-pocket/commit/6162816a" class="mono" target="_blank" rel="noopener">6162816a</a> 提交核验。机器可读版本：<a href="public-capabilities.json" class="mono">public-capabilities.json</a>。</span>
+        <span class="i18n-en">Capability claims for v1.9.3 were audited against commit <a href="https://github.com/heypandax/cc-pocket/commit/4016673b" class="mono" target="_blank" rel="noopener">4016673b</a> on <span class="mono">main</span>. Machine-readable: <a href="public-capabilities.json" class="mono">public-capabilities.json</a>.</span>
+        <span class="i18n-zh">v1.9.3 的公开能力已对照 <span class="mono">main</span> 分支的 <a href="https://github.com/heypandax/cc-pocket/commit/4016673b" class="mono" target="_blank" rel="noopener">4016673b</a> 提交核验。机器可读版本：<a href="public-capabilities.json" class="mono">public-capabilities.json</a>。</span>
       </p>
     </div>
 
     <div class="matrix-wrap reveal">
       <table class="matrix">
-        <caption class="sr-only"><span class="i18n-en">Agent backend capability matrix for v1.8.0: core session, approval and mode, changes and diff, usage.</span><span class="i18n-zh">v1.8.0 的 agent 后端能力矩阵：核心会话、审批与模式、改动与 diff、用量。</span></caption>
+        <caption class="sr-only"><span class="i18n-en">Agent backend capability matrix for v1.9.3: core session, approval and mode, changes and diff, usage.</span><span class="i18n-zh">v1.9.3 的 agent 后端能力矩阵：核心会话、审批与模式、改动与 diff、用量。</span></caption>
         <thead>
           <tr>
             <th scope="col"><span class="i18n-en">Agent</span><span class="i18n-zh">Agent</span></th>

--- a/site/zh/index.html
+++ b/site/zh/index.html
@@ -14,15 +14,15 @@
 {
   "@context": "https://schema.org",
   "@graph": [
-    { "@type": "WebPage", "name": "CC Pocket 中文", "url": "https://heypandax.github.io/cc-pocket/zh/", "description": "CC Pocket 是本地命令行编码 agent 的开源跨设备控制面，v1.8.0 支持六个 agent 后端。", "inLanguage": "zh-CN", "isPartOf": { "@id": "https://heypandax.github.io/cc-pocket/#website" }, "about": { "@id": "https://heypandax.github.io/cc-pocket/#app" }, "dateModified": "2026-08-16" },
-    { "@type": "SoftwareApplication", "@id": "https://heypandax.github.io/cc-pocket/#app", "name": "CC Pocket", "softwareVersion": "1.8.0", "applicationCategory": "DeveloperApplication", "operatingSystem": "iOS, iPadOS, Android, macOS, Windows, Linux, HarmonyOS", "url": "https://heypandax.github.io/cc-pocket/", "downloadUrl": "https://github.com/heypandax/cc-pocket/releases/latest", "description": "在手机、平板或另一台电脑上，掌控跑在自己电脑上的命令行编码 agent：查看进展、处理授权、继续会话、检查改动。", "license": "https://github.com/heypandax/cc-pocket/blob/main/LICENSE", "isAccessibleForFree": true }
+    { "@type": "WebPage", "name": "CC Pocket 中文", "url": "https://heypandax.github.io/cc-pocket/zh/", "description": "CC Pocket 是本地命令行编码 agent 的开源跨设备控制面，v1.9.3 支持六个 agent 后端。", "inLanguage": "zh-CN", "isPartOf": { "@id": "https://heypandax.github.io/cc-pocket/#website" }, "about": { "@id": "https://heypandax.github.io/cc-pocket/#app" }, "dateModified": "2026-08-26" },
+    { "@type": "SoftwareApplication", "@id": "https://heypandax.github.io/cc-pocket/#app", "name": "CC Pocket", "softwareVersion": "1.9.3", "applicationCategory": "DeveloperApplication", "operatingSystem": "iOS, iPadOS, Android, macOS, Windows, Linux, HarmonyOS", "url": "https://heypandax.github.io/cc-pocket/", "downloadUrl": "https://github.com/heypandax/cc-pocket/releases/latest", "description": "在手机、平板或另一台电脑上，掌控跑在自己电脑上的命令行编码 agent：查看进展、处理授权、继续会话、检查改动。", "license": "https://github.com/heypandax/cc-pocket/blob/main/LICENSE", "isAccessibleForFree": true }
   ]
 }
 </script>
 </head>
 <body>
 <nav class="guide-nav"><div class="wrap"><a class="brand" href="./"><span class="brand-mark" aria-hidden="true"></span><span class="wordmark mono">CC Pocket</span></a><div class="guide-links"><a class="manual-link" href="https://pocket.ark-nexus.cc/support/">帮助与客服</a><a href="../manual/zh/">用户手册</a><a href="#指南">指南</a><a href="#安全">安全</a><a class="lang-link" href="../" lang="en" hreflang="en">English</a></div></div></nav>
-<header class="guide-hero"><div class="wrap"><div class="breadcrumbs">CC Pocket / 中文</div><h1>本地编码 agent 的开源跨设备控制面</h1><p class="guide-deck">agent 继续跑在你自己的电脑上；你用手机、平板或另一台电脑查看输出、处理授权、继续同一个会话、检查改动。</p><div class="guide-meta"><span>v1.8.0</span><span>能力核验基线 main @ 6162816a</span><span>MIT 开源</span></div></div></header>
+<header class="guide-hero"><div class="wrap"><div class="breadcrumbs">CC Pocket / 中文</div><h1>本地编码 agent 的开源跨设备控制面</h1><p class="guide-deck">agent 继续跑在你自己的电脑上；你用手机、平板或另一台电脑查看输出、处理授权、继续同一个会话、检查改动。</p><div class="guide-meta"><span>v1.9.3</span><span>能力核验基线 main @ 4016673b</span><span>MIT 开源</span></div></div></header>
 <main class="guide-main">
   <div class="answer-box"><div class="answer-label">一句话说明</div><p>CC Pocket 是命令行编码 agent 的<strong>跨设备控制面</strong>，不是云端 IDE，也不托管模型；代码和 agent 都留在你的电脑上。</p></div>
   <dl class="fact-grid"><div class="fact"><dt>支持后端</dt><dd>六个：Claude Code、OpenAI Codex、OpenCode、Kimi Code（Preview）、ZCode、DeepSeek</dd></div><div class="fact"><dt>信任模型</dt><dd>端到端加密 + 零知识中继</dd></div><div class="fact"><dt>账号</dt><dd>无需 CC Pocket 账号</dd></div></dl>


### PR DESCRIPTION
## Summary
- update the English landing-page baseline and matrix caption to v1.9.3 @ 4016673b
- update the Chinese landing page metadata and visible baseline to v1.9.3
- extend the public-content gate so stale baseline blocks cannot regress silently

## Verification
- `python3 scripts/check-public-content.py`
- `python3 scripts/check-site-seo.py`
- `python3 scripts/check-appstore-content.py`
- `git diff --check`