### PR TITLE
fix(codex): release session writer after turns (#316)

### DIFF
--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/agent/AgentIo.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/agent/AgentIo.kt
@@ -24,4 +24,8 @@ class AgentIo(
      * has nowhere meaningful to go. Default no-op for the stdio backends, which never need it.
      */
     val inject: suspend (String) -> Unit = {},
+    /** Ask the owner to end this process after a provider-defined stable boundary. The callback launches
+     * the bounded graceful-shutdown ladder off the stdout pump; default no-op keeps backend unit tests and
+     * long-running providers unchanged. Codex uses it after turn/completed to release its cross-app writer. */
+    val requestProcessExit: () -> Unit = {},
 )

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/agent/AgentProcess.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/agent/AgentProcess.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.TimeUnit
@@ -52,6 +54,7 @@ class AgentProcess private constructor(
 
     /** Every write (prompt / allow / deny / rpc) funnels through this one writer -> no interleaving. */
     private val stdin: Channel<String> = Channel(capacity = 64)
+    private val shutdownLock = Mutex()
 
     // completed when the stderr pump has read its pipe to EOF — the OS exit alone does NOT imply
     // lastStderr is populated yet (the reader coroutine may not have been scheduled), and a startup
@@ -153,7 +156,7 @@ class AgentProcess private constructor(
         eofGraceMs: Long = EOF_GRACE_MS,
         termGraceMs: Long = TERM_GRACE_MS,
         forceGraceMs: Long = FORCE_GRACE_MS,
-    ) {
+    ) = shutdownLock.withLock {
         stdin.close()
         runCatching { process.outputStream.close() } // EOF — the CLI's stream-json shutdown signal
         var exited = withContext(Dispatchers.IO) { process.waitFor(eofGraceMs, TimeUnit.MILLISECONDS) }

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/codex/CodexBackend.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/codex/CodexBackend.kt
@@ -4,6 +4,7 @@ import dev.ccpocket.protocol.TokenUsage
 import dev.ccpocket.daemon.agent.AgentBackend
 import dev.ccpocket.daemon.agent.AgentEvent
 import dev.ccpocket.daemon.agent.AgentIo
+import dev.ccpocket.daemon.agent.AgentProcessMode
 import dev.ccpocket.daemon.agent.AgentSpec
 import dev.ccpocket.daemon.util.logger
 import dev.ccpocket.protocol.AgentKind
@@ -43,7 +44,7 @@ class CodexBackend(
     private val log = logger("CodexBackend")
     private val json = Json { ignoreUnknownKeys = true; isLenient = true }
     private val idSeq = AtomicLong(1)
-    private val bootstrap = Mutex() // guards threadId + pendingPrompt so the first turn is never lost to a race
+    private val bootstrap = Mutex() // guards thread/process state so prompts and the stable-turn exit cannot cross
 
     @Volatile private var io: AgentIo? = null
     @Volatile private var resolvedExe: Path? = null // codex binary, resolved lazily on first launch
@@ -58,17 +59,21 @@ class CodexBackend(
     @Volatile private var threadId: String? = null
     @Volatile private var currentTurnId: String? = null
     private var pendingPrompt: Prompt? = null // buffered first turn (guarded by [bootstrap])
+    private var phase = ProcessPhase.OPENING // guarded by [bootstrap]
+    private var startingTurn = false // turn/start selected but turn/started has not landed (guarded by [bootstrap])
+    private var promptWriteInFlight = 0 // closes sendPrompt selection -> JSON-RPC registration race (guarded by [bootstrap])
     private var pendingCompact = false // /compact may arrive while thread resume/fork is still handshaking
     private var pendingReview: String? = null // empty marker = uncommitted-changes review
 
     // JSON-RPC id correlation: which of our outstanding requests this id belongs to
     @Volatile private var initializeId: Long = -1
     @Volatile private var threadOpenId: Long = -1
+    @Volatile private var threadOpenOperation: String = "start"
     // Outstanding writes whose ERROR response must not be swallowed (PR #296 review): a steer that raced
     // turn completion retries as turn/start, a rejected turn/start settles the turn it never started, and
     // a control-plane op reports its failure instead of no-oping. Cleared on the success response.
     private val pendingSteers = ConcurrentHashMap<Long, SteerAttempt>() // turn/steer id → what rode it
-    private val pendingStarts = ConcurrentHashMap.newKeySet<Long>() // turn/start ids in flight
+    private val pendingStarts = ConcurrentHashMap<Long, Prompt>() // turn/start id → prompt (for rejection receipt)
     private val pendingControls = ConcurrentHashMap<Long, String>() // compact/review id → op label
     // Prompts that arrived mid-turn but can't ride turn/steer (it has no image transport — Tier C):
     // parked until the turn boundary instead of silently dropping their images (PR #296 re-review).
@@ -88,8 +93,16 @@ class CodexBackend(
 
     private data class Prompt(val text: String, val images: List<ImageData>)
     private data class Usage(val input: Long = 0, val output: Long = 0, val cached: Long = 0)
+    private enum class ProcessPhase { OPENING, READY, EXITING }
+    private sealed interface PromptAction {
+        data class Start(val prompt: Prompt) : PromptAction
+        data class Steer(val prompt: Prompt, val turnId: String) : PromptAction
+    }
 
     override val kind: AgentKind = AgentKind.CODEX
+    // A live app-server owns the rollout across applications even while idle on newer Codex builds.
+    // End it after each stable turn; Conversation treats that clean exit as normal and lazily resumes.
+    override val processMode: AgentProcessMode get() = AgentProcessMode.ONE_SHOT_TURN
 
     // app-server exposes compaction and review as control-plane RPCs (thread/compact/start, review/start)
     override val supportsNativeCompact: Boolean get() = true
@@ -111,7 +124,12 @@ class CodexBackend(
         this.serviceTier = normalizeServiceTier(spec.model, spec.serviceTier)
         // reset per-process protocol state (this runs on every (re)launch)
         threadId = null; currentTurnId = null
-        bootstrap.withLock { pendingPrompt = null; pendingCompact = false; pendingReview = null }
+        bootstrap.withLock {
+            pendingPrompt = null; pendingCompact = false; pendingReview = null
+            phase = ProcessPhase.OPENING
+            startingTurn = false
+            promptWriteInFlight = 0
+        }
         lastAgentText = null; lastErrorText = null; lastUsage = Usage(); usageSeen = false
         deltaSeen.clear(); fileChangePaths.clear(); fileChangeDiffs.clear(); pendingApprovals.clear()
         pendingSteers.clear(); pendingStarts.clear(); pendingControls.clear()
@@ -145,8 +163,10 @@ class CodexBackend(
 
     private suspend fun handleResponse(idEl: JsonElement?, result: JsonElement?): List<AgentEvent> {
         val id = (idEl as? JsonPrimitive)?.longOrNull
-        if (id != null) { pendingSteers.remove(id); pendingStarts.remove(id); pendingControls.remove(id) }
-        return when (id) {
+        val completedSteer = if (id != null) pendingSteers.remove(id) else null
+        val completedStart = if (id != null) pendingStarts.remove(id) else null
+        val completedControl = if (id != null) pendingControls.remove(id) else null
+        val events = when (id) {
             initializeId -> {
                 rpcNotify("initialized", null)
                 openThread()
@@ -155,6 +175,14 @@ class CodexBackend(
             threadOpenId -> onThreadReady(result as? JsonObject)
             else -> emptyList()
         }
+        // A steer may be accepted just as its turn completes. turn/completed deliberately waits while the
+        // steer response is outstanding; once success lands there is no next turn to start, so release now.
+        // Compact is a bounded control operation and emits no turn/completed of its own. Review does start
+        // a real turn, so its successful response deliberately waits for that turn's terminal notification.
+        if (completedSteer != null || completedStart != null || completedControl == "compact") {
+            maybeRequestProcessExit()
+        }
+        return events
     }
 
     /**
@@ -175,7 +203,7 @@ class CodexBackend(
             return emptyList()
         }
         pendingSteers.remove(id)?.let { attempt ->
-            if (currentTurnId == attempt.expectedTurnId) {
+            if (bootstrap.withLock { currentTurnId == attempt.expectedTurnId }) {
                 // Rejected while — by this pipe's own ordering — the steered turn is STILL running (its
                 // turn/completed would have been processed before this response). Not staleness: a blind
                 // turn/start retry would hit the active-writer conflict and its rejection would falsely
@@ -187,26 +215,53 @@ class CodexBackend(
             // the correct delivery now. One bounded hop — the retry registers in [pendingStarts], so a
             // second rejection surfaces below instead of looping.
             log.info("codex steer rejected (${msg.take(120)}) — re-delivering as turn/start")
-            writeTurnStart(attempt.prompt.text, attempt.prompt.images)
+            deliverPrompt(attempt.prompt)
             return emptyList()
         }
-        if (pendingStarts.remove(id)) {
+        pendingStarts.remove(id)?.let { rejected ->
             // Conversation marked the turn executing when it acked this prompt; only a TurnResult clears
-            // that. Settle the turn the server never started, and say so where the user can see it.
-            return listOf(AgentEvent.TurnResult("⚠️ Codex rejected the prompt: $msg", usage = null, isError = true))
+            // that. The correlated prompt is also a consumption receipt: without it, the deliberate clean
+            // process exit would classify this visible rejection as a lost write and auto-reinject it.
+            bootstrap.withLock { startingTurn = false }
+            maybeRequestProcessExit()
+            return listOf(
+                AgentEvent.UserReplay(rejected.text),
+                AgentEvent.TurnResult("⚠️ Codex rejected the prompt: $msg", usage = null, isError = true),
+            )
         }
         pendingControls.remove(id)?.let { op ->
+            // A rejected control cannot produce a later terminal notification. Release the idle writer now;
+            // the visible error below remains the operation's final result.
+            maybeRequestProcessExit()
             return listOf(AgentEvent.AssistantText("⚠️ Codex /$op failed: $msg"))
         }
         if (id == threadOpenId) {
             // Deliberately NO silent thread/resume fallback for a failed fork: fork exists so a take-over
             // never becomes a second writer on a rollout another codex may still own. Surface it instead —
             // a buffered first prompt would otherwise wait forever behind a thread that will never open.
-            val op = if (resumeId == null) "start" else if (forkSession) "fork" else "resume"
-            return listOf(AgentEvent.TurnResult("⚠️ Codex could not $op this session: $msg", usage = null, isError = true))
+            val op = threadOpenOperation
+            val rejected = bootstrap.withLock {
+                phase = ProcessPhase.EXITING
+                startingTurn = false
+                pendingPrompt.also { pendingPrompt = null }
+                    .also { queuedStarts.clear() }
+            }
+            io?.requestProcessExit?.invoke()
+            return listOfNotNull(
+                rejected?.let { AgentEvent.UserReplay(it.text) },
+                AgentEvent.TurnResult("⚠️ Codex could not $op this session: $msg", usage = null, isError = true),
+            )
         }
         if (id == initializeId) {
-            return listOf(AgentEvent.TurnResult("⚠️ Codex failed to initialize: $msg", usage = null, isError = true))
+            val rejected = bootstrap.withLock {
+                phase = ProcessPhase.EXITING
+                pendingPrompt.also { pendingPrompt = null }
+            }
+            io?.requestProcessExit?.invoke()
+            return listOfNotNull(
+                rejected?.let { AgentEvent.UserReplay(it.text) },
+                AgentEvent.TurnResult("⚠️ Codex failed to initialize: $msg", usage = null, isError = true),
+            )
         }
         log.warn("codex error: $error")
         return emptyList()
@@ -214,8 +269,10 @@ class CodexBackend(
 
     private suspend fun openThread() {
         val rid = resumeId
-        threadOpenId = if (rid != null) {
-            rpcRequest(if (forkSession) "thread/fork" else "thread/resume", buildJsonObject {
+        val operation = if (rid == null) "start" else if (forkSession) "fork" else "resume"
+        threadOpenOperation = operation
+        if (rid != null) {
+            rpcRequest("thread/$operation", register = { threadOpenId = it }, params = buildJsonObject {
                 put("threadId", rid)
                 // thread/fork and thread/resume accept the same relevant overrides in the v2 app-server
                 // protocol (probe-codex-wire.py proves fork on 0.145.0 already — mints a new thread id with
@@ -226,7 +283,7 @@ class CodexBackend(
                 serviceTier?.let { put("serviceTier", it) }
             })
         } else {
-            rpcRequest("thread/start", buildJsonObject {
+            rpcRequest("thread/start", register = { threadOpenId = it }, params = buildJsonObject {
                 put("cwd", workdir)
                 put("approvalPolicy", approvalPolicy())
                 put("sandbox", sandbox().flat) // thread/start takes the flat SandboxMode string
@@ -242,7 +299,9 @@ class CodexBackend(
         result.str("model")?.let { model = it }
         val flush = bootstrap.withLock {
             threadId = tid
+            phase = ProcessPhase.READY
             val prompt = pendingPrompt.also { pendingPrompt = null }
+            startingTurn = prompt != null
             val compact = pendingCompact.also { pendingCompact = false }
             val review = pendingReview.also { pendingReview = null }
             Triple(prompt, compact, review)
@@ -251,6 +310,32 @@ class CodexBackend(
         if (flush.second) requestCompact(tid)
         flush.third?.let { requestReview(tid, it) }
         return listOf(AgentEvent.SessionInit(sessionId = tid, cwd = workdir, model = result.str("model")))
+    }
+
+    /** Newer app-server builds retain the rollout's exclusive writer after thread/unsubscribe. A clean
+     * process exit is the only version-stable handoff boundary. Flip [phase] before asking Conversation to
+     * close the pipe: a prompt racing this edge stays in its delivery ledger and is re-injected by the
+     * clean one-shot exit path instead of being written into a dying process. */
+    private suspend fun maybeRequestProcessExit() {
+        val shouldExit = bootstrap.withLock {
+            if (
+                phase == ProcessPhase.READY &&
+                currentTurnId == null &&
+                !startingTurn &&
+                promptWriteInFlight == 0 &&
+                pendingPrompt == null &&
+                queuedStarts.isEmpty() &&
+                pendingSteers.isEmpty() &&
+                pendingStarts.isEmpty() &&
+                pendingControls.isEmpty()
+            ) {
+                phase = ProcessPhase.EXITING
+                true
+            } else {
+                false
+            }
+        }
+        if (shouldExit) io?.requestProcessExit?.invoke()
     }
 
     // ---- inbound: server notifications ----
@@ -262,7 +347,10 @@ class CodexBackend(
                 if (threadId == null) onThreadReady(buildJsonObject { params.obj("thread")?.let { put("thread", it) } }) else emptyList()
             }
             "turn/started" -> {
-                currentTurnId = params.obj("turn")?.str("id")
+                bootstrap.withLock {
+                    currentTurnId = params.obj("turn")?.str("id")
+                    startingTurn = false
+                }
                 lastErrorText = null // a stale between-turns error must not be billed to this new turn
                 emptyList()
             }
@@ -285,8 +373,14 @@ class CodexBackend(
             }
             "turn/completed" -> {
                 val events = onTurnCompleted(params.obj("turn"))
-                // one parked image-prompt per boundary: it becomes the NEXT turn; any others wait their own
-                bootstrap.withLock { queuedStarts.removeFirstOrNull() }?.let { writeTurnStart(it.text, it.images) }
+                // One parked prompt per boundary becomes the NEXT turn. If none exists, end this app-server
+                // process so another app can own the rollout immediately (#316).
+                val next = bootstrap.withLock {
+                    currentTurnId = null
+                    startingTurn = false
+                    queuedStarts.removeFirstOrNull()?.also { startingTurn = true }
+                }
+                if (next != null) writeTurnStart(next.text, next.images) else maybeRequestProcessExit()
                 events
             }
             "error" -> {
@@ -306,6 +400,16 @@ class CodexBackend(
         item ?: return emptyList()
         val id = item.str("id")
         return when (item.str("type")) {
+            "userMessage" -> {
+                // This is app-server's consumption receipt. Conversation's unconsumed-prompt ledger needs
+                // the exact text before a deliberate post-turn process exit, or it would re-inject an
+                // already-completed prompt into the next app-server and duplicate the turn.
+                val text = item.arr("content")
+                    ?.mapNotNull { (it as? JsonObject)?.takeIf { part -> part.str("type") == "text" }?.str("text") }
+                    ?.joinToString("")
+                    ?: ""
+                listOf(AgentEvent.UserReplay(text))
+            }
             "commandExecution" -> listOf(
                 AgentEvent.AssistantToolUse(id, "Bash", buildJsonObject {
                     item.str("command")?.let { put("command", it) }
@@ -366,7 +470,6 @@ class CodexBackend(
         )
         lastAgentText = null
         lastErrorText = null
-        currentTurnId = null
         deltaSeen.clear()
         fileChangePaths.clear(); fileChangeDiffs.clear() // approvals for this turn are resolved by now — don't accumulate
         return listOf(ev)
@@ -426,29 +529,67 @@ class CodexBackend(
     // ---- outbound (called by Conversation) ----
 
     override suspend fun sendPrompt(text: String, images: List<ImageData>) {
-        val promptText = text // expansion happens at Conversation's prompt boundary (expandSlashPrompt)
-        val ready = bootstrap.withLock {
-            if (threadId == null) { pendingPrompt = Prompt(promptText, images); false } else true
-        }
-        if (ready) {
-            val activeTurn = currentTurnId
-            when {
-                activeTurn != null && images.isNotEmpty() -> {
-                    // turn/steer has no image transport (Tier C): steering would silently drop the images
-                    // and answer the question without them. Park the whole prompt for the turn boundary —
-                    // delivered as its own turn/start from onTurnCompleted's drain, images intact.
-                    bootstrap.withLock { queuedStarts.addLast(Prompt(promptText, images)) }
-                    // The turn can complete between the activeTurn read and the enqueue — then no future
-                    // turn/completed exists to drain this. Re-check and drain ourselves; the lock makes
-                    // the two drains take each prompt exactly once.
-                    if (currentTurnId == null) {
-                        bootstrap.withLock { queuedStarts.removeFirstOrNull() }?.let { writeTurnStart(it.text, it.images) }
+        // Expansion happens at Conversation's prompt boundary (expandSlashPrompt).
+        deliverPrompt(Prompt(text, images))
+    }
+
+    /** Select under the same mutex that finishes a turn and requests process exit. This is the key #316
+     * invariant: a prompt either reserves this live process first, or stays solely in Conversation's
+     * delivery ledger for the clean-exit relaunch — it is never written into a dying app-server. */
+    private suspend fun deliverPrompt(prompt: Prompt) {
+        val action = bootstrap.withLock {
+            when (phase) {
+                ProcessPhase.OPENING -> {
+                    bufferPrompt(prompt)
+                    null
+                }
+                ProcessPhase.EXITING -> null // Conversation's ledger re-injects it after the clean exit
+                ProcessPhase.READY -> {
+                    val activeTurn = currentTurnId
+                    when {
+                        activeTurn != null && prompt.images.isNotEmpty() -> {
+                            // turn/steer has no image transport (Tier C): preserve the whole prompt and
+                            // start it at the boundary instead of silently dropping its images.
+                            queuedStarts.addLast(prompt)
+                            null
+                        }
+                        activeTurn != null -> {
+                            // Reserve the pipe before releasing the mutex. turn/completed can otherwise
+                            // select process exit in the tiny gap before writeTurnSteer registers its id.
+                            promptWriteInFlight += 1
+                            PromptAction.Steer(prompt, activeTurn)
+                        }
+                        startingTurn -> {
+                            // turn/start is accepted asynchronously; until turn/started supplies its id,
+                            // a second turn/start would collide with that writer. Preserve this as next turn.
+                            queuedStarts.addLast(prompt)
+                            null
+                        }
+                        else -> {
+                            startingTurn = true
+                            PromptAction.Start(prompt)
+                        }
                     }
                 }
-                activeTurn != null -> writeTurnSteer(promptText, images, activeTurn)
-                else -> writeTurnStart(promptText, images)
             }
         }
+        when (action) {
+            is PromptAction.Start -> writeTurnStart(action.prompt.text, action.prompt.images)
+            is PromptAction.Steer -> {
+                try {
+                    writeTurnSteer(action.prompt.text, action.prompt.images, action.turnId)
+                } finally {
+                    bootstrap.withLock { promptWriteInFlight -= 1 }
+                    maybeRequestProcessExit()
+                }
+            }
+            null -> Unit
+        }
+    }
+
+    /** [pendingPrompt] is the first turn after an open/resume; later inputs retain order in queuedStarts. */
+    private fun bufferPrompt(prompt: Prompt) {
+        if (pendingPrompt == null) pendingPrompt = prompt else queuedStarts.addLast(prompt)
     }
 
     /** `/simplify` is a Claude built-in skill, not an app-server method. Keep CC Pocket's action useful
@@ -467,7 +608,8 @@ class CodexBackend(
 
     private suspend fun writeTurnStart(text: String, images: List<ImageData>) {
         val tid = threadId ?: return
-        rpcRequest("turn/start", register = { pendingStarts.add(it) }, params = buildJsonObject {
+        val prompt = Prompt(text, images)
+        rpcRequest("turn/start", register = { pendingStarts[it] = prompt }, params = buildJsonObject {
             put("threadId", tid)
             putJsonArray("input") {
                 addJsonObject { put("type", "text"); put("text", text) }
@@ -512,11 +654,22 @@ class CodexBackend(
     }
 
     override suspend fun compact(): Boolean {
+        var accepted = true
         val tid = bootstrap.withLock {
-            threadId.also { if (it == null) pendingCompact = true }
+            when (phase) {
+                ProcessPhase.READY -> threadId
+                ProcessPhase.OPENING -> {
+                    pendingCompact = true
+                    null
+                }
+                ProcessPhase.EXITING -> {
+                    accepted = false
+                    null
+                }
+            }
         }
         if (tid != null) requestCompact(tid)
-        return true
+        return accepted
     }
 
     private suspend fun requestCompact(tid: String) {
@@ -525,11 +678,22 @@ class CodexBackend(
 
     override suspend fun review(instructions: String?): Boolean {
         val review = instructions?.trim().orEmpty()
+        var accepted = true
         val tid = bootstrap.withLock {
-            threadId.also { if (it == null) pendingReview = review }
+            when (phase) {
+                ProcessPhase.READY -> threadId
+                ProcessPhase.OPENING -> {
+                    pendingReview = review
+                    null
+                }
+                ProcessPhase.EXITING -> {
+                    accepted = false
+                    null
+                }
+            }
         }
         if (tid != null) requestReview(tid, review)
-        return true
+        return accepted
     }
 
     private suspend fun requestReview(tid: String, instructions: String) {

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/Conversation.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/Conversation.kt
@@ -1384,6 +1384,10 @@ class Conversation(
             // channel the pump below drains, so there is still exactly one ordering domain and one seq
             // assigner. Sends after the process exits fail on the closed channel and are dropped.
             inject = { line -> runCatching { p.stdout.send(line) } },
+            // Codex's app-server retains an exclusive cross-app writer even after thread/unsubscribe on
+            // newer builds. A stable turn boundary asks for the normal EOF → TERM → KILL ladder off this
+            // stdout pump; processMode classifies the resulting clean exit and lazily resumes next time.
+            requestProcessExit = { scope.launch { p.shutdown() } },
         )
         // Ask pushes ride the emit path for two flavors of conversation (issue #91 bridge + #138 owner):
         //  - BRIDGE (origin set, no pathScope): the ask frame fans out normally (the bridge's egress
@@ -1873,49 +1877,68 @@ class Conversation(
             // superseded: a newer launch already owns this conversation (a relaunch raced this pump's
             // tail) — the old process's death is history, not an error, and must not touch shared state
             if (proc !== p) return
-            // unexpected death: stdout EOF precedes the last transcript flush, so wait for the
-            // real process exit before touching the file (intentional stops settle in stopProcess)
-            revokeAllBridgeGrants() // nor may its one-off grant survive into the respawned process
+            // stdout EOF precedes the last transcript flush, so wait for the real process exit before
+            // classifying it (intentional stops settle in stopProcess)
             p.awaitExit()
             if (backend.processMode == AgentProcessMode.ONE_SHOT_TURN && p.exitCode() == 0 && turnCompleted) {
+                // The completed turn's ACTIVE authority always dies here. A later prompt that raced this
+                // clean edge keeps its still-staged token: pending authority grants nothing until that exact
+                // prompt's replay activates it in the fresh process. An unexpected crash below preserves none.
+                revokeActiveBridgeGrant(generation)
                 log.info("$convoId one-shot process completed normally (sid=${sessionId?.take(8) ?: "-"})")
                 // settle any card the clean exit left open (a tool_use that never reported completed)
                 for (taskId in workflows.killRunning(System.currentTimeMillis())) emitWorkflow(taskId)
                 bridge?.cancelAll()
                 bridge = null
-                // MID-TURN QUEUE, one-shot flavor: prompts that arrived while this process ran were
-                // ledgered (and acked as queued) by sendPrompt — argv can't take a second message, so
-                // the queue drains ONE per process: pop the oldest and relaunch with it as the next
-                // spawn's argv message. launchProcess re-records it as initialSend under the fresh
-                // generation, so SessionInit settles it exactly like a directly-sent prompt. Drain only
-                // on a CLEAN exit: after a crash the entries stay ledgered and the client's resend path
-                // recovers them via releaseLostPrompt (#122 ④) — auto-draining a crash would loop the
-                // same prompt into the same failure forever. No onProcessEnded: a one-shot clean exit
-                // is the turn's natural end, not a death to clean up after.
                 proc = null // dead handle dropped FIRST — a failed drain-launch below must not leave prompts writing into it
-                val next = popQueuedPrompt()
-                if (next != null) {
+                if (backend.promptDelivery == AgentPromptDelivery.INITIAL_ARG_ONE_SHOT) {
+                    // Argv one-shot: drain ONE queued prompt per process. Pop it, then re-record it as the
+                    // next launch's initialSend so SessionInit is its consumption receipt.
+                    val next = popQueuedPrompt()
+                    if (next != null) {
+                        carryPendingPromptTransfer()
+                        log.info("$convoId one-shot queue: relaunching with queued prompt ${next.key.take(8)}…")
+                        runCatching {
+                            launchProcess(
+                                AgentSpec(
+                                    workdir, sessionId ?: openedResumeId, model, mode, effort = effort,
+                                    permissionMode = permissionMode, serviceTier = serviceTier, initialPrompt = next.text,
+                                ),
+                                armExecuting = true,
+                                initialSend = InitialSend(next.key, next.text, next.images, next.bridgeGrantToken),
+                            )
+                        }.onFailure { e ->
+                            clearTurnWork() // the spawn never started a turn
+                            // The popped entry is gone from the ledger — forget its id too, so the client's
+                            // resend runs it fresh instead of being hollow-re-acked as "already delivered".
+                            synchronized(seenPromptIds) { seenPromptIds.remove(next.key) }
+                            sink.emit(PocketError("agent_unavailable", "agent failed to start for a queued message (${e.message})", convoId))
+                        }
+                    } else clearTurnWork()
+                } else if (hasUnconsumedPrompts()) {
+                    // Stdin one-shot (Codex): keep the whole ledger in place. launchProcess's ordinary
+                    // re-injection stamps the fresh generation and replays EVERY entry in original order.
+                    // This closes the turn/completed → process-exit race without dropping a just-acked input.
                     carryPendingPromptTransfer()
-                    log.info("$convoId one-shot queue: relaunching with queued prompt ${next.key.take(8)}…")
+                    log.info("$convoId stdin one-shot queue: relaunching with unconsumed prompt(s)")
                     runCatching {
                         launchProcess(
                             AgentSpec(
                                 workdir, sessionId ?: openedResumeId, model, mode, effort = effort,
-                                permissionMode = permissionMode, serviceTier = serviceTier, initialPrompt = next.text,
+                                permissionMode = permissionMode, serviceTier = serviceTier,
                             ),
                             armExecuting = true,
-                            initialSend = InitialSend(next.key, next.text, next.images, next.bridgeGrantToken),
                         )
                     }.onFailure { e ->
-                        clearTurnWork() // the spawn never started a turn
-                        // the popped entry is gone from the ledger — forget its id too, so the client's
-                        // resend runs it fresh instead of being hollow-re-acked as "already delivered"
-                        synchronized(seenPromptIds) { seenPromptIds.remove(next.key) }
-                        sink.emit(PocketError("agent_unavailable", "agent failed to start for a queued message (${e.message})", convoId))
+                        clearTurnWork()
+                        sink.emit(PocketError("agent_unavailable", "agent failed to restart for queued messages (${e.message})", convoId))
                     }
                 } else clearTurnWork()
                 return
             }
+            // Unexpected process loss is a hard authority boundary: neither active nor staged grants may
+            // survive into a later lazy respawn.
+            revokeAllBridgeGrants()
             // Not the clean one-shot queue-transfer path: no live process can consume a turn, grace, job,
             // or pending prompt now. Clear only after awaitExit classified the path, so a queued one-shot
             // prompt never loses its work shield between the old process and its next spawn.
@@ -2350,7 +2373,7 @@ class Conversation(
         if (!ensureProcessForControlOp("compacting context")) return
         // the backend queues this across an in-flight open handshake, so a cold session's first Compact
         // tap still becomes exactly one native request; a rejection surfaces via its error path
-        backend.compact()
+        if (!backend.compact()) reply("The agent is finishing the previous turn. Please retry /compact.")
     }
 
     /** Native code review. `/review` defaults to all working tree changes; trailing text becomes the
@@ -2358,7 +2381,7 @@ class Conversation(
     private suspend fun handleNativeReviewCommand(text: String) {
         if (!ensureProcessForControlOp("starting a review")) return
         val instructions = text.removePrefix("/review").trim().takeIf { it.isNotEmpty() }
-        backend.review(instructions)
+        if (!backend.review(instructions)) reply("The agent is finishing the previous turn. Please retry /review.")
     }
 
     /** Handle the phone's `/model [name]` — the agent `-p` ignores it, so the daemon honors it. */

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/codex/CodexBackendTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/codex/CodexBackendTest.kt
@@ -2,6 +2,7 @@ package dev.ccpocket.daemon.codex
 
 import dev.ccpocket.daemon.agent.AgentEvent
 import dev.ccpocket.daemon.agent.AgentIo
+import dev.ccpocket.daemon.agent.AgentProcessMode
 import dev.ccpocket.daemon.agent.AgentSpec
 import dev.ccpocket.protocol.ImageData
 import dev.ccpocket.protocol.PermissionMode
@@ -39,10 +40,17 @@ class CodexBackendTest {
     private fun JsonArray.field(index: Int, key: String): String? =
         this[index].jsonObject[key]?.jsonPrimitive?.content
 
+    private fun requestId(line: String): Int =
+        Json.parseToJsonElement(line).jsonObject["id"]!!.jsonPrimitive.content.toInt()
+
     /** attach + handshake to a live thread "thr-1". Leaves `w` holding every line the backend wrote. */
-    private suspend fun ready(w: MutableList<String>, mode: PermissionMode = PermissionMode.DEFAULT): CodexBackend {
+    private suspend fun ready(
+        w: MutableList<String>,
+        mode: PermissionMode = PermissionMode.DEFAULT,
+        onExit: () -> Unit = {},
+    ): CodexBackend {
         val b = CodexBackend(null)
-        b.attach(AgentIo(writeLine = { w += it }, emit = {}), AgentSpec(Path.of("/repo"), mode = mode))
+        b.attach(AgentIo(writeLine = { w += it }, emit = {}, requestProcessExit = onExit), AgentSpec(Path.of("/repo"), mode = mode))
         b.parse(initResponse(1))          // → initialized + thread/start (id 2)
         b.parse(threadStartResponse(2, "thr-1"))
         return b
@@ -51,10 +59,22 @@ class CodexBackendTest {
     @Test
     fun attach_sends_initialize_then_initialized_and_thread_start() = runBlocking {
         val w = mutableListOf<String>()
-        ready(w)
+        val b = ready(w)
         assertTrue("\"method\":\"initialize\"" in w[0], w[0])
         assertTrue(w.any { "\"method\":\"initialized\"" in it })
         assertTrue(w.any { "\"method\":\"thread/start\"" in it })
+        assertEquals(AgentProcessMode.ONE_SHOT_TURN, b.processMode)
+    }
+
+    @Test
+    fun user_message_item_is_the_prompt_consumption_receipt() = runBlocking {
+        val b = ready(mutableListOf())
+
+        val ev = b.parse(
+            """{"method":"item/started","params":{"item":{"type":"userMessage","id":"u1","content":[{"type":"text","text":"hello ledger"}]}}}""",
+        )
+
+        assertEquals("hello ledger", assertIs<AgentEvent.UserReplay>(ev.single()).text)
     }
 
     @Test
@@ -110,6 +130,77 @@ class CodexBackendTest {
         assertTrue("\"threadId\":\"thr-1\"" in request, request)
         assertTrue("\"expectedTurnId\":\"turn-live\"" in request, request)
         assertTrue("continue with the next batch" in request, request)
+    }
+
+    @Test
+    fun second_prompt_before_turn_started_waits_for_the_next_boundary() = runBlocking {
+        val w = mutableListOf<String>()
+        var exits = 0
+        val b = ready(w, onExit = { exits += 1 })
+
+        b.sendPrompt("first", emptyList())
+        b.sendPrompt("second", emptyList())
+
+        assertEquals(1, w.count { "\"method\":\"turn/start\"" in it })
+        b.parse("""{"method":"turn/started","params":{"turn":{"id":"t1"}}}""")
+        b.parse("""{"method":"turn/completed","params":{"turn":{"id":"t1","status":"completed"}}}""")
+        assertEquals(2, w.count { "\"method\":\"turn/start\"" in it })
+        assertTrue("second" in w.last(), w.last())
+        assertEquals(0, exits, "queued work owns the next turn")
+    }
+
+    @Test
+    fun completed_turn_requests_a_clean_process_exit_for_cross_app_handoff() = runBlocking {
+        val w = mutableListOf<String>()
+        var exits = 0
+        val b = ready(w, onExit = { exits += 1 })
+        b.sendPrompt("finish this", emptyList())
+        val startId = requestId(w.last { "\"method\":\"turn/start\"" in it })
+        b.parse("""{"method":"turn/started","params":{"threadId":"thr-1","turn":{"id":"t1"}}}""")
+
+        b.parse("""{"method":"turn/completed","params":{"threadId":"thr-1","turn":{"id":"t1","status":"completed"}}}""")
+        assertEquals(0, exits, "the turn/start response still owns the stdout pipe")
+        b.parse("""{"id":$startId,"result":{"turn":{"id":"t1"}}}""")
+
+        assertEquals(1, exits)
+        assertTrue(w.none { "thread/unsubscribe" in it }, "unsubscribe is not a writer-release boundary on newer Codex")
+        assertFalse(b.compact(), "a control op racing process exit must ask the caller to retry")
+        assertFalse(b.review(), "a control op racing process exit must ask the caller to retry")
+    }
+
+    @Test
+    fun re_injected_prompt_on_the_next_process_resumes_before_starting_a_turn() = runBlocking {
+        val w = mutableListOf<String>()
+        val b = ready(w)
+        b.parse("""{"method":"turn/completed","params":{"threadId":"thr-1","turn":{"id":"t1","status":"completed"}}}""")
+
+        b.attach(AgentIo(writeLine = { w += it }, emit = {}), AgentSpec(Path.of("/repo"), resumeId = "thr-1"))
+        b.sendPrompt("continue after handoff", emptyList()) // Conversation's clean-exit ledger re-injection
+        val initId = requestId(w.last { "\"method\":\"initialize\"" in it })
+        b.parse(initResponse(initId))
+
+        val resume = w.last()
+        assertTrue("\"method\":\"thread/resume\"" in resume, resume)
+        assertTrue("\"threadId\":\"thr-1\"" in resume, resume)
+
+        b.parse(threadStartResponse(requestId(resume), "thr-1"))
+        val turn = w.last()
+        assertTrue("\"method\":\"turn/start\"" in turn, turn)
+        assertTrue("continue after handoff" in turn, turn)
+    }
+
+    @Test
+    fun prompt_racing_the_exit_is_not_written_into_the_dying_process() = runBlocking {
+        val w = mutableListOf<String>()
+        var exits = 0
+        val b = ready(w, onExit = { exits += 1 })
+        b.parse("""{"method":"turn/completed","params":{"threadId":"thr-1","turn":{"id":"t1","status":"completed"}}}""")
+        val writesBefore = w.size
+
+        b.sendPrompt("arrived during handoff", emptyList())
+
+        assertEquals(1, exits)
+        assertEquals(writesBefore, w.size, "the process-exit ledger, not this dying pipe, owns the prompt")
     }
 
     @Test
@@ -169,13 +260,16 @@ class CodexBackendTest {
     @Test
     fun compact_uses_native_app_server_rpc_when_thread_is_ready() = runBlocking {
         val w = mutableListOf<String>()
-        val b = ready(w)
+        var exits = 0
+        val b = ready(w, onExit = { exits += 1 })
 
         assertTrue(b.compact())
 
         val request = w.last()
         assertTrue("\"method\":\"thread/compact/start\"" in request, request)
         assertTrue("\"threadId\":\"thr-1\"" in request, request)
+        b.parse("""{"id":${requestId(request)},"result":{}}""")
+        assertEquals(1, exits, "compact has no turn/completed, so its response is the handoff boundary")
     }
 
     @Test
@@ -195,13 +289,16 @@ class CodexBackendTest {
     @Test
     fun review_uses_native_app_server_target() = runBlocking {
         val w = mutableListOf<String>()
-        val b = ready(w)
+        var exits = 0
+        val b = ready(w, onExit = { exits += 1 })
 
         assertTrue(b.review())
 
         val request = w.last()
         assertTrue("\"method\":\"review/start\"" in request, request)
         assertTrue("\"type\":\"uncommittedChanges\"" in request, request)
+        b.parse("""{"id":${requestId(request)},"result":{}}""")
+        assertEquals(0, exits, "review success owns a real turn and must wait for turn/completed")
         assertTrue("\"delivery\":\"inline\"" in request, request)
     }
 
@@ -453,6 +550,7 @@ class CodexBackendTest {
         val ev = b.parse("""{"id":3,"error":{"code":-32000,"message":"model overloaded"}}""")
 
         // Conversation marked this turn executing on ack; only a TurnResult clears that state again
+        assertEquals("do the thing", ev.filterIsInstance<AgentEvent.UserReplay>().single().text)
         val r = ev.filterIsInstance<AgentEvent.TurnResult>().single()
         assertTrue(r.isError)
         assertTrue("model overloaded" in (r.finalText ?: ""), r.finalText ?: "<null>")
@@ -476,13 +574,15 @@ class CodexBackendTest {
     @Test
     fun a_rejected_compact_reports_failure_instead_of_a_silent_noop() = runBlocking {
         val w = mutableListOf<String>()
-        val b = ready(w)
+        var exits = 0
+        val b = ready(w, onExit = { exits += 1 })
         b.compact() // → thread/compact/start (id 3)
 
         val ev = b.parse("""{"id":3,"error":{"code":-32601,"message":"method not found"}}""")
 
         val t = ev.filterIsInstance<AgentEvent.AssistantText>().single()
         assertTrue("compact" in t.text && "method not found" in t.text, t.text)
+        assertEquals(1, exits, "a rejected control has no later terminal notification")
     }
 
     @Test
@@ -571,7 +671,8 @@ class CodexBackendTest {
     @Test
     fun an_image_prompt_sent_mid_turn_waits_for_the_boundary_instead_of_losing_its_image() = runBlocking {
         val w = mutableListOf<String>()
-        val b = ready(w)
+        var exits = 0
+        val b = ready(w, onExit = { exits += 1 })
         b.parse("""{"method":"turn/started","params":{"turn":{"id":"t1"}}}""")
 
         b.sendPrompt("look at this", listOf(ImageData("image/png", "iVBORw==")))
@@ -580,6 +681,7 @@ class CodexBackendTest {
         b.parse("""{"method":"turn/completed","params":{"turn":{"id":"t1","status":"completed"}}}""")
         val start = w.last { "\"method\":\"turn/start\"" in it }
         assertTrue("look at this" in start && "iVBORw==" in start, start)
+        assertEquals(0, exits, "queued work owns the next turn")
     }
 
     @Test

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/conversation/ConversationOpenCodeOneShotTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/conversation/ConversationOpenCodeOneShotTest.kt
@@ -73,6 +73,59 @@ class ConversationOpenCodeOneShotTest {
         override fun resumeContextTokens(workdir: String, sessionId: String): Long? = null
     }
 
+    /** Codex-shaped one-shot: prompt travels over stdin, a user replay is its receipt, and the backend
+     * asks Conversation to close the process after a stable result. Each child intentionally ignores any
+     * second stdin line so the clean-exit ledger must re-inject it into the next launch. */
+    private class StdinOneShotBackend : AgentBackend {
+        val specs = CopyOnWriteArrayList<AgentSpec>()
+        val sends = CopyOnWriteArrayList<String>()
+        @Volatile private var io: AgentIo? = null
+        override val kind = AgentKind.CODEX
+        override val processMode = AgentProcessMode.ONE_SHOT_TURN
+        override val promptDelivery = AgentPromptDelivery.STDIN_REPLAY
+
+        override fun processBuilder(spec: AgentSpec): ProcessBuilder {
+            specs += spec
+            val sid = spec.resumeId ?: "codex-stdin-1"
+            val script = """
+                IFS= read -r line
+                printf 'session:%s\n' '$sid'
+                printf 'user:%s\n' "${'$'}line"
+                sleep 0.3
+                printf 'result\n'
+                while IFS= read -r ignored; do :; done
+            """.trimIndent()
+            return ProcessBuilder("sh", "-c", script)
+        }
+
+        override suspend fun attach(io: AgentIo, spec: AgentSpec) { this.io = io }
+        override suspend fun parse(line: String): List<AgentEvent> = when {
+            line.startsWith("session:") -> listOf(AgentEvent.SessionInit(line.removePrefix("session:"), specCwd(), model = null))
+            line.startsWith("user:") -> listOf(AgentEvent.UserReplay(line.removePrefix("user:")))
+            line == "result" -> {
+                io?.requestProcessExit?.invoke()
+                listOf(AgentEvent.TurnResult("ok", usage = null, isError = false))
+            }
+            else -> emptyList()
+        }
+        private fun specCwd() = specs.lastOrNull()?.workdir?.toString().orEmpty()
+        override suspend fun sendPrompt(text: String, images: List<ImageData>) {
+            sends += text
+            io?.writeLine?.invoke(text)
+        }
+        override suspend fun interrupt() {}
+        override suspend fun respondPermission(
+            askId: String, allow: Boolean, remember: Boolean,
+            originalInput: JsonObject?, updatedInput: String?, denyMessage: String?,
+        ) {}
+        override fun applySettings(mode: PermissionMode?, model: String?, effort: String?) = false
+        override suspend fun onProcessEnded(sessionId: String?) {}
+        override fun transcriptDir(workdir: String): Path = Path.of(workdir)
+        override fun listSessions(workdir: String): List<SessionSummary> = emptyList()
+        override fun replayHistory(workdir: String, sessionId: String): List<HistoryMessage> = emptyList()
+        override fun resumeContextTokens(workdir: String, sessionId: String): Long? = null
+    }
+
     private fun okTurn(sessionId: String, text: String = "ok") = listOf(
         """{"type":"step_start","sessionID":"$sessionId","part":{"sessionID":"$sessionId","type":"step-start"}}""",
         """{"type":"text","sessionID":"$sessionId","part":{"type":"text","text":"$text"}}""",
@@ -282,6 +335,32 @@ class ConversationOpenCodeOneShotTest {
             assertEquals(2, backend.specs.size)
             assertEquals("second", backend.specs[1].initialPrompt)
             assertEquals("ses_open_1", backend.specs[1].resumeId) // queued turn continues the SAME session
+        } finally {
+            convo.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun stdin_one_shot_reinjects_a_prompt_that_raced_the_clean_exit() = runBlocking {
+        if (win()) return@runBlocking
+        val frames = CopyOnWriteArrayList<Frame>()
+        val scope = CoroutineScope(Dispatchers.Default)
+        val backend = StdinOneShotBackend()
+        val convo = Conversation("cCodex", Files.createTempDirectory("ccp-codex-one-shot"), PermissionMode.DEFAULT, { frames.add(it) }, scope, backend)
+        try {
+            convo.open(resumeId = null, model = null)
+            convo.sendPrompt("first", promptId = "p1")
+            await { frames.any { it is PromptAck && it.promptId == "p1" } }
+            convo.sendPrompt("second", promptId = "p2") // old child receives but deliberately never acknowledges it
+
+            await { frames.count { it is TurnDone } >= 2 }
+
+            assertFalse(frames.any { it is PocketError }, frames.toString())
+            assertEquals(2, backend.specs.size)
+            assertEquals("codex-stdin-1", backend.specs[1].resumeId)
+            assertEquals(listOf("first", "second", "second"), backend.sends.toList())
+            assertEquals(1, frames.count { it is PromptAck && it.promptId == "p2" })
         } finally {
             convo.close()
             scope.cancel()

--- a/scripts/probe-codex-wire.py
+++ b/scripts/probe-codex-wire.py
@@ -2,7 +2,7 @@
 """codex app-server 行为回归探针 —— 升级 codex CLI 后跑一次，防依赖漂移。
 
 `codex app-server` 是**官方标注 experimental** 的 JSON-RPC 接口，版本间会漂移。daemon 的
-CodexBackend（daemon/src/main/kotlin/dev/ccpocket/daemon/codex/CodexBackend.kt）押了四条未写进
+CodexBackend（daemon/src/main/kotlin/dev/ccpocket/daemon/codex/CodexBackend.kt）押了六条未写进
 正式契约的行为，任一条漂移都会让 App 静默变坏：
 
   handshake   initialize 应答 → `initialized` 通知 → thread/start，响应 result.thread.id 非空。
@@ -15,12 +15,20 @@ CodexBackend（daemon/src/main/kotlin/dev/ccpocket/daemon/codex/CodexBackend.kt�
               （PR #296 评审修的「已 ack 的提示词被吞」类，issue #84/#104 同源）。
               若漂成静默、或漂成不带 id 的 `error` 通知 → 用户的话直接消失，且没有任何报错
 
+  receipt     item/started 的 userMessage.content 必须逐字带回刚消费的文本。Conversation 用它结算
+              unconsumed-prompt ledger；回合后的主动进程退出若缺这张收据，会把已完成的 prompt 当成
+              丢失写入，在下一 app-server 中重复执行
+
   fork        thread/fork 存在且铸出**新的** thread id（result.thread.forkedFromId 指回原 thread）。
               这是接管防双写的唯一手段：手机接管一个桌面还开着的会话时走 fork，绝不让两个 writer
               同时写一份 rollout。它一消失，openThread 会被 error 打回（daemon 故意不静默退回
               thread/resume），接管功能须整体重估。
               ⚠️ fork 认的是**盘上的 rollout**，而 rollout 随第一个 turn 懒创建 —— 所以这条 check
               必须排在 steer_stale 的 turn 之后，否则只会拿到 "no rollout found"（非漂移）
+
+  handoff     回合结束后给 app-server stdin EOF，进程须干净退出；另一个 app-server 随后能 resume 同一 id。
+              新版 Codex 的 thread/unsubscribe 仍可能保留 active writer，daemon 因此以进程退出作为
+              跨 App 交接边界；若 EOF 不退出或退出后仍占用，ChatGPT App 会继续提示「已在另一个应用中打开」
 
   unknown     未知方法必须回**带 id 的 error response**，而不是断连或静默。handleErrorResponse 的
               全部关联逻辑（pendingSteers / pendingStarts / pendingControls / threadOpenId /
@@ -29,7 +37,7 @@ CodexBackend（daemon/src/main/kotlin/dev/ccpocket/daemon/codex/CodexBackend.kt�
 说的是 CodexBackend 那套方言：裸 {id, method, params}，**不带 `jsonrpc` 字段**（与
 probe-codex-concurrent.py 一致）。
 
-用法：python3 scripts/probe-codex-wire.py [handshake|steer_stale|fork|unknown|all]（默认 all）
+用法：python3 scripts/probe-codex-wire.py [handshake|steer_stale|fork|handoff|unknown|all]（默认 all）
       CC_POCKET_CODEX_BIN=/path/to/codex 可覆盖二进制。
 退出码：0 全绿 / 1 有 FAIL（行为漂移）/ 2 缺依赖（找不到 codex）。
 探针在临时目录起真实 codex app-server（approvalPolicy=never + sandbox=read-only，只碰自己新建的
@@ -84,8 +92,10 @@ class Server:
         self.notes = queue.Queue()   # 服务端 → 客户端的通知，按到达顺序
         self.orphans = []            # 带 id 的应答但没人等 —— id 关联漂移的证据
         self.stderr_tail = []
-        threading.Thread(target=self._read, daemon=True).start()
-        threading.Thread(target=self._read_err, daemon=True).start()
+        self._stdout_thread = threading.Thread(target=self._read, daemon=True)
+        self._stderr_thread = threading.Thread(target=self._read_err, daemon=True)
+        self._stdout_thread.start()
+        self._stderr_thread.start()
 
     def _record(self, tag, line):
         self.log.write("%s %s\n" % (tag, line))
@@ -173,6 +183,26 @@ class Server:
     def kill(self):
         if self.alive():
             self.proc.kill()
+        try:
+            self.proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            return
+        # Drain both pipes before main closes the wire log; otherwise a fast teardown can make the reader
+        # thread write to an already-closed file and print a misleading post-PASS traceback.
+        self._stdout_thread.join(timeout=1)
+        self._stderr_thread.join(timeout=1)
+
+    def close_input(self, timeout=10):
+        """Close stdin like AgentProcess.shutdown's first rung; return exit code, or None on timeout."""
+        if self.proc.stdin and not self.proc.stdin.closed:
+            self.proc.stdin.close()
+        try:
+            code = self.proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            return None
+        self._stdout_thread.join(timeout=1)
+        self._stderr_thread.join(timeout=1)
+        return code
 
 
 # ── checks ────────────────────────────────────────────────────────────────────────────────────────
@@ -220,9 +250,10 @@ def check_steer_stale(srv, thread_id, cwd):
         return check("前置 thread 可用", False, "handshake 没拿到 thread id，跳过")
 
     # 唯一一个真实 turn：prompt 尽量小，只为拿一个「已完结」的 turn id
+    probe_prompt = "Reply with exactly: ok"
     rid, env = srv.request("turn/start", {
         "threadId": thread_id,
-        "input": [{"type": "text", "text": "Reply with exactly: ok"}],
+        "input": [{"type": "text", "text": probe_prompt}],
         "cwd": cwd,
         "approvalPolicy": "never",
         # 两处 sandbox 拼写不同且都会被服务端强校验（CodexBackend.sandbox() 的 flat/tag 双拼写就为这个）：
@@ -233,7 +264,23 @@ def check_steer_stale(srv, thread_id, cwd):
         show("turn/start <<<", env if env else "<silence>")
         return check("turn/start 被接受", False, excerpt((env or {}).get("error"), 200) if env else "静默")
 
-    note = srv.wait_note({"turn/completed", "turn/failed"}, TURN_TIMEOUT)
+    note = None
+    user_receipts = []
+    deadline = time.time() + TURN_TIMEOUT
+    while time.time() < deadline:
+        try:
+            candidate = srv.notes.get(timeout=min(1.0, max(0.05, deadline - time.time())))
+        except queue.Empty:
+            continue
+        if candidate.get("method") == "item/started":
+            item = (candidate.get("params") or {}).get("item") or {}
+            if item.get("type") == "userMessage":
+                text = "".join(part.get("text", "") for part in (item.get("content") or [])
+                               if part.get("type") == "text")
+                user_receipts.append(text)
+        if candidate.get("method") in ("turn/completed", "turn/failed"):
+            note = candidate
+            break
     if note is None:
         return check("turn 跑到 turn/completed", False, "%.0fs 内没有终态通知" % TURN_TIMEOUT)
     show("turn 终态 <<<", note)
@@ -243,6 +290,8 @@ def check_steer_stale(srv, thread_id, cwd):
     if not check("turn/completed 带 turn.id（steer 的 expectedTurnId 来源）", bool(turn_id),
                  turn_id or excerpt(note.get("params"), 200)):
         return False
+    check("userMessage item 是逐字 prompt 消费收据（退出前结算 ledger）",
+          probe_prompt in user_receipts, excerpt(user_receipts, 200))
 
     srv.drain_notes()   # 清干净，好判断「拒绝」是不是漂成了通知
     rid, env = srv.request("turn/steer", {
@@ -303,8 +352,41 @@ def check_fork(srv, thread_id):
     return ok
 
 
+def check_handoff(srv, thread_id, cwd):
+    """④ 稳定回合后的 stdin EOF 必须退出并允许另一 app-server 接手。"""
+    print("── handoff：A stdin EOF/exit → B resume 同一 thread ──")
+    if not thread_id:
+        return check("前置 thread 可用", False, "handshake 没拿到 thread id，跳过")
+
+    exit_code = srv.close_input()
+    ok = check("stdin EOF 后 app-server 干净退出", exit_code == 0,
+               "exit=%s alive=%s" % (exit_code, srv.alive()))
+    if exit_code is None:
+        return ok
+
+    # A second process is the real ChatGPT/cc-pocket boundary. Process death, not an RPC result, must have
+    # released the active writer for this to succeed on Codex builds whose unsubscribe is insufficient.
+    peer = Server(cwd, srv.log)
+    try:
+        _rid, peer_init = peer.request("initialize", {
+            "clientInfo": {"name": "cc-pocket-handoff-peer", "version": "0"},
+            "capabilities": {"experimentalApi": False},
+        })
+        if peer_init is None or "error" in peer_init:
+            return check("另一 app-server 初始化", False, excerpt(peer_init or "silence", 200)) and ok
+        peer.notify("initialized")
+        _rid, peer_resume = peer.request("thread/resume", {"threadId": thread_id})
+        show("peer thread/resume <<<", peer_resume or "<silence>")
+        peer_id = (((peer_resume or {}).get("result") or {}).get("thread") or {}).get("id")
+        ok &= check("A 退出后另一 app-server 可接手同一 thread", peer_id == thread_id,
+                    excerpt((peer_resume or {}).get("error"), 200) if peer_id != thread_id else peer_id)
+    finally:
+        peer.kill()
+    return ok
+
+
 def check_unknown(srv):
-    """④ 未知方法 → 带 id 的 error response，连接不断、不静默。"""
+    """⑤ 未知方法 → 带 id 的 error response，连接不断、不静默。"""
     print("── unknown：未知方法 → 带 id 的 error response ──")
     rid, env = srv.request("thread/nonexistent/probe", {})
     if env is None:
@@ -327,8 +409,8 @@ def check_unknown(srv):
 def main():
     global CODEX
     which = sys.argv[1] if len(sys.argv) > 1 else "all"
-    if which not in ("all", "handshake", "steer_stale", "fork", "unknown"):
-        print("用法：python3 scripts/probe-codex-wire.py [handshake|steer_stale|fork|unknown|all]",
+    if which not in ("all", "handshake", "steer_stale", "fork", "handoff", "unknown"):
+        print("用法：python3 scripts/probe-codex-wire.py [handshake|steer_stale|fork|handoff|unknown|all]",
               file=sys.stderr)
         return 2
     resolved = shutil.which(CODEX) if CODEX else None
@@ -352,8 +434,9 @@ def main():
         thread_id = check_handshake(srv, cwd)
         if which in ("all", "handshake") and thread_id:
             print()
-        # steer_stale / fork 都要一个真 thread；单跑它们时也得先握手（握手的 check 结果照常计入）
-        if which in ("all", "steer_stale"):
+        # steer_stale / handoff / fork 都要一份真实落盘的 rollout；thread/start 本身只创建内存
+        # thread，第一轮 turn 才落盘。单跑后两项也复用 steer_stale 的唯一真实 turn 建前置。
+        if which in ("all", "steer_stale", "handoff", "fork"):
             check_steer_stale(srv, thread_id, cwd)
             print()
         if which in ("all", "fork"):
@@ -361,6 +444,10 @@ def main():
             print()
         if which in ("all", "unknown"):
             check_unknown(srv)
+            print()
+        # Handoff exits the primary process, so it is deliberately LAST in `all`.
+        if which in ("all", "handoff"):
+            check_handoff(srv, thread_id, cwd)
     finally:
         srv.kill()
         log.close()
@@ -378,7 +465,10 @@ def main():
               "（handleErrorResponse / openThread / writeTurnSteer）确认是否要适配。")
         print("完整 wire：%s" % log_path)
         return 1
-    print("codex app-server wire 契约完好 —— CodexBackend 依赖的四条行为全部成立。")
+    if which == "all":
+        print("codex app-server wire 契约完好 —— CodexBackend 依赖的六条行为全部成立。")
+    else:
+        print("codex app-server wire 契约完好 —— 本次请求的行为及其前置检查全部成立。")
     print("完整 wire：%s" % log_path)
     return 0
 


### PR DESCRIPTION
## Summary

- end the cc-pocket-owned Codex app-server at a stable idle boundary so ChatGPT can resume the same thread
- lazily resume the existing thread on the next cc-pocket prompt
- preserve prompt ordering and exactly-once delivery across the turn-completed/process-exit race
- release the writer after native compact responses as well as normal/review turns
- extend the real app-server probe with consumption-receipt and cross-process handoff checks

## Issue

- #316
- Keeps the issue open until a formally verified release contains the fix.

## Validation

- `JAVA_HOME=/opt/homebrew/opt/openjdk@17 ./gradlew :daemon:test --tests dev.ccpocket.daemon.codex.CodexBackendTest --tests dev.ccpocket.daemon.conversation.ConversationOpenCodeOneShotTest`
- `bash scripts/check-all.sh` — protocol + daemon + relay + mobile Desktop all green
- ChatGPT bundled Codex `0.150.0-alpha.8`: handoff probe 10/10
- local Codex `0.145.0`: handoff probe 10/10
- installed development daemon logs show repeated clean `one-shot process completed normally` boundaries with a single relay-connected daemon

## Risk review

- no protocol or relay wire change
- single-writer protection remains intact; the daemon only shuts down the child app-server it launched
- active bridge authority is revoked at the completed turn; a staged grant remains inert until its exact prompt replay
- clean EOF is attempted first, with the existing bounded TERM/KILL fallback serialized against concurrent shutdowns
- unconsumed prompts remain in the daemon ledger and are replayed in order after a clean relaunch

## Not run

- iOS Simulator tests: the default merge gate excludes them, and this change has no protocol/mobile runtime edits.
