### PR TITLE
fix: repair Codex/ZCode replay and settings mode group (#310 #312 #313)

### DIFF
--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/codex/CodexPaths.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/codex/CodexPaths.kt
@@ -5,15 +5,17 @@ import java.nio.file.LinkOption
 import java.nio.file.Path
 import java.nio.file.attribute.FileTime
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.io.path.getLastModifiedTime
 import kotlin.io.path.isDirectory
 import kotlin.io.path.isRegularFile
 
 /**
  * Codex stores rollout transcripts under `$CODEX_HOME/sessions` (default `~/.codex/sessions`), nested by
- * date as `YYYY/MM/DD/rollout-<timestamp>-<threadId>.jsonl` (verified against codex 0.124). The threadId in
- * the filename is the resume handle. Unlike Claude's per-project folders, rollouts are global — callers
- * filter by the `cwd` recorded in each file's session_meta line.
+ * date as `YYYY/MM/DD/rollout-<timestamp>-<threadId>.jsonl` (verified against codex 0.124). A resumed
+ * thread may instead continue in `rollout-<timestamp>-<threadId>_<runId>.jsonl`; its `session_meta.id`
+ * remains the logical thread id. Unlike Claude's per-project folders, rollouts are global — callers filter
+ * by the `cwd` recorded in each file's session_meta line.
  *
  * Both listing entry points are on hot paths (the 10-second project refresh lists the whole tree; opening
  * one Codex session looked one id up four times), so both are memoized — see [entriesOf] and [findSession].
@@ -38,34 +40,50 @@ object CodexPaths {
         if (!root.isDirectory()) return emptyList()
         val files = ArrayList<Path>()
         collectRollouts(root, 0, files)
-        return files
+        val sorted = files
             .mapNotNull { p -> runCatching { p.getLastModifiedTime().toMillis() }.getOrNull()?.let { p to it } }
             .sortedByDescending { it.second }
             .take(limit)
             .map { it.first }
+        noteListing(sorted)
+        return sorted
     }
 
     /**
-     * The rollout file for a thread id (filename ends with `-<threadId>.jsonl`).
+     * The newest rollout file for one logical thread id. Codex can leave both the original
+     * `-<threadId>.jsonl` and a resumed `-<threadId>_<runId>.jsonl`; replay/resume must follow the latter
+     * or every message written after the branch/resume disappears from cc-pocket (issue #312).
      *
      * Answered from a lazy id→path index: opening ONE Codex session asks for the same id four times
      * (resumeContextTokens / resumeModel / resumeTitle plus SessionRegistry's own lookup), and each of those
-     * used to walk the entire tree (PR #296 review). Rollouts are never renamed, so a cached hit only has to
-     * still exist; when it doesn't, the entry is dropped and the full walk backfills it.
+     * used to walk the entire tree (PR #296 review). A changed [sessionFiles] path set advances
+     * [listingGeneration], invalidating the cached choice once; the next lookup resolves the newest matching
+     * rollout and the other three accessors stay O(1).
      */
     fun findSession(sessionId: String, root: Path = sessionsRoot()): Path? {
-        idIndex[sessionId]?.let {
-            if (it.isRegularFile()) return it
-            idIndex.remove(sessionId, it) // deleted/archived since — fall through to a fresh walk
+        val generation = listingGeneration.get()
+        idIndex[sessionId]?.let { indexed ->
+            if (indexed.generation == generation && indexed.path.isRegularFile()) return indexed.path
+            if (!indexed.path.isRegularFile()) idIndex.remove(sessionId, indexed)
         }
         if (!root.isDirectory()) return null
-        val suffix = "-$sessionId.jsonl"
         val files = ArrayList<Path>()
         collectRollouts(root, 0, files)
-        // No mtime sort here: this lookup only needs the first name match, not newest-first ordering.
-        val hit = files.firstOrNull { it.fileName.toString().endsWith(suffix) && it.isRegularFile() }
-        if (hit != null) idIndex[sessionId] = hit
+        // A logical thread can have several rollout files. Choose by mtime, exactly like the session-list
+        // scanner does, so the row the user tapped and the file replayed below cannot disagree.
+        val hit = files.asSequence()
+            .filter { matchesSession(it, sessionId) && it.isRegularFile() }
+            .mapNotNull { path -> runCatching { path.getLastModifiedTime().toMillis() }.getOrNull()?.let { path to it } }
+            .maxByOrNull { it.second }
+            ?.first
+        if (hit != null) idIndex[sessionId] = IndexedSession(hit, generation)
         return hit
+    }
+
+    private fun matchesSession(path: Path, sessionId: String): Boolean {
+        val name = path.fileName.toString()
+        return name.endsWith("-$sessionId.jsonl") ||
+            (name.contains("-${sessionId}_") && name.endsWith(".jsonl"))
     }
 
     /** One directory's children plus whether each is itself a directory. `isDir` rides along with the
@@ -75,8 +93,24 @@ object CodexPaths {
 
     private val dirCache = ConcurrentHashMap<Path, Pair<FileTime, List<DirEntry>>>()
 
-    /** id → rollout path, backfilled by [findSession]; validated by existence, never by time. */
-    private val idIndex = ConcurrentHashMap<String, Path>()
+    private data class IndexedSession(val path: Path, val generation: Long)
+
+    /** id → newest rollout path, backfilled by [findSession] for the current [listingGeneration]. */
+    private val idIndex = ConcurrentHashMap<String, IndexedSession>()
+
+    // Only path-set changes matter here. Appends move a file's mtime but keep the cached path correct; a
+    // branch/resume creates a NEW path, which invalidates every logical-id choice exactly once.
+    private val listingGeneration = AtomicLong(0)
+    private var lastListing: Set<Path>? = null
+
+    @Synchronized
+    private fun noteListing(files: List<Path>) {
+        val paths = files.toSet()
+        if (lastListing != paths) {
+            lastListing = paths
+            listingGeneration.incrementAndGet()
+        }
+    }
 
     /**
      * [dir]'s children, re-listed only when its mtime moved. The rollout tree is date-nested, so every
@@ -118,6 +152,8 @@ object CodexPaths {
     internal fun clearForTest() {
         dirCache.clear()
         idIndex.clear()
+        synchronized(this) { lastListing = null }
+        listingGeneration.set(0)
     }
 
     private const val MAX_DEPTH = 8

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/zcode/ZCodeTranscriptProjection.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/zcode/ZCodeTranscriptProjection.kt
@@ -1,0 +1,32 @@
+package dev.ccpocket.daemon.zcode
+
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+/**
+ * Projects ZCode's persisted user rows onto the human conversation timeline.
+ *
+ * ZCode 3.7.6 deliberately stores compact summaries and post-compact reminders as `role=user` because
+ * they remain provider context. They are not user input: the official store marks them synthetic and/or
+ * `semantics.origin=agent_runtime`, `kind=compact_summary`, `transcriptVisibility=hidden`. Older summary
+ * rows may have only the top-level `summary` marker. Prefer those structural facts over inspecting the
+ * text — a real user is still free to paste XML or discuss summaries verbatim (#313).
+ */
+internal object ZCodeTranscriptProjection {
+    fun isVisibleUserRow(message: JsonObject): Boolean {
+        if (message["summary"] != null && message["summary"] !is JsonNull) return false
+        if (message.bool("synthetic") || message.str("visibility") == "model-only") return false
+
+        val semantics = message["semantics"] as? JsonObject ?: return true // legacy real-user row
+        if (semantics.str("kind") == "compact_summary") return false
+        if (semantics.str("uiVisibility") == "hidden" || semantics.str("transcriptVisibility") == "hidden") {
+            return false
+        }
+        return semantics.str("origin") == "real_user"
+    }
+
+    private fun JsonObject.str(key: String): String? = (this[key] as? JsonPrimitive)?.contentOrNull
+    private fun JsonObject.bool(key: String): Boolean = str(key)?.toBooleanStrictOrNull() == true
+}

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/zcode/ZCodeTranscriptReplay.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/zcode/ZCodeTranscriptReplay.kt
@@ -25,6 +25,7 @@ object ZCodeTranscriptReplay {
             ms.executeQuery().use { mr -> while (mr.next()) {
                 val msg = parse(mr.getString("data")) ?: continue
                 val role = when (msg.str("role")) { "user" -> ChatRole.USER; "assistant" -> ChatRole.ASSISTANT; else -> continue }
+                if (role == ChatRole.USER && !ZCodeTranscriptProjection.isVisibleUserRow(msg)) continue
                 val text = StringBuilder()
                 // harness injections (system-reminder / task-notification blocks, the resume nudge)
                 // are plumbing, not the user talking — same judgement the claude replay uses (#253)

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/zcode/ZCodeTranscriptScanner.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/zcode/ZCodeTranscriptScanner.kt
@@ -80,16 +80,18 @@ object ZCodeTranscriptScanner {
         return null
     }
 
-    /** Text parts of [role]'s messages, oldest first. User rows are screened through the shared noise
-     *  judgement so a harness injection (system-reminder / task-notification) never becomes the list
-     *  preview — the same filter the replay applies (issue #253). */
+    /** Text parts of [role]'s messages, oldest first. ZCode's own visibility semantics remove compact
+     *  summaries/model-only rows first (#313); the shared noise judgement then catches legacy harness
+     *  injections so neither can become the list preview (#253). The replay applies the same two gates. */
     internal fun messageParts(conn: Connection, sid: String, role: String): List<String> {
         val out = mutableListOf<String>()
         val user = role == "user"
         conn.prepareStatement("SELECT m.id,m.data FROM message m WHERE m.session_id=? ORDER BY m.sequence,m.time_created").use { ms ->
             ms.setString(1, sid)
             ms.executeQuery().use { mr -> while (mr.next()) {
-                if (parse(mr.getString("data"))?.str("role") != role) continue
+                val message = parse(mr.getString("data")) ?: continue
+                if (message.str("role") != role) continue
+                if (user && !ZCodeTranscriptProjection.isVisibleUserRow(message)) continue
                 conn.prepareStatement("SELECT data FROM part WHERE session_id=? AND message_id=? ORDER BY sequence,time_created").use { ps ->
                     ps.setString(1, sid); ps.setString(2, mr.getString("id"))
                     ps.executeQuery().use { pr -> while (pr.next()) {

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/codex/CodexScanCacheTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/codex/CodexScanCacheTest.kt
@@ -167,6 +167,18 @@ class CodexScanCacheTest {
             .also { it.writeText("""{"timestamp":"t0","type":"session_meta","payload":{"id":"$id","cwd":"/repo"}}""") }
     }
 
+    private fun continuation(root: Path, id: String, runId: String): Path {
+        val leaf = root.resolve("2026/08/25")
+        Files.createDirectories(leaf)
+        return leaf.resolve("rollout-2026-08-25T01-00-00-${id}_$runId.jsonl")
+            .also {
+                it.writeText(
+                    """{"timestamp":"t0","type":"session_meta","payload":{"id":"$id","cwd":"/repo"}}""" + "\n" +
+                        """{"timestamp":"t1","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"post-branch turn"}]}}""",
+                )
+            }
+    }
+
     @Test
     fun a_settled_directory_is_listed_once_and_relisted_when_its_mtime_moves() {
         val root = Files.createDirectory(tmp.resolve("settled-root"))
@@ -218,5 +230,29 @@ class CodexScanCacheTest {
         // …and the index is validated by existence, so a deleted rollout falls back to the walk and misses
         Files.delete(file)
         assertNull(CodexPaths.findSession("thr-idx", root))
+    }
+
+    @Test
+    fun findSession_follows_the_newest_continuation_after_a_listing_refresh() {
+        // issue #312, copied from the real Codex Desktop shape:
+        //   rollout-<ts>-<threadId>.jsonl
+        //   rollout-<ts>-<threadId>_<runId>.jsonl
+        // Both headers keep the SAME logical thread id. The second file owns every post-branch turn.
+        val root = Files.createDirectory(tmp.resolve("continuation-root"))
+        val original = tree(root, "thr-branch")
+        Files.setLastModifiedTime(original, FileTime.fromMillis(1_000_000))
+
+        CodexPaths.sessionFiles(root = root)
+        assertEquals(original, CodexPaths.findSession("thr-branch", root))
+
+        val resumed = continuation(root, "thr-branch", "run-2")
+        Files.setLastModifiedTime(resumed, FileTime.fromMillis(2_000_000))
+        // The session-list refresh observes a new path and invalidates the old id→file choice. The next
+        // replay lookup must converge on the same newest file the list row represents.
+        CodexPaths.sessionFiles(root = root)
+
+        val found = CodexPaths.findSession("thr-branch", root)
+        assertEquals(resumed, found)
+        assertEquals("post-branch turn", CodexTranscriptReplay.read(found!!).single().text)
     }
 }

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/zcode/ZCodeTranscriptTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/zcode/ZCodeTranscriptTest.kt
@@ -78,4 +78,56 @@ class ZCodeTranscriptTest {
         assertEquals(true, history[2].ok)
         assertEquals("/repo", history[2].output)
     }
+
+    /** Exact compact-summary and reminder semantics from the official ZCode 3.7.6 store. */
+    private fun compactedDatabase(): Connection = database().also { db ->
+        db.createStatement().use { st ->
+            st.execute("INSERT INTO session VALUES('s3','/compact','Compacted','3.7.6',2000,NULL,'interactive',NULL)")
+            st.execute(
+                """INSERT INTO message VALUES('c1','s3',1,1,'{"role":"user","semantics":{"origin":"real_user","kind":"slash_command","commandName":"compact","uiVisibility":"visible","providerVisibility":"visible","transcriptVisibility":"visible"}}',1)""",
+            )
+            st.execute("""INSERT INTO part VALUES('cp1','c1','s3',1,1,'{"type":"text","text":"/compact"}',1)""")
+            st.execute(
+                """INSERT INTO message VALUES('c2','s3',2,2,'{"role":"user","summary":{"title":"Compact summary","body":"internal"},"semantics":{"origin":"agent_runtime","kind":"compact_summary","uiVisibility":"hidden","providerVisibility":"visible","transcriptVisibility":"hidden"}}',2)""",
+            )
+            st.execute("""INSERT INTO part VALUES('cp2','c2','s3',2,2,'{"type":"text","text":"<summary>large internal compact prompt</summary>","synthetic":true}',1)""")
+            st.execute("""INSERT INTO part VALUES('cp3','c2','s3',2,2,'{"type":"compaction","trigger":"manual"}',2)""")
+            st.execute(
+                """INSERT INTO message VALUES('c3','s3',3,3,'{"role":"user","synthetic":true,"visibility":"model-only","semantics":{"origin":"agent_runtime","kind":"system_reminder","source":"compact_reminder","uiVisibility":"hidden","providerVisibility":"visible","transcriptVisibility":"hidden"}}',3)""",
+            )
+            st.execute("""INSERT INTO part VALUES('cp4','c3','s3',3,3,'{"type":"text","text":"<context>internal post-compact reminder</context>","synthetic":true}',1)""")
+            // Old ZCode rows can carry the authoritative summary marker without the newer semantics object.
+            st.execute(
+                """INSERT INTO message VALUES('c4','s3',4,4,'{"role":"user","summary":{"title":"Compact summary","body":"legacy"}}',4)""",
+            )
+            st.execute("""INSERT INTO part VALUES('cp5','c4','s3',4,4,'{"type":"text","text":"legacy compact body"}',1)""")
+            st.execute(
+                """INSERT INTO message VALUES('c5','s3',5,5,'{"role":"user","semantics":{"origin":"real_user","kind":"user_prompt","uiVisibility":"visible","providerVisibility":"visible","transcriptVisibility":"visible"}}',5)""",
+            )
+            st.execute("""INSERT INTO part VALUES('cp6','c5','s3',5,5,'{"type":"text","text":"why is <summary> visible?"}',1)""")
+            st.execute(
+                """INSERT INTO message VALUES('c6','s3',6,6,'{"role":"assistant","semantics":{"origin":"agent_runtime","kind":"assistant_response","uiVisibility":"visible","providerVisibility":"visible","transcriptVisibility":"visible"}}',6)""",
+            )
+            st.execute("""INSERT INTO part VALUES('cp7','c6','s3',6,6,'{"type":"text","text":"done"}',1)""")
+        }
+    }
+
+    @Test
+    fun `replay hides compact plumbing but keeps literal real user XML`() {
+        val history = ZCodeTranscriptReplay.readFrom(compactedDatabase(), "s3")
+
+        assertEquals(listOf(ChatRole.USER, ChatRole.USER, ChatRole.ASSISTANT), history.map { it.role })
+        assertEquals(listOf("/compact", "why is <summary> visible?", "done"), history.map { it.text })
+        assertFalse(history.any { "internal" in it.text || "legacy compact" in it.text })
+    }
+
+    @Test
+    fun `scanner user projection excludes compact plumbing`() {
+        val db = compactedDatabase()
+
+        assertEquals(
+            listOf("/compact", "why is <summary> visible?"),
+            ZCodeTranscriptScanner.messageParts(db, "s3", "user"),
+        )
+    }
 }

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/Settings.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/Settings.kt
@@ -406,13 +406,13 @@ private fun AgentDefaultsPage(repo: PocketRepository) {
     )
 
     SectionLabel(stringResource(Res.string.default_mode_section))
-    Column(Modifier.fillMaxWidth()) {
+    Column(Modifier.settingsChoiceContainer()) {
         val modeOptions = MODES + if (
             defaultAgent == AgentKind.CLAUDE &&
             repo.supportsPermissionMode(CLAUDE_PERMISSION_MODE_AUTO)
         ) listOf(AUTO_MODE) else emptyList()
-        modeOptions.forEach { m ->
-            Hairline()
+        modeOptions.forEachIndexed { index, m ->
+            if (index > 0) Hairline(Modifier.padding(horizontal = 12.dp))
             val sel = repo.defaultMode.value == m.key && effectivePermissionMode == m.nativeMode
             Row(
                 Modifier.fillMaxWidth().heightIn(min = 48.dp)
@@ -420,7 +420,7 @@ private fun AgentDefaultsPage(repo: PocketRepository) {
                     .clickable {
                         if (m.nativeMode == CLAUDE_PERMISSION_MODE_AUTO) repo.setDefaultAutoMode()
                         else repo.setDefaultMode(m.key)
-                    }.padding(vertical = 12.dp),
+                    }.padding(horizontal = 12.dp, vertical = 10.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text("●", color = m.color, fontSize = 9.sp, modifier = Modifier.padding(end = 10.dp))
@@ -431,7 +431,6 @@ private fun AgentDefaultsPage(repo: PocketRepository) {
                 if (sel) Text("✓", color = Tok.accent, fontSize = 13.5.sp)
             }
         }
-        Hairline()
     }
 
     SectionLabel("${stringResource(Res.string.default_model_section)} · ${agentName(defaultAgent)}")
@@ -1234,10 +1233,7 @@ private fun <T> SettingsChoiceRows(
     monospace: (T) -> Boolean = { false },
     onPick: (T) -> Unit,
 ) {
-    Column(
-        Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp)).background(Tok.surface)
-            .border(1.dp, Tok.hair, RoundedCornerShape(10.dp)),
-    ) {
+    Column(Modifier.settingsChoiceContainer()) {
         options.forEachIndexed { index, opt ->
             if (index > 0) Hairline(Modifier.padding(horizontal = 12.dp))
             val sel = selected == opt
@@ -1260,6 +1256,11 @@ private fun <T> SettingsChoiceRows(
         }
     }
 }
+
+/** Shared card language for the peer choice groups on Agent & session defaults (#310). */
+private fun Modifier.settingsChoiceContainer(): Modifier =
+    fillMaxWidth().clip(RoundedCornerShape(10.dp)).background(Tok.surface)
+        .border(1.dp, Tok.hair, RoundedCornerShape(10.dp))
 
 /**
  * A settings row with a title + subtitle on the left and a Switch on the right.


### PR DESCRIPTION
## Summary

- hide ZCode compact summaries and reminders from the user transcript while preserving real prompts (#313)
- align the mobile Agent and session default mode choices with the grouped-card settings style (#310)
- make Codex resumed branch sessions follow the newest rollout file so post-branch turns remain visible after reopening (#312)

## Validation

- targeted daemon Codex/ZCode tests passed
- targeted mobile SettingsIaTest passed
- full daemon suite passed with per-class fork isolation
- protocol, relay, and mobile test suites passed
- git diff --check passed
- development device/FIR validation completed before release preparation

## Release boundary

Keep the issues open until v1.9.4 artifacts and affected platform paths are formally verified. The existing affected-mode helper has a pre-existing shell interpolation defect, so the equivalent full suites were used for release evidence.