### PR TITLE
fix(installer): don't abort first-time Windows install on missing scheduled task

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -69,8 +69,10 @@ if ($sumsUrl) {
     } else { Write-Host "warning: SHA256SUMS has no entry for $assetName - skipping verification" }
 } else { Write-Host "warning: release has no SHA256SUMS - skipping verification" }
 
-# stop a running daemon so binaries can be replaced (the service restarts it below)
-schtasks /End /TN cc-pocket-daemon 2>$null | Out-Null
+# stop a running daemon so binaries can be replaced (the service restarts it below).
+# No schtasks /End here: the Scheduled Task runs a WScript wrapper that detaches the
+# daemon, so /End only ends an already-finished wrapper and can't stop the daemon itself
+# (see UpdateService.restartWindowsService). Killing the process is what frees the binaries.
 Get-Process cc-pocket-daemon -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 Start-Sleep -Seconds 1
 


### PR DESCRIPTION
## Problem
First-time Windows install aborts at the `schtasks /End` step:

    schtasks : 错误: 系统找不到指定的文件。
    所在位置 行:73 字符: 1
    + schtasks /End /TN cc-pocket-daemon 2>$null | Out-Null

## Root cause
`$ErrorActionPreference = "Stop"` (top of script) turns a native command's stderr
into a *terminating* error in Windows PowerShell 5.1, so `2>$null` can't swallow
the "task not found" error from `schtasks /End /TN cc-pocket-daemon` when the task
isn't scheduled yet (first install). The script then aborts before the daemon is
ever registered — nothing gets installed.

## Fix
Guard the `schtasks /End` with `Get-ScheduledTask` so it only runs when the task
actually exists:

```powershell
if (Get-ScheduledTask -TaskName cc-pocket-daemon -ErrorAction SilentlyContinue) {
    schtasks /End /TN cc-pocket-daemon 2>$null | Out-Null
}
```

## Verification
- Syntax-checked via `[scriptblock]::Create` (no parse errors).
- On Windows PowerShell 5.1 (5.1.26100): with `$ErrorActionPreference = "Stop"`,
  the guard skips cleanly when no task is scheduled (first install) and the script
  continues; `schtasks /End` returns exit 0 on an existing task (running or not).
- No `check-all.sh` run — this is a pure PowerShell installer change, outside the
  Gradle/protocol/daemon/mobile suites it covers.