### PR TITLE
fix: dsh 会话状态与提问作答、Windows 托盘、缓存命中口径 (#320 #321 #322 #323)

### DIFF
--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/agent/AgentEvent.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/agent/AgentEvent.kt
@@ -14,6 +14,25 @@ sealed interface AgentEvent {
     /** The authoritative session_id carrier (Claude system/init; Codex thread/started → thread.id). */
     data class SessionInit(val sessionId: String?, val cwd: String?, val model: String?) : AgentEvent
 
+    /**
+     * Session metadata a backend MEASURED on its own wire after the init frame — issue #320.
+     *
+     * [SessionInit] is the wrong carrier for it: it arrives once, before the facts exist (dsh only names
+     * its model on the first `request/context` / `assistant/message`), and the Conversation hangs fork
+     * convergence, group inheritance and rewind journalling off it — re-emitting one to carry a late model
+     * would replay all of that. This event carries nothing BUT the metadata.
+     *
+     * Every field is independently optional: null = "this frame didn't say", never "no value". A non-null
+     * field is always a runtime FACT off the wire — never inferred from a model name, which is exactly the
+     * guesswork issue #320 forbids (a context window sniffed from an id is how "default" got invented in
+     * the first place).
+     */
+    data class RuntimeMeta(
+        val model: String? = null,
+        val effort: String? = null,
+        val contextWindow: Long? = null,
+    ) : AgentEvent
+
     /** [parentId] on the assistant/tool events = the enclosing sub-agent's Task/Agent tool_use id
      *  (Claude stream-json `parent_tool_use_id`); null for main-chain events and for Codex. */
     data class AssistantText(val text: String, val parentId: String? = null) : AgentEvent

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/claude/ClaudeQuotaService.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/claude/ClaudeQuotaService.kt
@@ -117,7 +117,12 @@ class ClaudeQuotaService(
         val token = when (val c = withContext(Dispatchers.IO) { credentials() }) {
             is QuotaCredential.Present -> c.accessToken
             QuotaCredential.Missing -> return ClaudeQuota(status = CLAUDE_QUOTA_NO_TOKEN, error = "not signed in to a Claude subscription")
-            QuotaCredential.Expired -> return ClaudeQuota(status = CLAUDE_QUOTA_NO_TOKEN, error = "the stored Claude login has expired")
+            // TRANSIENT, not signed-out: the OAuth token expires ~8h after the last claude run and renews
+            // itself the next time ANY claude runs. Mapping this to NO_TOKEN made the strip vanish every
+            // night and reappear mid-morning (observed daily in the QuotaRoute log, 08-24→08-27) — the
+            // client clears its snapshot on NO_TOKEN but keeps an aging one on a transient status, which
+            // is the honest render for "the numbers are stale until claude next runs".
+            QuotaCredential.Expired -> return ClaudeQuota(status = CLAUDE_QUOTA_NETWORK, error = "the stored Claude login has expired — it renews the next time Claude runs")
         }
         return when (val out = transport(token)) {
             is HttpOutcome.Body -> parse(out.text, now())

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/Conversation.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/Conversation.kt
@@ -428,6 +428,19 @@ class Conversation(
      *  the TurnResult branch, which prefers it over the result event's across-calls sum. */
     private var lastCallUsage: AgentEvent.AssistantUsage? = null
 
+    // Reasoning effort the BACKEND reported for itself (dsh's `request/header.config.reasoningEffort`) —
+    // issue #320. Distinct from [effort], which is what the USER asked for: a session opened without an
+    // explicit level still runs at some level, and this is the only place that fact exists. Display only,
+    // and always yields to [effort] (see [live]).
+    @Volatile
+    private var runtimeEffort: String? = null
+
+    // Context window the BACKEND reported for itself (dsh's `request/context.contextWindow`) — issue #320.
+    // Backends other than Claude have no window table we could derive one from, so before this every
+    // non-Claude session announced contextWindow=null and the phone could only show raw tokens.
+    @Volatile
+    private var runtimeContextWindow: Long? = null
+
     // the turn emitted a `<synthetic>` placeholder (every API call failed) — consumed by TurnResult,
     // which reports the turn as an ERROR instead of letting the placeholder pass for a real reply (issue #65)
     @Volatile
@@ -714,10 +727,17 @@ class Conversation(
     /** The announce frame, stamped with everything mutable the phone reconciles from (mode, executing, model, effort, agent). */
     private fun live(sid: String?) =
         SessionLive(
-            convoId, announcedWorkdir ?: workdir.toString(), sid, mode = mode, executing = isExecuting(), model = displayModel(), effort = effort,
+            convoId, announcedWorkdir ?: workdir.toString(), sid, mode = mode, executing = isExecuting(), model = displayModel(),
+            // the user's chosen level leads; [runtimeEffort] only fills the gap left by "never chose one"
+            // (issue #320 — a dsh session runs at `high` whether or not anybody asked for it).
+            effort = effort ?: runtimeEffort,
             // stamp the 1M/200k window from the model so the phone's usage % has an authoritative denominator
             // (issue #20) instead of sniffing the id itself. Phones that predate the field simply ignore it.
-            contextWindow = claudeWindow(),
+            // Claude goes through [claudeWindow] because its window is DERIVED (id table + the observed-usage
+            // upgrade — beta-gated 1M models declare 200k); every other backend has no such table, so the only
+            // honest denominator is the one it reported about itself (issue #320). Never both: a derived
+            // Claude window and a self-reported dsh window can never be in play for the same session.
+            contextWindow = claudeWindow() ?: runtimeContextWindow,
             contextUsed = resumeContextUsed, agent = backend.kind,
             degraded = degraded(),
             origin = origin, // "via <bridge>" label (issue #91); null for interactive sessions
@@ -1759,6 +1779,27 @@ class Conversation(
                         if (workflows.onProgress(ev.taskId, ev.toolUseId, ev.items, System.currentTimeMillis())) emitWorkflow(ev.taskId)
                     }
                     is AgentEvent.AssistantUsage -> lastCallUsage = ev
+                    // Session metadata the backend measured on its own wire AFTER init (issue #320). dsh
+                    // names its model/effort/window on `request/context`, `request/header` and every
+                    // `assistant/message` — never on the init that SessionLive was stamped from — so the
+                    // header read "default" with no denominator for the session's whole life.
+                    is AgentEvent.RuntimeMeta -> {
+                        var changed = false
+                        // The user's pick outranks it: `model` is a deliberate choice (switchModel clears
+                        // the backfill precisely so an echo can't undo it), so only the DISPLAY backfill
+                        // moves here — exactly like the transcript guess it shares a field with.
+                        ev.model?.takeIf { it.isNotBlank() && model == null && it != backfilledModel }?.let {
+                            backfilledModel = it
+                            changed = true
+                        }
+                        ev.effort?.takeIf { it.isNotBlank() && it != runtimeEffort }?.let { runtimeEffort = it; changed = true }
+                        // > 0 only: a zero window would divide the phone's usage % by nothing.
+                        ev.contextWindow?.takeIf { it > 0 && it != runtimeContextWindow }?.let { runtimeContextWindow = it; changed = true }
+                        // Re-announce only on a REAL change. dsh restates the model on every
+                        // assistant/message, so an unconditional emit would push one SessionLive per step
+                        // of every turn — the same frame, over the relay, forever.
+                        if (changed) sink.emit(live(sessionId))
+                    }
                     // the CLI's API-failure placeholder — never a real reply. Suppress the chunk (the
                     // TurnDone error row replaces it) but still arm `executing`: a turn did run (issue #65).
                     is AgentEvent.SyntheticReply -> {
@@ -2440,6 +2481,10 @@ class Conversation(
         // session's occupancy, which re-seeded the phone's "Context NN%" statusline post-clear (issue #149)
         resumeContextUsed = null
         lastCallUsage = null // nor may a killed mid-flight turn's usage leak into the fresh session's first TurnDone
+        // the backend re-reports these on the new session's first frames (issue #320); carrying them over
+        // would state as fact what the fresh process has not said yet
+        runtimeEffort = null
+        runtimeContextWindow = null
         launchProcess(
             AgentSpec(
                 workdir, resumeId = null, model = model, mode = mode, effort = effort,

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/disk/UsageService.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/disk/UsageService.kt
@@ -283,8 +283,14 @@ object UsageService {
             UsageModel(it.key, it.value, agent)
         }
         val cacheHit = (inputToday + cacheReadToday).takeIf { it > 0 }?.let { ((cacheReadToday * 100) / it).toInt() }
-        // window cache-hit: the exact today formula over the window accumulators (cacheRead / (input + cacheRead))
-        val cacheHitWindow = (inputWindow + cacheReadWindow).takeIf { it > 0 }?.let { ((cacheReadWindow * 100) / it).toInt() }
+        // window cache-hit: the exact today formula over the window accumulators (cacheRead / (input + cacheRead)).
+        // issue #323: the same base also SHIPS, so the App can show the raw numerator/denominator under the
+        // percentage. Deriving all three from this one `takeIf` is the point — a separately-gated numerator
+        // could go null (or non-null) while the percentage didn't, and a ratio that doesn't reproduce the
+        // number printed above it is worse than printing no ratio at all. No sample (base 0) => all null,
+        // matching the today fields' "null means unknown, 0 means measured zero" semantics.
+        val cacheBaseWindow = (inputWindow + cacheReadWindow).takeIf { it > 0 }
+        val cacheHitWindow = cacheBaseWindow?.let { ((cacheReadWindow * 100) / it).toInt() }
 
         return Usage(
             days = trend,
@@ -298,6 +304,8 @@ object UsageService {
             requestsWindow = requestsWindow,
             cacheHitPctWindow = cacheHitWindow,
             costUsdWindow = if (costWindowSeen) costWindow else null,
+            cacheReadTokensWindow = cacheBaseWindow?.let { cacheReadWindow },
+            cacheBaseTokensWindow = cacheBaseWindow,
         )
     }
 

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/dsh/DshAskLedger.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/dsh/DshAskLedger.kt
@@ -90,24 +90,37 @@ internal class DshAskLedger(
     fun reset() = synchronized(lock) { pending.clear(); byApproval.clear() }
 
     /**
-     * A `…/requested` frame → the [AgentEvent.ControlRequest] the permission bridge turns into a card, or
-     * null when there is nothing new to show (a replay of a card already pending, or a frame we cannot
-     * answer and must therefore not pretend to).
+     * A `…/requested` frame → the [AgentEvent.ControlRequest] the permission bridge turns into a card.
+     *
+     * Three other outcomes, and the difference between them is the whole point (issue #321):
+     *  - **null, silently** — nothing new to show: a replay of a card already pending, or an ask for a
+     *    session that is not ours. Someone else's turn, or one we already deal.
+     *  - **a [hangNotice]** — the ask IS (or may well be) ours but is unanswerable as it arrived. dsh will
+     *    wait on it forever, so the user is told rather than left watching a turn that never moves.
+     *  - a real card, below.
      */
-    fun requested(method: String, rpcId: String?, payload: JsonObject): AgentEvent.ControlRequest? {
+    fun requested(method: String, rpcId: String?, payload: JsonObject): AgentEvent? {
         if (rpcId.isNullOrEmpty()) {
             log.warn("dsh $method with no rpcId — unanswerable, ignored")
-            return null
+            return hangNotice(method, "the request carried no id to answer it with")
         }
-        // Fail-closed session check (see [ourSession]). A dropped ask means a HUNG dsh turn and dsh never
-        // reports one, so this is logged loudly rather than silently discarded.
         val ours = ourSession()
         val sessionId = payload.str("sessionId")
-        if (ours == null || sessionId == null || sessionId != ours) {
-            log.warn(
-                "dsh $method for session=$sessionId is not ours (${ours ?: "session not open yet"}) — " +
-                    "dropped, and dsh will block that turn until it is cancelled",
-            )
+        // `sessionId` is mandatory in dsh's own frame schema, so a frame without one is host breakage
+        // rather than a foreign session — we can neither prove it is ours nor route an answer to it, and
+        // it is the one drop that is BOTH unprovable and probably ours. Say so.
+        if (sessionId == null) {
+            log.warn("dsh $method named no session — unanswerable, dropped")
+            return hangNotice(method, "the request named no session")
+        }
+        // Fail-closed session check (see [ourSession]). Silent on purpose here, unlike the two cases
+        // above: the mux is multiplexed across every session the host holds, so a frame for a session
+        // that is not ours belongs to somebody else's turn and is not ours to announce or to answer.
+        // `ours == null` means our own session does not exist yet (fresh create, pre-`session.create`),
+        // which likewise cannot be the session this ask names — issue #321 seeds the resumed id into
+        // [ourSession] precisely so a RESUME no longer lands in this branch.
+        if (ours == null || sessionId != ours) {
+            log.info("dsh $method for session=$sessionId is not ours (${ours ?: "session not open yet"}) — ignored")
             return null
         }
         return when (method) {
@@ -115,7 +128,7 @@ internal class DshAskLedger(
                 val questions = DshAsk.questionsOf(payload)
                 if (questions.isEmpty()) {
                     log.warn("dsh question/requested carried no answerable question — ignored")
-                    return null
+                    return hangNotice(method, "it carried no question anyone could answer")
                 }
                 if (!claim(rpcId, QuestionEntry(rpcId, sessionId, questions))) return null
                 AgentEvent.ControlRequest(
@@ -140,6 +153,26 @@ internal class DshAskLedger(
             }
             else -> null
         }
+    }
+
+    /**
+     * The chat line for an ask we refuse to claim — issue #321.
+     *
+     * dsh has NO timeout (probe-verified), so an unclaimed request does not degrade, it WEDGES: the turn
+     * sits waiting for an answer that can never arrive, and until now the only trace was a daemon log line
+     * nobody reads from a phone. That is indistinguishable, from the outside, from "the model is thinking",
+     * and it is exactly what #321 describes as a question you can see but cannot complete.
+     *
+     * Deliberately an [AgentEvent.AssistantText] rather than a [AgentEvent.TurnResult]: the turn genuinely
+     * IS still running on dsh's side, and minting a fake result would tell the phone it had ended (the same
+     * judgement [DshBackend]'s `report` channel makes for a refused answer).
+     */
+    private fun hangNotice(method: String, why: String): AgentEvent.AssistantText {
+        val what = if (method == QUESTION_REQUESTED) "asked a question" else "asked for an approval"
+        return AgentEvent.AssistantText(
+            "⚠️ DeepSeek Harness $what that cc-pocket cannot answer — $why. That turn is now waiting on a " +
+                "reply nothing can deliver; stop it and send the prompt again.",
+        )
     }
 
     /**

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/dsh/DshBackend.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/dsh/DshBackend.kt
@@ -49,7 +49,8 @@ import java.nio.file.Path
  * ## v1 scope (deliberately narrow)
  *
  * Session discovery, history replay, opening a session, sending/receiving messages including live
- * streaming, and (issue #291) the question/approval bridge. NOT included: usage accounting, model
+ * streaming, (issue #291) the question/approval bridge, and (issue #320) the session's self-reported
+ * model / reasoning effort / context window plus its live per-call token usage. NOT included: model
  * switching, tool cards, the web UI, plugins.
  *
  * ## Two product constraints worth quoting in the follow-up work
@@ -94,12 +95,27 @@ class DshBackend(private val dshBin: String?) : AgentBackend {
      *  backend's whole life (not per process) and is [DshAskLedger.reset] on every attach, because an
      *  rpcId only means anything to the host process that minted it. */
     private val asks = DshAskLedger(
-        ourSession = { sessionId },
+        ourSession = { ourSessionId() },
         send = { rpcId, value -> api?.respond(rpcId, value) ?: DshRespond.UNREACHABLE },
         // A refused reply is surfaced as a NOTICE, not a turn error: the dsh turn really is still running
         // (that is the whole problem), and faking a TurnResult would tell the phone it had ended.
         report = { message -> io?.inject?.invoke(syntheticNotice("⚠️ $message")) },
     )
+
+    /**
+     * The session id this backend may claim frames for — issue #321.
+     *
+     * `resumeId` stands in until `session.create`/resume has landed [sessionId], and a RESUMED id is
+     * provably ours: the conversation asked the host for exactly that session. That closes the one window
+     * where an ask that really was ours got dropped — the host replays still-pending `…/requested` frames
+     * the moment a mux subscribes, which is BEFORE `openSession` assigns [sessionId]. A dropped ask is not
+     * a lost card, it is a dsh turn that then waits forever (dsh has no timeout of its own).
+     *
+     * A FRESH session keeps the strict null, and must: before `session.create` returns our session does not
+     * exist yet, so no pending ask can possibly belong to it, and claiming one would be claiming somebody
+     * else's.
+     */
+    private fun ourSessionId(): String? = sessionId ?: resumeId
 
     /** Guards [sessionId] and [pendingPrompts] so the opening turn can never be lost to a race between
      *  "the session is not open yet, buffer it" and "the session just opened, flush the buffer". */
@@ -268,7 +284,7 @@ class DshBackend(private val dshBin: String?) : AgentBackend {
         // The mux is MULTIPLEXED across every session the host holds — including sub-agents' own
         // sessions. Without this filter another session's output would be spliced into this chat.
         val frameSession = payload.str("sessionId")
-        val ours = sessionId
+        val ours = ourSessionId()
         if (frameSession != null && ours != null && frameSession != ours) return emptyList()
 
         return when (method) {
@@ -319,8 +335,31 @@ class DshBackend(private val dshBin: String?) : AgentBackend {
                     else -> emptyList()
                 }
             }
-            // Dropped on purpose — already streamed as chunks above.
-            "assistant/message" -> emptyList()
+            // The session's real context window, straight off dsh's own wire (issue #320) — the header's
+            // usage % has no denominator without it, because no window table on our side knows deepseek ids.
+            "request/context" -> listOf(
+                runtimeMeta(model = data?.str("model"), contextWindow = data?.long("contextWindow"))
+                    ?: AgentEvent.Ignored(type),
+            )
+            // The resolved per-request configuration. `reasoningEffort` is the session header's only source
+            // for the level a dsh turn actually runs at.
+            // ⚠️ `config.maxTokens` is deliberately NOT read: it is the OUTPUT cap (256k on the same model
+            // that reports a 1,000,000-token window above), and mistaking it for the context window would
+            // understate occupancy four-fold. The window comes from `request/context`, full stop.
+            "request/header" -> {
+                val config = data?.obj("header")?.obj("config")
+                listOf(
+                    runtimeMeta(model = config?.str("model"), effort = config?.str("reasoningEffort"))
+                        ?: AgentEvent.Ignored(type),
+                )
+            }
+            // The assembled reply is still NOT rendered — it was already streamed as chunks above (see the
+            // class comment: live takes the deltas, disk takes the message). What it IS mined for is the two
+            // facts nothing else on the live wire carries: which model answered, and what the call cost.
+            "assistant/message" -> listOfNotNull(
+                runtimeMeta(model = data?.obj("message")?.obj("source")?.str("model")),
+                assistantUsage(data),
+            )
             "turn/end" -> listOf(AgentEvent.TurnResult(finalText = null, usage = null, isError = false))
             // v1 is text-only in BOTH the live and the replay path, so tool events render nothing. Doing
             // it in one path only would make a resumed session look different from the live one.
@@ -328,6 +367,49 @@ class DshBackend(private val dshBin: String?) : AgentBackend {
                 listOf(AgentEvent.Ignored(type))
             else -> listOf(AgentEvent.Ignored(type ?: "dsh-event"))
         }
+    }
+
+    /** A [AgentEvent.RuntimeMeta] only when at least one field is really present — an all-null event would
+     *  travel to the Conversation to say nothing, and blanks are dropped so a `""` can never displace a
+     *  model we already know. */
+    private fun runtimeMeta(
+        model: String? = null,
+        effort: String? = null,
+        contextWindow: Long? = null,
+    ): AgentEvent.RuntimeMeta? {
+        val m = model?.takeIf { it.isNotBlank() }
+        val e = effort?.takeIf { it.isNotBlank() }
+        val w = contextWindow?.takeIf { it > 0 }
+        return if (m == null && e == null && w == null) null else AgentEvent.RuntimeMeta(m, e, w)
+    }
+
+    /**
+     * One `assistant/message`'s token spend, normalized to cc-pocket's disjoint columns (issue #320).
+     *
+     * ⚠️ `usage` sits under `data` as a SIBLING of `message`, NOT inside it — the same trap
+     * [DshUsageScanner] calls out; reading `message.usage` yields nothing and the statusline stays empty.
+     *
+     * DeepSeek is OpenAI-lineage, so `cacheReadTokens` is a SUBSET of `inputTokens`, while
+     * [dev.ccpocket.protocol.TokenUsage.contextTokens] adds its four columns as DISJOINT sets. Passing the
+     * pair through raw would count the cached prefix twice and overstate occupancy. Subtracting is exactly
+     * what [DshUsageScanner] does on the disk path, so the live statusline and the usage page agree.
+     *
+     * Absent or all-zero usage returns null rather than zeros: a zero [AgentEvent.AssistantUsage] becomes a
+     * zero TurnDone usage, which snaps the phone's context readout back to 0% mid-session — the same reason
+     * [AgentEvent.TurnResult] carries a null usage instead of placeholder zeros.
+     */
+    private fun assistantUsage(data: JsonObject?): AgentEvent.AssistantUsage? {
+        val usage = data?.obj("usage") ?: return null
+        val input = usage.long("inputTokens") ?: 0L
+        val cacheRead = usage.long("cacheReadTokens") ?: 0L
+        if (input <= 0L && cacheRead <= 0L) return null
+        return AgentEvent.AssistantUsage(
+            inputTokens = (input - cacheRead).coerceAtLeast(0L),
+            // null vs 0 is a real distinction here: dsh has NO cache-write counter (null = never reported),
+            // while `cacheReadTokens` IS reported and is simply 0 on a cold prompt (a measurement).
+            cacheCreationInputTokens = null,
+            cacheReadInputTokens = cacheRead,
+        )
     }
 
     // ---- outbound ----
@@ -373,6 +455,12 @@ class DshBackend(private val dshBin: String?) : AgentBackend {
      */
     internal fun bindSessionForTest(id: String) {
         sessionId = id
+    }
+
+    /** VISIBLE FOR TESTS ONLY. Stands in for the `resumeId` [attach] would have taken off the spec, so the
+     *  pre-`session.create` window issue #321 closes can be exercised without a live host. */
+    internal fun bindResumeForTest(id: String) {
+        resumeId = id
     }
 
     override suspend fun interrupt() {
@@ -438,8 +526,10 @@ class DshBackend(private val dshBin: String?) : AgentBackend {
         DshTranscriptScanner.find(sessionId, workdir)?.let { DshTranscriptReplay.page(it.file, beforeSeq, limit) }
             ?: ReplaySlice.EMPTY
 
-    /** dsh records per-turn usage in `assistant/message.usage`, but usage accounting is out of v1 scope
-     *  and a half-populated statusline reads worse than an absent one. */
+    /** The RESUME SEED only — the occupancy a reopened session shows BEFORE its first new turn. Still null:
+     *  issue #320 wired the LIVE path (`assistant/message.usage` → [assistantUsage]), so the readout appears
+     *  as soon as the session answers once, but seeding it off disk means re-reading the transcript's tail
+     *  and is a separate piece of work. Null (no readout) beats a stale or wrong one. */
     override fun resumeContextTokens(workdir: String, sessionId: String): Long? = null
 
     // ---- synthetic frames (our own injections, distinguished from dsh's by their `type`) ----

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/claude/ClaudeQuotaServiceTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/claude/ClaudeQuotaServiceTest.kt
@@ -191,17 +191,24 @@ class ClaudeQuotaServiceTest {
     // ── service behaviour ──────────────────────────────────────────────────────────────────────────
 
     @Test
-    fun no_credential_and_an_expired_one_both_answer_no_token_without_a_request() = runBlocking {
-        for (cred in listOf(QuotaCredential.Missing, QuotaCredential.Expired)) {
+    fun a_missing_credential_answers_no_token_but_an_expired_one_is_only_transient() = runBlocking {
+        // Missing = never signed in / API-key machine → authoritative NO_TOKEN (client hides the strip).
+        // Expired = the ~8h OAuth token lapsed between claude runs → TRANSIENT (client keeps its aging
+        // snapshot); mapping it to NO_TOKEN made the strip vanish every night (QuotaRoute log, 08-24→27).
+        // Neither state may burn a doomed request on Anthropic.
+        for ((cred, want) in listOf(
+            QuotaCredential.Missing to CLAUDE_QUOTA_NO_TOKEN,
+            QuotaCredential.Expired to dev.ccpocket.protocol.CLAUDE_QUOTA_NETWORK,
+        )) {
             val calls = AtomicInteger()
             val svc = ClaudeQuotaService(
                 credentials = { cred },
                 transport = { calls.incrementAndGet(); HttpOutcome.Body(fixture) },
             )
             val q = svc.get()
-            assertEquals(CLAUDE_QUOTA_NO_TOKEN, q.status, "for $cred")
+            assertEquals(want, q.status, "for $cred")
             assertTrue(q.limits.isEmpty())
-            assertEquals(0, calls.get(), "a signed-out machine must not call Anthropic at all")
+            assertEquals(0, calls.get(), "a token-less machine must not call Anthropic at all")
         }
     }
 

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/conversation/ConversationRuntimeMetaTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/conversation/ConversationRuntimeMetaTest.kt
@@ -1,0 +1,144 @@
+package dev.ccpocket.daemon.conversation
+
+import dev.ccpocket.daemon.agent.AgentBackend
+import dev.ccpocket.daemon.agent.AgentEvent
+import dev.ccpocket.daemon.agent.AgentIo
+import dev.ccpocket.daemon.agent.AgentSpec
+import dev.ccpocket.protocol.AgentKind
+import dev.ccpocket.protocol.Frame
+import dev.ccpocket.protocol.HistoryMessage
+import dev.ccpocket.protocol.ImageData
+import dev.ccpocket.protocol.PermissionMode
+import dev.ccpocket.protocol.SessionLive
+import dev.ccpocket.protocol.SessionSummary
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.JsonObject
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Issue #320 — [AgentEvent.RuntimeMeta] is the ONLY way a non-Claude backend can name the model, effort and
+ * context window it is really running under, because those facts do not exist yet when its init frame is
+ * emitted. This pins what the phone actually receives: the announce, not just the event.
+ *
+ * The backend is a stub on purpose. What the dsh wire looks like is [dev.ccpocket.daemon.dsh.DshRuntimeMetaTest]'s
+ * job; what the CONVERSATION does with the result is this one's, and the two must not be able to fail together.
+ */
+class ConversationRuntimeMetaTest {
+
+    private fun isWindows() = System.getProperty("os.name").lowercase().contains("win")
+
+    /**
+     * Turns marker lines into events. The stream is gated on the prompt (`read go`) for the same reason
+     * [ConversationContinuationGraceTest] gates its own: the process is launched BEFORE `executing` is
+     * armed, so an ungated `cat` can race its whole script past the pump.
+     */
+    private class MetaBackend(private val script: Path) : AgentBackend {
+        override val kind = AgentKind.DSH
+        private var io: AgentIo? = null
+        override fun processBuilder(spec: AgentSpec): ProcessBuilder =
+            ProcessBuilder("sh", "-c", "read go; cat '${script.absolutePathString()}'; sleep 30")
+        override suspend fun attach(io: AgentIo, spec: AgentSpec) { this.io = io }
+        override suspend fun parse(line: String): List<AgentEvent> = when (line.trim()) {
+            // dsh's init is synthetic and carries no model — exactly the shape that left the header on "default"
+            "init" -> listOf(AgentEvent.SessionInit(SID, "/tmp", model = null))
+            "meta" -> listOf(AgentEvent.RuntimeMeta(model = MODEL, effort = "high", contextWindow = 1_000_000))
+            // a DIFFERENT window: the terminator the duplicate-suppression assertion counts up to
+            "narrow" -> listOf(AgentEvent.RuntimeMeta(contextWindow = 200_000))
+            else -> listOf(AgentEvent.Ignored(line))
+        }
+        override suspend fun sendPrompt(text: String, images: List<ImageData>) { io?.writeLine("go") }
+        override suspend fun interrupt() {}
+        override suspend fun respondPermission(
+            askId: String, allow: Boolean, remember: Boolean,
+            originalInput: JsonObject?, updatedInput: String?, denyMessage: String?,
+        ) {}
+        override fun applySettings(mode: PermissionMode?, model: String?, effort: String?) = true
+        override suspend fun onProcessEnded(sessionId: String?) {}
+        override fun transcriptDir(workdir: String): Path = Path.of(workdir)
+        override fun listSessions(workdir: String): List<SessionSummary> = emptyList()
+        override fun replayHistory(workdir: String, sessionId: String): List<HistoryMessage> = emptyList()
+        override fun resumeContextTokens(workdir: String, sessionId: String): Long? = null
+    }
+
+    private fun harness(
+        lines: List<String>,
+        openModel: String?,
+        until: (List<Frame>) -> Boolean,
+        body: (List<SessionLive>) -> Unit,
+    ) = runBlocking {
+        val script = Files.createTempDirectory("ccp-meta-fx").resolve("stream.txt")
+            .apply { writeText(lines.joinToString("\n") + "\n") }
+        val frames = ArrayList<Frame>()
+        val scope = CoroutineScope(Dispatchers.Default)
+        val convo = Conversation(
+            convoId = "cMeta", initialWorkdir = Files.createTempDirectory("ccp-meta"),
+            initialMode = PermissionMode.DEFAULT,
+            initialSink = { f -> synchronized(frames) { frames.add(f) } },
+            parentScope = scope, backend = MetaBackend(script),
+        )
+        try {
+            convo.open(resumeId = null, model = openModel)
+            convo.sendPrompt("go") // lazy start (issue #61): this is what launches the scripted process
+            withTimeout(10_000) { while (!until(synchronized(frames) { frames.toList() })) delay(20) }
+            body(synchronized(frames) { frames.filterIsInstance<SessionLive>() })
+        } finally {
+            convo.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun runtime_metadata_reaches_the_announce_and_re_announces_only_when_it_changes() {
+        if (isWindows()) return
+        harness(
+            lines = listOf("init", "meta", "meta", "narrow"),
+            openModel = null,
+            until = { fs -> fs.any { it is SessionLive && it.contextWindow == 200_000L } },
+        ) { lives ->
+            // the regression baseline: the init announce really does carry nothing — this is the state the
+            // phone was stuck in for the session's whole life before #320
+            val first = lives.first()
+            assertNull(first.model)
+            assertNull(first.contextWindow)
+            // …and the metadata frame corrects all three fields at once
+            val corrected = lives.filter { it.contextWindow == 1_000_000L }
+            assertEquals(MODEL, corrected.first().model)
+            assertEquals("high", corrected.first().effort)
+            // exactly once, though `meta` arrived twice: dsh restates its model on EVERY assistant/message,
+            // and an unconditional re-announce would push one identical SessionLive per step, over the relay
+            assertEquals(1, corrected.size, "an unchanged RuntimeMeta must not re-announce")
+        }
+    }
+
+    /** The user's pick outranks the backend's echo — the same rule `switchModel` enforces by clearing the
+     *  backfill. A session opened on a chosen model must not silently become whatever answered. */
+    @Test
+    fun an_explicitly_chosen_model_survives_the_backends_own_report() {
+        if (isWindows()) return
+        harness(
+            lines = listOf("init", "meta"),
+            openModel = "deepseek-reasoner",
+            until = { fs -> fs.any { it is SessionLive && it.contextWindow == 1_000_000L } },
+        ) { lives ->
+            val announced = lives.last { it.contextWindow == 1_000_000L }
+            assertEquals("deepseek-reasoner", announced.model) // NOT MODEL — the choice stands
+            assertEquals(1_000_000L, announced.contextWindow) // the window still lands: nobody chose one
+        }
+    }
+
+    private companion object {
+        const val SID = "dsh-sid"
+        const val MODEL = "deepseek-v4-flash"
+    }
+}

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/disk/UsageServiceTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/disk/UsageServiceTest.kt
@@ -191,6 +191,54 @@ class UsageServiceTest {
         }
     }
 
+    /**
+     * issue #323: the window cache-hit percentage now ships the two accumulators it was computed from.
+     * The whole value of that is MACHINE-CHECKABLE traceability, so this pins the ratio against the
+     * printed percentage — if the three could ever disagree, the "here is where the number came from"
+     * line would itself be something the user has to take on faith, which is the bug.
+     */
+    @Test
+    fun window_cache_hit_ships_the_numerator_and_denominator_behind_it() {
+        withProjects { root ->
+            val proj = root.resolve("-Users-x-proj").also { it.createDirectories() }
+            proj.resolve("s1.jsonl").writeText(
+                listOf(
+                    richTurn(0, 100, 100, 0.10, "a"),  // today
+                    richTurn(3, 300, 100, 0.30, "b"),  // mid-window
+                    richTurn(6, 200, 200, 0.20, "c"),  // oldest in-window day
+                    richTurn(8, 999, 999, 9.90, "d"),  // prev window — must feed neither accumulator
+                ).joinToString("\n") + "\n",
+            )
+            val u = hermetic(7, projectsRoot = root)
+            // the accumulators themselves: cache-read 400, and its base input(600) + cache-read(400)
+            assertEquals(400L, u.cacheReadTokensWindow, "numerator = the window's cache-read tokens")
+            assertEquals(1000L, u.cacheBaseTokensWindow, "denominator = input + cache-read over the same window")
+            // …and they reproduce the percentage the card prints, under the page's own formula
+            assertEquals(40, u.cacheHitPctWindow)
+            assertEquals(
+                u.cacheHitPctWindow,
+                ((u.cacheReadTokensWindow!! * 100) / u.cacheBaseTokensWindow!!).toInt(),
+                "the shipped ratio must reproduce the shipped percentage exactly",
+            )
+            // the denominator EXCLUDES cache-creation on purpose (writing the cache was never a hit
+            // opportunity) — it is input + cache-read and nothing else
+            assertEquals(600L + u.cacheReadTokensWindow!!, u.cacheBaseTokensWindow)
+        }
+    }
+
+    /** No sample at all → both null, never a tidy-looking 0. Same "unknown vs measured zero" distinction
+     *  cacheHitPctWindow has always drawn: 0/0 rendered as "0 / 0 tokens" would read as a real measurement
+     *  of a cache that never got asked anything. */
+    @Test
+    fun window_cache_raw_tokens_are_null_without_a_sample() {
+        withProjects { root ->
+            val u = hermetic(7, projectsRoot = root)
+            assertNull(u.cacheHitPctWindow, "an empty window is unknown, not 0%")
+            assertNull(u.cacheReadTokensWindow)
+            assertNull(u.cacheBaseTokensWindow)
+        }
+    }
+
     @Test
     fun window_cost_is_null_when_no_transcript_records_a_cost() {
         withProjects { root ->

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/dsh/DshAskLedgerTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/dsh/DshAskLedgerTest.kt
@@ -86,8 +86,9 @@ class DshAskLedgerTest {
     fun a_replayed_rpcId_does_not_deal_a_second_card() {
         val f = Fixture()
         val frame = questionFrame()
-        val first = f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(frame))
-        assertNotNull(first)
+        val first = assertIs<AgentEvent.ControlRequest>(
+            f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(frame)),
+        )
         assertEquals(DshAsk.ASK_ID_PREFIX + askRpc, first.requestId)
         assertEquals(AskQuestions.TOOL, first.toolName)
 
@@ -100,11 +101,17 @@ class DshAskLedgerTest {
         assertEquals(1, f.sent.size)
     }
 
+    /**
+     * No rpcId = nothing to answer against, so no card. But NOT silence (issue #321): dsh has no timeout,
+     * so the turn behind that ask now waits forever, and a daemon log line is invisible from a phone.
+     * The drop reaches the chat as a notice instead.
+     */
     @Test
-    fun a_frame_without_an_rpcId_is_unanswerable_and_ignored() {
+    fun a_frame_without_an_rpcId_deals_no_card_but_says_so() {
         val f = Fixture()
-        assertNull(f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, null, payload(questionFrame())))
-        assertNull(f.ledger.requested(DshAskLedger.APPROVAL_REQUESTED, "", payload(approvalFrame())))
+        assertIs<AgentEvent.AssistantText>(f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, null, payload(questionFrame())))
+        assertIs<AgentEvent.AssistantText>(f.ledger.requested(DshAskLedger.APPROVAL_REQUESTED, "", payload(approvalFrame())))
+        assertTrue(f.sent.isEmpty(), "nothing may be answered on dsh's side")
     }
 
     /**
@@ -132,7 +139,7 @@ class DshAskLedgerTest {
     @Test
     fun the_response_carries_our_own_session_id() {
         val f = Fixture()
-        val ask = f.ledger.requested(DshAskLedger.APPROVAL_REQUESTED, approvalRpc, payload(approvalFrame()))!!
+        val ask = assertIs<AgentEvent.ControlRequest>(f.ledger.requested(DshAskLedger.APPROVAL_REQUESTED, approvalRpc, payload(approvalFrame())))
         runBlocking { f.ledger.answer(ask.requestId, allow = true, updatedInput = null) }
         assertEquals("session-abc", f.sent.single().value.str("sessionId"))
     }
@@ -142,7 +149,7 @@ class DshAskLedgerTest {
     @Test
     fun question_resolved_withdraws_the_card_and_clears_the_entry() {
         val f = Fixture()
-        val ask = f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(questionFrame()))!!
+        val ask = assertIs<AgentEvent.ControlRequest>(f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(questionFrame())))
         val resolved = json(
             """{"method":"question/resolved","payload":{"type":"question/resolved",
                 "sessionId":"session-abc","questionRpcId":"$askRpc","outcome":"cancelled"}}""",
@@ -161,7 +168,7 @@ class DshAskLedgerTest {
     @Test
     fun approval_resolved_matches_on_approvalId_not_rpcId() {
         val f = Fixture()
-        val ask = f.ledger.requested(DshAskLedger.APPROVAL_REQUESTED, approvalRpc, payload(approvalFrame()))!!
+        val ask = assertIs<AgentEvent.ControlRequest>(f.ledger.requested(DshAskLedger.APPROVAL_REQUESTED, approvalRpc, payload(approvalFrame())))
         val resolved = json(
             """{"method":"approval/resolved","payload":{"type":"approval/resolved",
                 "sessionId":"session-abc","approvalId":"apr-77","outcome":"cancelled"}}""",
@@ -188,7 +195,7 @@ class DshAskLedgerTest {
     @Test
     fun answers_are_translated_by_text_to_id_positionally_for_every_question() {
         val f = Fixture()
-        val ask = f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(questionFrame(multi = true)))!!
+        val ask = assertIs<AgentEvent.ControlRequest>(f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(questionFrame(multi = true))))
         // the phone answers by question TEXT and in whatever order it likes; dsh needs question ORDER + ids
         val updated = AskQuestions.answeredInput(
             ask.input,
@@ -219,7 +226,7 @@ class DshAskLedgerTest {
     @Test
     fun an_unanswered_question_still_gets_an_entry_with_empty_selected() {
         val f = Fixture()
-        val ask = f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(questionFrame()))!!
+        val ask = assertIs<AgentEvent.ControlRequest>(f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(questionFrame())))
         val updated = AskQuestions.answeredInput(ask.input, mapOf("Which color do you prefer?" to "Blue"), null)
         runBlocking { f.ledger.answer(ask.requestId, allow = true, updatedInput = updated) }
 
@@ -236,7 +243,7 @@ class DshAskLedgerTest {
     @Test
     fun a_freeform_response_becomes_custom_on_every_unpicked_question() {
         val f = Fixture()
-        val ask = f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(questionFrame()))!!
+        val ask = assertIs<AgentEvent.ControlRequest>(f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(questionFrame())))
         val updated = AskQuestions.answeredInput(ask.input, null, "neither — use whatever the theme says")
         runBlocking { f.ledger.answer(ask.requestId, allow = true, updatedInput = updated) }
 
@@ -254,7 +261,7 @@ class DshAskLedgerTest {
     @Test
     fun an_other_text_rides_in_custom_beside_the_matched_labels() {
         val f = Fixture()
-        val ask = f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(questionFrame(multi = true)))!!
+        val ask = assertIs<AgentEvent.ControlRequest>(f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(questionFrame(multi = true))))
         val updated = AskQuestions.answeredInput(
             ask.input,
             mapOf("Which sizes should I build?" to "Small, XXL please"),
@@ -271,7 +278,7 @@ class DshAskLedgerTest {
     @Test
     fun single_select_other_text_drops_the_selected_array() {
         val f = Fixture()
-        val ask = f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(questionFrame()))!!
+        val ask = assertIs<AgentEvent.ControlRequest>(f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(questionFrame())))
         val updated = AskQuestions.answeredInput(ask.input, mapOf("Which color do you prefer?" to "Teal"), null)
         runBlocking { f.ledger.answer(ask.requestId, allow = true, updatedInput = updated) }
 
@@ -286,7 +293,7 @@ class DshAskLedgerTest {
     fun an_approval_allow_sends_allowed_once_with_both_ids() {
         val f = Fixture()
         val frame = approvalFrame()
-        val ask = f.ledger.requested(DshAskLedger.APPROVAL_REQUESTED, approvalRpc, payload(frame))!!
+        val ask = assertIs<AgentEvent.ControlRequest>(f.ledger.requested(DshAskLedger.APPROVAL_REQUESTED, approvalRpc, payload(frame)))
         assertEquals("bash", ask.toolName)
         // the model's own escalation reason is what the human reads
         assertEquals("needs to delete build/ which is outside the sandbox", ask.input?.str("description"))
@@ -301,7 +308,7 @@ class DshAskLedgerTest {
     @Test
     fun an_approval_deny_sends_rejected() {
         val f = Fixture()
-        val ask = f.ledger.requested(DshAskLedger.APPROVAL_REQUESTED, approvalRpc, payload(approvalFrame()))!!
+        val ask = assertIs<AgentEvent.ControlRequest>(f.ledger.requested(DshAskLedger.APPROVAL_REQUESTED, approvalRpc, payload(approvalFrame())))
         runBlocking { f.ledger.answer(ask.requestId, allow = false, updatedInput = null) }
         assertEquals(DshAsk.OUTCOME_REJECT, f.sent.single().value.str("outcome"))
     }
@@ -311,7 +318,7 @@ class DshAskLedgerTest {
     @Test
     fun a_bad_response_is_surfaced_in_the_chat() {
         val f = Fixture(result = { DshRespond(false, "bad-response") })
-        val ask = f.ledger.requested(DshAskLedger.APPROVAL_REQUESTED, approvalRpc, payload(approvalFrame()))!!
+        val ask = assertIs<AgentEvent.ControlRequest>(f.ledger.requested(DshAskLedger.APPROVAL_REQUESTED, approvalRpc, payload(approvalFrame())))
         runBlocking { f.ledger.answer(ask.requestId, allow = true, updatedInput = null) }
         assertEquals(1, f.reported.size)
         assertTrue("bad-response" in f.reported.single(), f.reported.single())
@@ -320,7 +327,7 @@ class DshAskLedgerTest {
     @Test
     fun not_pending_is_a_benign_race_and_stays_quiet() {
         val f = Fixture(result = { DshRespond(false, DshRespond.NOT_PENDING) })
-        val ask = f.ledger.requested(DshAskLedger.APPROVAL_REQUESTED, approvalRpc, payload(approvalFrame()))!!
+        val ask = assertIs<AgentEvent.ControlRequest>(f.ledger.requested(DshAskLedger.APPROVAL_REQUESTED, approvalRpc, payload(approvalFrame())))
         runBlocking { f.ledger.answer(ask.requestId, allow = true, updatedInput = null) }
         assertTrue(f.reported.isEmpty())
     }
@@ -338,7 +345,7 @@ class DshAskLedgerTest {
     @Test
     fun reset_drops_every_pending_entry() {
         val f = Fixture()
-        val ask = f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(questionFrame()))!!
+        val ask = assertIs<AgentEvent.ControlRequest>(f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(questionFrame())))
         f.ledger.reset()
         runBlocking { assertFalse(f.ledger.answer(ask.requestId, allow = true, updatedInput = null)) }
         // …and the rpcId is claimable again (a fresh host process may legitimately reuse nothing, but the
@@ -360,7 +367,9 @@ class DshAskLedgerTest {
             verdictTimeoutMs = 60, questionTimeoutMs = 60,
             forceNeverRemember = true, // what Conversation sets for AgentKind.DSH
         )
-        val ask = f.ledger.requested(DshAskLedger.APPROVAL_REQUESTED, approvalRpc, payload(approvalFrame()))!!
+        val ask = assertIs<AgentEvent.ControlRequest>(
+            f.ledger.requested(DshAskLedger.APPROVAL_REQUESTED, approvalRpc, payload(approvalFrame())),
+        )
         bridge.onControlRequest(ask)
 
         val card = emitted.filterIsInstance<PermissionAsk>().single()
@@ -388,7 +397,10 @@ class DshAskLedgerTest {
             respond = { askId, allow, _, _, updated, _ -> f.ledger.answer(askId, allow, updated) },
             verdictTimeoutMs = 30_000, questionTimeoutMs = 30_000, forceNeverRemember = true,
         )
-        val ask = f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(questionFrame()))!!
+        // a well-formed frame yields a real CARD, never the #321 "cannot answer this" chat notice
+        val ask = assertIs<AgentEvent.ControlRequest>(
+            f.ledger.requested(DshAskLedger.QUESTION_REQUESTED, askRpc, payload(questionFrame())),
+        )
         bridge.onControlRequest(ask)
 
         val card = emitted.filterIsInstance<PermissionAsk>().single()

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/dsh/DshBackendAskTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/dsh/DshBackendAskTest.kt
@@ -60,21 +60,69 @@ class DshBackendAskTest {
     fun another_sessions_ask_never_becomes_a_card() = runBlocking<Unit> {
         // dropped by the backend's own session filter…
         assertTrue(backend().parse(approvalLine("session-someone-else")).isEmpty())
-        // …and, for a frame that carries no sessionId at all to filter on, by the ledger's fail-closed
-        // check — which is the half that also covers the pre-`session.create` boot window
+        // …and a frame that carries no sessionId at all still deals no card. It does NOT stay silent
+        // though (issue #321): `sessionId` is mandatory in dsh's own schema, so its absence is host
+        // breakage rather than somebody else's session — unprovable AND probably ours, the one drop the
+        // user has to hear about, because the turn behind it now waits forever.
         val noSession = frame(
             """
             {"type":"server-request","rpcId":"$rpcId","method":"approval/requested",
              "payload":{"type":"approval/requested","approvalId":"a-2","toolName":"bash","reason":"nope"}}
             """,
         )
-        assertIs<AgentEvent.Ignored>(backend().parse(noSession).single())
+        assertIs<AgentEvent.AssistantText>(backend().parse(noSession).single())
     }
 
     /** Before `session.create` returns there is nothing to prove an ask is ours against. */
     @Test
     fun no_card_is_dealt_before_the_session_is_open() = runBlocking<Unit> {
         assertIs<AgentEvent.Ignored>(DshBackend(null).parse(approvalLine()).single())
+    }
+
+    /**
+     * issue #321. A RESUME is the one case where a still-pending ask can exist BEFORE `session.create`
+     * lands `sessionId`: the host replays undecided `…/requested` frames the moment a mux subscribes. The
+     * resumed id is provably ours, so the card must be dealt rather than dropped into a turn that then
+     * waits forever (dsh has no timeout of its own).
+     */
+    @Test
+    fun a_resumed_session_claims_an_ask_that_beats_session_create() = runBlocking<Unit> {
+        val backend = DshBackend(null).apply { bindResumeForTest(SESSION) } // note: no bindSessionForTest
+        val ask = assertIs<AgentEvent.ControlRequest>(backend.parse(questionLine()).single())
+        assertEquals("dsh-$rpcId", ask.requestId)
+    }
+
+    /** …but only for the resumed id: another session's ask still gets nothing (fail-closed). */
+    @Test
+    fun a_resumed_session_still_refuses_a_foreign_ask() = runBlocking<Unit> {
+        val backend = DshBackend(null).apply { bindResumeForTest(SESSION) }
+        assertTrue(backend.parse(approvalLine("session-someone-else")).isEmpty())
+    }
+
+    /**
+     * issue #321. An ask we cannot answer does not "degrade" — it WEDGES the dsh turn permanently, and a
+     * daemon log line is invisible from a phone. Every drop that leaves a turn hanging must reach the chat.
+     */
+    @Test
+    fun an_unanswerable_ask_says_so_in_the_chat_instead_of_hanging_silently() = runBlocking<Unit> {
+        // no rpcId → nothing to answer against
+        val noRpc = frame(
+            """
+            {"type":"server-request","method":"question/requested",
+             "payload":{"type":"question/requested","sessionId":"$SESSION","questions":[
+               {"id":"q1","question":"Ship it?","options":[{"label":"Yes"}]}]}}
+            """,
+        )
+        assertIs<AgentEvent.AssistantText>(backend().parse(noRpc).single())
+
+        // an empty question batch is equally unanswerable
+        val noQuestions = frame(
+            """
+            {"type":"server-request","rpcId":"$rpcId","method":"question/requested",
+             "payload":{"type":"question/requested","sessionId":"$SESSION","questions":[]}}
+            """,
+        )
+        assertIs<AgentEvent.AssistantText>(backend().parse(noQuestions).single())
     }
 
     @Test

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/dsh/DshRuntimeMetaTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/dsh/DshRuntimeMetaTest.kt
@@ -1,0 +1,144 @@
+package dev.ccpocket.daemon.dsh
+
+import dev.ccpocket.daemon.agent.AgentEvent
+import dev.ccpocket.protocol.TokenUsage
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Issue #320 — a dsh session's header read "default" with no context readout for its whole life, because
+ * the only [AgentEvent.SessionInit] the backend ever emitted was our OWN synthetic one (model = null) and
+ * `assistant/message` was dropped whole, usage and all.
+ *
+ * Every frame below is a REAL shape, copied off a local `~/.dsh/sessions/**/session.jsonl.zstd`, and every
+ * test goes through the public `parse(line)` seam (mux envelope included) so a translation that regresses
+ * shows up here rather than as a quietly empty header on the phone.
+ */
+class DshRuntimeMetaTest {
+
+    private fun backend() = DshBackend(null).apply { bindSessionForTest(SESSION) }
+
+    /** Wrap one SessionEvent in the mux envelope the WS client re-injects. */
+    private fun event(body: String): String =
+        """{"method":"session/event","payload":{"sessionId":"$SESSION","event":${body.trimIndent().replace("\n", " ")}}}"""
+
+    private val requestContext = event(
+        """
+        {"type":"request/context",
+         "data":{"provider":"deepseek-official","model":"deepseek-v4-flash","contextWindow":1000000}}
+        """,
+    )
+
+    private val requestHeader = event(
+        """
+        {"type":"request/header",
+         "data":{"header":{"config":{"provider":"deepseek-official","model":"deepseek-v4-flash",
+                                     "maxTokens":256000,"reasoningEffort":"high"}}}}
+        """,
+    )
+
+    /** [usage] is spliced in verbatim so the negative cases can drop or zero it without touching the rest. */
+    private fun assistantMessage(usage: String) = event(
+        """
+        {"type":"assistant/message","seq":36,"time":1786805272848,
+         "data":{"turn":1,"step":1,
+                 "message":{"role":"assistant","content":[{"type":"text","text":"hello"}],
+                            "source":{"kind":"model","provider":"deepseek-official","model":"deepseek-v4-flash"},
+                            "id":"580798a2-1f2c-4a3b-9c11-6d5e4f3a2b10"}$usage}}
+        """,
+    )
+
+    @Test
+    fun request_context_carries_the_model_and_the_real_context_window() = runBlocking<Unit> {
+        val meta = assertIs<AgentEvent.RuntimeMeta>(backend().parse(requestContext).single())
+        assertEquals("deepseek-v4-flash", meta.model)
+        assertEquals(1_000_000L, meta.contextWindow)
+        assertNull(meta.effort) // this frame says nothing about effort — and null means exactly that
+    }
+
+    /**
+     * ⚠️ The trap this test exists for: `config.maxTokens` (256000) is the OUTPUT cap of the very model whose
+     * context window is 1,000,000. Reading it as the window would understate occupancy four-fold, so the
+     * header frame must contribute model + effort and NOTHING resembling a window.
+     */
+    @Test
+    fun request_header_carries_effort_but_never_mistakes_maxTokens_for_the_window() = runBlocking<Unit> {
+        val meta = assertIs<AgentEvent.RuntimeMeta>(backend().parse(requestHeader).single())
+        assertEquals("deepseek-v4-flash", meta.model)
+        assertEquals("high", meta.effort)
+        assertNull(meta.contextWindow)
+        assertTrue(meta.contextWindow != 256_000L, "maxTokens is the output cap, never the context window")
+    }
+
+    @Test
+    fun assistant_message_yields_the_answering_model_and_its_usage_but_still_renders_no_text() = runBlocking<Unit> {
+        val events = backend().parse(assistantMessage(USAGE_UNCACHED))
+        // still no AssistantText: the reply already streamed as `assistant/chunk` deltas, and surfacing
+        // both would print every dsh answer twice (the live-vs-disk rule in DshBackend's class comment)
+        assertTrue(events.none { it is AgentEvent.AssistantText }, "the assembled message must not re-render")
+        assertEquals("deepseek-v4-flash", events.filterIsInstance<AgentEvent.RuntimeMeta>().single().model)
+        val usage = events.filterIsInstance<AgentEvent.AssistantUsage>().single()
+        assertEquals(11_149L, usage.inputTokens)
+        assertNull(usage.cacheCreationInputTokens) // dsh has no cache-write counter at all — never reported
+        assertEquals(0L, usage.cacheReadInputTokens) // …whereas this one IS reported, and measured zero
+    }
+
+    /**
+     * DeepSeek is OpenAI-lineage — `cacheReadTokens` is a SUBSET of `inputTokens` — while
+     * [TokenUsage.contextTokens] sums its columns as DISJOINT sets. Handing the pair over raw would count the
+     * cached prefix twice; this pins the same subtraction [DshUsageScanner] applies on the disk path.
+     */
+    @Test
+    fun a_cached_prefix_is_subtracted_so_the_window_readout_cannot_double_count() = runBlocking<Unit> {
+        val usage = backend().parse(assistantMessage(USAGE_CACHED))
+            .filterIsInstance<AgentEvent.AssistantUsage>().single()
+        assertEquals(7_149L, usage.inputTokens) // 11149 prompt − 4000 of it served from cache
+        assertEquals(4_000L, usage.cacheReadInputTokens)
+        // what the phone's statusline actually divides by the window: the prompt, counted once
+        val occupancy = TokenUsage(usage.inputTokens, 0, usage.cacheCreationInputTokens, usage.cacheReadInputTokens)
+        assertEquals(11_149L, occupancy.contextTokens)
+    }
+
+    /**
+     * The negative half. A zero [AgentEvent.AssistantUsage] would become a zero TurnDone usage and snap the
+     * phone's "Context NN%" back to 0 mid-session — the same reason TurnResult carries a null usage instead of
+     * placeholder zeros. Absent numbers must therefore produce NO usage event at all.
+     */
+    @Test
+    fun a_missing_or_all_zero_usage_reports_nothing_rather_than_zeros() = runBlocking<Unit> {
+        for (shape in listOf(USAGE_ABSENT, USAGE_ZERO)) {
+            val events = backend().parse(assistantMessage(shape))
+            assertTrue(
+                events.none { it is AgentEvent.AssistantUsage },
+                "usage shape `$shape` carries no tokens — it must not be reported as zero",
+            )
+            // the model is still learned: knowing WHO answered doesn't depend on knowing what it cost
+            assertEquals("deepseek-v4-flash", events.filterIsInstance<AgentEvent.RuntimeMeta>().single().model)
+        }
+    }
+
+    /** A frame whose fields are all missing says nothing — and an all-null RuntimeMeta travelling to the
+     *  Conversation to say nothing is worse than no event: it would re-announce on every arrival. */
+    @Test
+    fun a_metadata_frame_with_nothing_in_it_is_ignored() = runBlocking<Unit> {
+        assertIs<AgentEvent.Ignored>(backend().parse(event("""{"type":"request/context","data":{}}""")).single())
+        assertIs<AgentEvent.Ignored>(backend().parse(event("""{"type":"request/header","data":{}}""")).single())
+    }
+
+    private companion object {
+        const val SESSION = "session-1"
+
+        /** The probed shape: `usage` is a SIBLING of `message` under `data`, never a field of it. */
+        const val USAGE_UNCACHED =
+            ""","usage":{"inputTokens":11149,"outputTokens":123,"cacheReadTokens":0,"reasoningTokens":41}"""
+        const val USAGE_CACHED =
+            ""","usage":{"inputTokens":11149,"outputTokens":123,"cacheReadTokens":4000,"reasoningTokens":41}"""
+        const val USAGE_ZERO =
+            ""","usage":{"inputTokens":0,"outputTokens":0,"cacheReadTokens":0,"reasoningTokens":0}"""
+        const val USAGE_ABSENT = ""
+    }
+}

--- a/mobile/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -516,6 +516,10 @@
     <string name="usage_selected">%1$s · %2$s tokens</string>
     <string name="usage_na">暂无数据</string>
     <string name="usage_agent_all">全部</string>
+    <!-- issue #323：缓存命中是 daemon 扫到的所有后端的混合值，卡片要自己说明覆盖范围 -->
+    <string name="usage_scope_all_agents">全部 agent</string>
+    <string name="usage_scope_no_filter">这是本机所有 agent 的合计——当前 daemon 还不支持按 agent 拆开看。</string>
+    <string name="usage_cache_ratio">%1$s / %2$s tokens</string>
     <!-- ── Claude 订阅额度（CLI /usage 面板背后的 5 小时 / 7 天窗口）── -->
     <string name="quota_title">Claude 订阅额度</string>
     <string name="quota_5h">5 小时</string>
@@ -617,6 +621,8 @@
     <string name="label_context">上下文</string>
     <string name="value_default">默认</string>
     <string name="value_model_default">账号默认</string>
+    <!-- issue #320：只有 Claude 才有真正的「账号默认模型」；其他 agent 报不出模型就是未知，写「默认」等于编造事实。 -->
+    <string name="value_unknown">未知</string>
     <string name="session_actions_open">会话操作</string>
     <string name="quick_actions_title">快捷操作</string>
     <string name="qa_model">切换模型</string>
@@ -678,6 +684,7 @@
     <string name="questions_answered_one">回答了 %1$d 个问题</string>
     <string name="questions_answered_many">回答了 %1$d 个问题</string>
     <string name="questions_withdrawn">Claude 已继续，无需再回答</string>
+    <string name="questions_unanswered">未作答的提问——该回合已结束，没有收到回答</string>
     <string name="path_copy">复制</string>
     <string name="path_open">在浏览器打开</string>
     <string name="path_copied">已复制</string>

--- a/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -516,6 +516,10 @@
     <string name="usage_selected">%1$s · %2$s tokens</string>
     <string name="usage_na">not available yet</string>
     <string name="usage_agent_all">All</string>
+    <!-- issue #323: the cache-hit number is a mix across every backend the daemon scanned, so the card names its own scope -->
+    <string name="usage_scope_all_agents">all agents</string>
+    <string name="usage_scope_no_filter">Every agent on this computer, added together — this daemon can't break the number down per agent yet.</string>
+    <string name="usage_cache_ratio">%1$s / %2$s tokens</string>
     <!-- ── Claude subscription allowance (the 5h/7d windows behind the CLI's own /usage panel) ── -->
     <string name="quota_title">Claude plan allowance</string>
     <string name="quota_5h">5-hour</string>
@@ -617,6 +621,8 @@
     <string name="label_context">Context</string>
     <string name="value_default">default</string>
     <string name="value_model_default">Default</string>
+    <!-- issue #320: only Claude has a real "account default" model; for any other agent an unnamed model is simply unknown, and saying "default" invented a fact. -->
+    <string name="value_unknown">unknown</string>
     <string name="session_actions_open">Session actions</string>
     <string name="quick_actions_title">Quick actions</string>
     <string name="qa_model">Switch model</string>
@@ -678,6 +684,7 @@
     <string name="questions_answered_one">Answered %1$d question</string>
     <string name="questions_answered_many">Answered %1$d questions</string>
     <string name="questions_withdrawn">Claude moved on — answers no longer needed</string>
+    <string name="questions_unanswered">Unanswered question — that turn ended without a reply</string>
     <string name="path_copy">Copy</string>
     <string name="path_open">Open in browser</string>
     <string name="path_copied">Copied</string>

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
@@ -344,6 +344,11 @@ private data class PendingGrantMutation(
     val clearAll: Boolean = false,
 )
 
+/** The tool name every backend's transcript replay files an AskUserQuestion under (the daemon's own
+ *  `TranscriptReplay.ASK_TOOL` / `DshTranscriptReplay.ASK_TOOL`, and the live `AskQuestions.TOOL`). It is
+ *  a display key on the wire, not an enum, so the client matches the same literal. */
+private const val ASK_QUESTION_TOOL = "AskUserQuestion"
+
 sealed interface ChatItem {
     /** [pending] = sent from this device but the daemon hasn't echoed any evidence back yet (stream
      *  chunk / tool event / turn end). Stays true while the link is down so the UI can say so —
@@ -419,6 +424,21 @@ sealed interface ChatItem {
 
     /** Claude withdrew its questions (control_cancel) — muted one-liner where the card used to be. */
     data object QuestionsWithdrawn : ChatItem
+
+    /**
+     * A replayed AskUserQuestion that NOBODY ever answered — issue #321.
+     *
+     * The live, answerable card is a [dev.ccpocket.protocol.PermissionAsk]; this is its historical
+     * counterpart, and until now the two were indistinguishable on screen: an unanswered question replayed
+     * as a plain [Tool] row whose preview happened to be the question text, so it read as "a question I
+     * can see but cannot complete" — exactly the report. dsh makes it bite hardest (its turns wait on an
+     * unanswered question forever), but the shape is backend-agnostic: any interrupted Claude turn leaves
+     * the same row behind.
+     *
+     * [text] is the question text the daemon carried on the row, rendered read-only and clearly labelled
+     * as unanswered. A card that cannot be answered must SAY so rather than look like one that can.
+     */
+    data class QuestionsUnanswered(val text: String) : ChatItem
 
     /** OpenCode's `question` tool surfaced as a READ-ONLY question card (issue #210, phase 1): the
      *  parsed questions + options, rendered like the AskUserQuestion card but non-interactive with a
@@ -2924,7 +2944,11 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
                 replace(archivedSessions, f.items)
                 archivedRefreshing.value = false
             }
-            is Usage -> { usage.value = f; usageLoading.value = false }
+            // usageAgent advances WITH the reply, never with the selection (issue #323): the page keeps
+            // rendering the previous reply while the next fetch is in flight, so a label read off the
+            // chip would name an agent whose numbers are not on screen yet — a mislabeled ratio, which is
+            // the exact failure the per-agent label exists to remove.
+            is Usage -> { usage.value = f; usageAgent.value = usageRequestedAgent; usageLoading.value = false }
             // The Claude subscription allowance behind the CLI's `/usage` panel. Two different kinds of
             // non-OK reply, deliberately handled differently:
             //  · NO_TOKEN is AUTHORITATIVE — the machine signed out, or authenticates with an API key.
@@ -3770,6 +3794,11 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         // workflowRunId binds a Workflow card to its separately-pushed run (issue #106)
         ChatRole.TOOL -> h.answers?.let { a -> ChatItem.QuestionsAnswered(a.map { it.question to it.answer }) }
             ?: OpenCodeQuestionParse.parse(h.tool ?: "", h.text)?.let { ChatItem.OpenCodeQuestion(it) }
+            // …and one with NO answers is a question that never got one (issue #321). Falling through to
+            // the plain tool row below made it read as a live-looking card with nothing to tap; say what
+            // it actually is. Every backend's replay names the tool the same way (see the daemon's
+            // TranscriptReplay / DshTranscriptReplay ASK_TOOL), so this needs no per-agent branch.
+            ?: h.text.takeIf { h.tool == ASK_QUESTION_TOOL }?.let { ChatItem.QuestionsUnanswered(it) }
             ?: ChatItem.Tool(h.tool ?: "tool", h.text, ok = h.ok, output = h.output, workflowRunId = h.workflowRunId)
     }
 
@@ -4162,10 +4191,18 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
     val usage = mutableStateOf<Usage?>(null)
     val usageLoading = mutableStateOf(false)
 
+    /** Which backend [usage] actually covers — null = the all-backends total (issue #323). Distinct from
+     *  the page's chip selection: this one only moves when a reply lands, so whatever labels the snapshot
+     *  describes the snapshot. The daemon does not echo the filter it applied, and asking it to would
+     *  mislabel every filter-capable daemon released before the echo — so the client remembers instead. */
+    val usageAgent = mutableStateOf<AgentKind?>(null)
+    private var usageRequestedAgent: AgentKind? = null
+
     /** Ask the daemon to aggregate usage over the last [days] local days; the reply lands in [usage].
      *  [agent] non-null narrows it to one backend (issue #258); null is the all-backends total. */
     fun fetchUsage(days: Int = 7, agent: AgentKind? = null) {
         usageLoading.value = true
+        usageRequestedAgent = agent
         scope.launch { send(FetchUsage(days, agent)) }
     }
 

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/App.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/App.kt
@@ -3747,6 +3747,9 @@ private fun MessageItem(
         // the quiet residue of a question exchange: an expandable answered row / a muted withdrawn note
         is ChatItem.QuestionsAnswered -> QuestionsAnsweredRow(m.items)
         is ChatItem.QuestionsWithdrawn -> QuestionsWithdrawnRow()
+        // …and asked-but-never-answered (issue #321): read-only and labelled as such, so it can't be
+        // mistaken for the live card docked above the composer
+        is ChatItem.QuestionsUnanswered -> QuestionsUnansweredRow(m.text)
         // OpenCode asked a question — read-only card (no answer channel yet, issue #210)
         is ChatItem.OpenCodeQuestion -> OpenCodeQuestionCard(m.questions)
         // a live turn's end: quiet ✓ line so "finished" stays visible in the transcript

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/QuestionCard.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/QuestionCard.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.ccpocket.app.resources.*
 import dev.ccpocket.app.theme.Tok
+import dev.ccpocket.app.theme.tightCenter
 import dev.ccpocket.protocol.AskQuestion
 import dev.ccpocket.protocol.PermissionAsk
 import org.jetbrains.compose.resources.stringResource
@@ -477,6 +478,42 @@ private fun TinyChip(text: String, muted: Boolean = false) {
             .background(Tok.base).border(1.dp, Tok.hair, RoundedCornerShape(6.dp))
             .padding(horizontal = 7.dp, vertical = 2.dp),
     )
+}
+
+/**
+ * Unanswered: a replayed question NOBODY ever answered — issue #321.
+ *
+ * Sits between [QuestionsAnsweredRow] (it has answers) and [QuestionsWithdrawnRow] (the agent took it
+ * back): this one was asked, went unanswered, and the turn ended around it. It borrows the answered row's
+ * frame so it still reads as a question, but everything actionable is gone and the label says why — the
+ * whole complaint in #321 was a question card you could see and not complete, with nothing explaining it.
+ * Muted, not alarming: an unanswered question is a dead end, not an error.
+ */
+@Composable
+fun QuestionsUnansweredRow(text: String) {
+    val shape = RoundedCornerShape(12.dp)
+    Row(
+        Modifier.fillMaxWidth().clip(shape).background(Tok.surface).border(1.dp, Tok.hair, shape)
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(9.dp),
+    ) {
+        QBadge(22.dp)
+        Column(Modifier.weight(1f)) {
+            Text(
+                stringResource(Res.string.questions_unanswered), color = Tok.muted, fontSize = 11.5.sp,
+                style = tightCenter(11.5.sp),
+            )
+            // Both Texts carry tightCenter, never just one: this Column is geometrically centred against
+            // the QBadge beside it, and a mixed row is the alignment trap CLAUDE.md's rule exists for.
+            if (text.isNotBlank()) {
+                Text(
+                    text, color = Tok.tx2, fontSize = 13.sp, maxLines = 3, overflow = TextOverflow.Ellipsis,
+                    style = tightCenter(13.sp), modifier = Modifier.padding(top = 2.dp),
+                )
+            }
+        }
+    }
 }
 
 /** Withdrawn: the muted one-liner left where the card used to be (dot + text, no drama). */

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/SessionSheets.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/SessionSheets.kt
@@ -158,6 +158,11 @@ internal fun modelChipLabel(model: String?): String {
 
 /** Compact human token count: 45200 -> "45k", 1000000 -> "1.0M" (one decimal, truncated). */
 fun formatTokens(n: Long): String = when {
+    // A billion tokens is an ordinary 30d figure on a busy machine, and without this tier it read as
+    // "4388.8M" — four significant digits in front of a unit, which is exactly the number nobody parses.
+    // Added with the cache-hit traceability line (issue #323), whose whole job is being read; it only ever
+    // changes output that was already past the M tier's useful range.
+    n >= 1_000_000_000 -> "${(n / 100_000_000) / 10.0}B"
     n >= 1_000_000 -> "${(n / 100_000) / 10.0}M" // integer /100k then /10.0 = one truncated decimal
     n >= 1_000 -> "${n / 1000}k"
     else -> n.toString()
@@ -195,7 +200,16 @@ fun SessionInfoSheet(repo: PocketRepository, onDismiss: () -> Unit, onHandoff: (
                     AgentTag(repo.sessionAgent.value ?: AgentKind.CLAUDE, small = false)
                 }
                 Hairline()
-                AboutRow(stringResource(Res.string.label_model), repo.model.value ?: stringResource(Res.string.value_default))
+                // Same rule as the desktop header (issue #320): "default" is only true for Claude, whose
+                // account HAS a default model. A dsh/OpenCode session whose backend never named its model
+                // is unknown — and this row is a status readout, so it must not invent one.
+                AboutRow(
+                    stringResource(Res.string.label_model),
+                    repo.model.value ?: stringResource(
+                        if ((repo.sessionAgent.value ?: AgentKind.CLAUDE) == AgentKind.CLAUDE) Res.string.value_default
+                        else Res.string.value_unknown,
+                    ),
+                )
                 Hairline()
                 AboutRow(stringResource(Res.string.label_effort), repo.effort.value ?: stringResource(Res.string.value_default))
                 if (repo.serviceTier.value == "priority") {

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/UsageScreen.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/UsageScreen.kt
@@ -48,6 +48,7 @@ import dev.ccpocket.app.resources.Res
 import dev.ccpocket.app.resources.usage_agent_all
 import dev.ccpocket.app.resources.usage_by_model
 import dev.ccpocket.app.resources.usage_cache
+import dev.ccpocket.app.resources.usage_cache_ratio
 import dev.ccpocket.app.resources.usage_cost
 import dev.ccpocket.app.resources.usage_empty
 import dev.ccpocket.app.resources.usage_empty_hint
@@ -62,6 +63,8 @@ import dev.ccpocket.app.resources.usage_per_hour
 import dev.ccpocket.app.resources.usage_period_range
 import dev.ccpocket.app.resources.usage_period_today
 import dev.ccpocket.app.resources.usage_requests
+import dev.ccpocket.app.resources.usage_scope_all_agents
+import dev.ccpocket.app.resources.usage_scope_no_filter
 import dev.ccpocket.app.resources.usage_selected
 import dev.ccpocket.app.resources.usage_title
 import dev.ccpocket.app.resources.usage_tokens
@@ -69,6 +72,7 @@ import dev.ccpocket.app.resources.usage_trend
 import dev.ccpocket.app.resources.usage_vs_prev_days
 import dev.ccpocket.app.resources.usage_vs_yesterday
 import dev.ccpocket.app.theme.Tok
+import dev.ccpocket.app.theme.tightCenter
 import dev.ccpocket.protocol.AgentKind
 import dev.ccpocket.protocol.Usage
 import dev.ccpocket.protocol.UsageDay
@@ -92,7 +96,10 @@ private fun money(v: Double): String {
  * All views branch on the reply's own shape (u.days.size), so a stale reply keeps rendering coherently while
  * the next fetch is in flight. Data is aggregated by the daemon from EVERY backend's own records — Claude
  * and Codex transcripts, the OpenCode and ZCode databases, and Kimi Code's wire logs (issue #258).
- * A second header row filters that total to ONE agent; "All" (the default) is the unfiltered view.
+ * A second header row filters that total to ONE agent; "All" (the default) is the unfiltered view — and
+ * the cache-hit card names that scope in its own label (issue #323), because a RATIO mixed across backends
+ * with very different cache behaviour is unreadable without knowing whose it is, and prints the raw
+ * cache-read / (input + cache-read) tokens beneath it so the percentage can be traced, not just believed.
  *
  * [embedded] drops the page's OWN back arrow + title (and its system-back interception) for a host that
  * already provides them — the desktop settings modal, which frames it as one pane among ten. Everything
@@ -167,7 +174,15 @@ fun UsageScreen(repo: PocketRepository, onBack: () -> Unit, embedded: Boolean = 
         // strip in the desktop sidebar footer (desktop/QuotaBar.kt). This page stays what it always was:
         // token accounting read out of local transcripts.
         when {
-            u != null && (u.tokensToday > 0 || u.models.isNotEmpty() || u.days.any { it.tokens > 0 }) -> Populated(u)
+            u != null && (u.tokensToday > 0 || u.models.isNotEmpty() || u.days.any { it.tokens > 0 }) ->
+                // The cache-hit card names WHOSE number it is (issue #323), so it needs the effective
+                // agent — and `filterable`, since a daemon that ignores the filter hides the chips above
+                // and would otherwise leave a whole-machine mix looking like one agent's rate.
+                // …and it names the agent the RENDERED reply covers (repo.usageAgent), not the chip that
+                // is currently lit: the page deliberately keeps the previous reply on screen while the
+                // next fetch runs, so labelling from the selection would put a new agent's name over an
+                // old agent's numbers every time the chips are tapped.
+                Populated(u, repo.usageAgent.value, filterable)
             u != null -> Empty(u.days.size)
             !connected || timedOut -> Offline()
             else -> Loading()
@@ -176,7 +191,7 @@ fun UsageScreen(repo: PocketRepository, onBack: () -> Unit, embedded: Boolean = 
 }
 
 @Composable
-private fun Populated(u: Usage) {
+private fun Populated(u: Usage, agent: AgentKind?, filterable: Boolean) {
     Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp)) {
         // Range-scoped headline: the Tokens hero is the WINDOW total (== the sum of the trend it sits above),
         // so the top number and the chart never contradict, and switching Today/7d/30d visibly changes it.
@@ -211,13 +226,42 @@ private fun Populated(u: Usage) {
         val requests = u.requestsWindow ?: u.requestsToday
         val cacheHit = if (windowMode) u.cacheHitPctWindow else u.cacheHitPct
         val cost = if (windowMode) u.costUsdWindow else u.costUsdToday
+        // issue #323: cache hit is the one sub-metric that is unreadable unless you know WHOSE it is. The
+        // page aggregates every backend the daemon scanned, and their real hit rates differ by tens of
+        // points — a DeepSeek-heavy machine reading 55% next to an Anthropic-heavy account's 95% looks like
+        // a parsing bug when it is simply two different populations. So the label always carries the agent
+        // dimension, "all agents" included: it was the UNLABELED aggregate that made the number impossible
+        // to argue with. The other two cards stay scope-only — requests and cost are sums, and a sum over
+        // more agents is self-evidently bigger; a RATIO over more agents is just a number you can't place.
+        val cacheAgent = agent?.let(::agentName) ?: stringResource(Res.string.usage_scope_all_agents)
+        // The raw numerator/denominator the percentage was computed from. They come off the SAME window
+        // accumulators as cacheHitPctWindow, so they ride the same windowMode gate: a ratio describing a
+        // different window than the number above it would re-create the "where is this from?" problem it
+        // exists to answer. An old daemon sends neither → no line, calmly.
+        val cacheRead = if (windowMode) u.cacheReadTokensWindow else null
+        val cacheBase = if (windowMode) u.cacheBaseTokensWindow else null
         Spacer(Modifier.height(10.dp))
         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
             StatCard(Modifier.weight(1f), scopeLabel(stringResource(Res.string.usage_requests), metricScope), requests.toString())
             if (cost != null) StatCard(Modifier.weight(1f), scopeLabel(stringResource(Res.string.usage_cost), metricScope), money(cost))
         }
         Spacer(Modifier.height(10.dp))
-        StatCard(Modifier.fillMaxWidth(), scopeLabel(stringResource(Res.string.usage_cache), metricScope), cacheHit?.let { "$it%" }, arcPct = cacheHit)
+        StatCard(
+            Modifier.fillMaxWidth(),
+            agentScopeLabel(stringResource(Res.string.usage_cache), metricScope, cacheAgent),
+            cacheHit?.let { "$it%" },
+            arcPct = cacheHit,
+            foot = if (cacheRead != null && cacheBase != null)
+                stringResource(Res.string.usage_cache_ratio, formatTokens(cacheRead), formatTokens(cacheBase)) else null,
+        )
+        // A daemon that can't filter hides the chip row entirely, so without this line NOTHING on the page
+        // would say the rate covers the whole machine — the worst case of #323, since it's also the case
+        // where the label's "all agents" can't be changed by the reader to check it.
+        if (!filterable) Text(
+            stringResource(Res.string.usage_scope_no_filter),
+            color = Tok.muted, fontSize = 11.sp, style = tightCenter(11.sp),
+            modifier = Modifier.padding(top = 6.dp),
+        )
 
         // Each range answers its own question: Today → hourly bars, 7d → daily bars, 30d → a calendar heatmap.
         // Branch on the reply's own shape (span == days.size), not the selected tab — while a fetch is in flight
@@ -292,10 +336,11 @@ private fun HeroCard(tokens: Long, scope: String, period: String, deltaPct: Int?
  * A secondary scope-tagged metric (its label carries "· today"/"· 7d"/"· 30d"). [value] null → a labeled "not
  * available yet" placeholder (never a bare dash), so a missing cache-hit reads as calm-not-broken; the caller
  * drops the cost card entirely instead (a null cost is common — subscriptions/Codex record none). Optional
- * [arcPct] draws the cache-hit gauge.
+ * [arcPct] draws the cache-hit gauge; optional [foot] is a muted line UNDER the value showing the raw
+ * numbers it was derived from (issue #323) — omitted, and the card is exactly the two-line card it was.
  */
 @Composable
-private fun StatCard(modifier: Modifier, label: String, value: String?, arcPct: Int? = null) {
+private fun StatCard(modifier: Modifier, label: String, value: String?, arcPct: Int? = null, foot: String? = null) {
     Column(
         modifier.clip(RoundedCornerShape(14.dp)).background(Tok.surface).border(1.dp, Tok.hair, RoundedCornerShape(14.dp))
             .padding(horizontal = 15.dp, vertical = 13.dp),
@@ -307,12 +352,21 @@ private fun StatCard(modifier: Modifier, label: String, value: String?, arcPct: 
             else Text(stringResource(Res.string.usage_na), color = Tok.muted, fontSize = 12.5.sp, modifier = Modifier.weight(1f, fill = false).padding(bottom = 3.dp))
             if (arcPct != null) Arc(arcPct)
         }
+        // tightCenter: this file's small type is set next to geometry (the arc) and to 22sp values, and a
+        // font-metric line box drifts between Roboto Mono / SF Mono / the desktop fallback — pin it to the
+        // size instead (project rule, TightText.kt).
+        if (foot != null) Text(foot, color = Tok.muted, fontFamily = FontFamily.Monospace, fontSize = 11.sp, style = tightCenter(11.sp))
     }
 }
 
 /** "Requests" -> "Requests · 7d": pins a sub-metric's baseline in its label — the window scope ("today"/"7d"/
  *  "30d"), or "today" when falling back to an old daemon's today-only values. */
 private fun scopeLabel(metric: String, scope: String) = "$metric · $scope"
+
+/** "Cache hit" -> "Cache hit · 7d · Claude" / "… · all agents": a RATIO also needs the population it was
+ *  taken over, not just the time window (issue #323). [agent] is the selected agent's name, or the explicit
+ *  all-agents wording — never blank, because an unlabeled aggregate is the thing this fixes. */
+private fun agentScopeLabel(metric: String, scope: String, agent: String) = "${scopeLabel(metric, scope)} · $agent"
 
 private val MONTHS = listOf("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
 

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/ChatPane.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/ChatPane.kt
@@ -178,6 +178,7 @@ import dev.ccpocket.app.resources.thinking_streaming
 import dev.ccpocket.app.resources.thought_for
 import dev.ccpocket.app.resources.turn_done_marker
 import dev.ccpocket.app.resources.value_default
+import dev.ccpocket.app.resources.value_unknown
 import org.jetbrains.compose.resources.stringResource
 import dev.ccpocket.app.share.previewFile
 import dev.ccpocket.app.ui.CheckMiniGlyph
@@ -1070,9 +1071,16 @@ private fun ChatSubHeader(model: DesktopModel, onTerminalMenu: () -> Unit = {}) 
         val ctx = model.contextUsed?.let { u ->
             model.contextWindow?.let { w -> "  ·  ctx ${(u * 100 / w)}%" } ?: "  ·  ctx ~${u / 1000}k"
         } ?: ""
-        // model segment falls back to "default" (never a dangling " · ") for a pre-first-turn session the
-        // daemon couldn't eager-resolve — mirrors mobile's placeholder + the ⋯ Model row (issue #96)
-        val modelLabel = model.chatModel.ifBlank { stringResource(Res.string.value_default) }
+        // model segment always says SOMETHING (never a dangling " · ") for a pre-first-turn session the
+        // daemon couldn't eager-resolve — mirrors mobile's placeholder + the ⋯ Model row (issue #96).
+        // "default" is a Claude FACT (the account's default model when the user pinned none); for every
+        // other agent it was a lie the header told for the whole session — a dsh chat running
+        // deepseek-v4-flash read "default" (issue #320). If the backend hasn't named its model, say so.
+        val unknownModel = stringResource(Res.string.value_unknown)
+        val defaultModel = stringResource(Res.string.value_default)
+        val modelLabel = model.chatModel.ifBlank {
+            if (model.chatAgent == AgentKind.CLAUDE) defaultModel else unknownModel
+        }
         // pathLinked left-clicks OPEN the workdir (when it's local); right-click adds "Copy path" so the
         // cwd is grabbable even on a remote session where it isn't a link at all. Copies the bare workdir,
         // not the whole machine·branch·model meta line.
@@ -1268,6 +1276,10 @@ private fun MessageRow(
         is ChatItem.QuestionsWithdrawn -> Text(
             stringResource(Res.string.questions_withdrawn), color = Tok.muted, fontFamily = Dk.ui, fontSize = 12.sp,
         )
+        // asked but never answered (issue #321) — the read-only counterpart of the live card the tail
+        // item docks. It used to fall through to a plain tool row named "AskUserQuestion", which is why
+        // it read as a question you could see and not complete.
+        is ChatItem.QuestionsUnanswered -> dev.ccpocket.app.ui.QuestionsUnansweredRow(item.text)
         // OpenCode asked a question — read-only card (no answer channel yet, issue #210)
         is ChatItem.OpenCodeQuestion -> dev.ccpocket.app.ui.OpenCodeQuestionCard(item.questions)
         // a live turn's end: quiet ✓ divider so "finished" stays visible after the caret stops blinking

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/MenuBarExtra.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/MenuBarExtra.kt
@@ -26,12 +26,16 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberWindowState
+import dev.ccpocket.app.resources.Res
+import dev.ccpocket.app.resources.tray_exit_app
+import dev.ccpocket.app.resources.tray_open_app
 import dev.ccpocket.app.theme.PocketTheme
 import dev.ccpocket.app.theme.Tok
 import java.awt.BasicStroke
 import java.awt.Color
 import java.awt.Font
 import java.awt.GraphicsConfiguration
+import java.awt.GraphicsDevice
 import java.awt.GraphicsEnvironment
 import java.awt.RenderingHints
 import java.awt.Toolkit
@@ -40,6 +44,7 @@ import java.awt.geom.Path2D
 import java.awt.image.BaseMultiResolutionImage
 import java.awt.image.BufferedImage
 import kotlinx.coroutines.delay
+import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.skiko.SystemTheme
 import org.jetbrains.skiko.currentSystemTheme
 
@@ -55,6 +60,8 @@ import org.jetbrains.skiko.currentSystemTheme
  * Compose [Window] packed to the popover's content, anchored under the click (macOS) or above it
  * (bottom taskbars), dismissed on focus loss / Esc; ⌘⏎ raises the main window. The popover renders the
  * SAME [TrayPopover] the title-bar dot shows in-window — one surface, promoted to the OS layer.
+ * Windows additionally gets a right-click menu drawn by the OS ([trayContextMenu]) and a transparent
+ * flyout shell so the 8dp corners can actually read ([trayWindowChrome]) — both issue #322.
  *
  * Headless / unsupported trays (Linux without a tray, CI) compose to nothing, so every other platform
  * behavior is unchanged.
@@ -143,10 +150,54 @@ internal fun MenuBarExtra(
             if (added) runCatching { java.awt.SystemTray.getSystemTray().remove(trayIcon) }
         }
     }
+
+    // ── 右键：Windows 的原生上下文菜单（issue #322） ──
+    // stringResource 是 composable，effect 里调不了，所以文案先在组合作用域取出来，再当 key 用
+    // （换语言 → 菜单重建；托盘图标本身不重挂，避免语言开关顺带让通知区图标闪一下）。
+    val openLabel = stringResource(Res.string.tray_open_app)
+    val exitLabel = stringResource(Res.string.tray_exit_app)
+    val menuSpec = trayContextMenu(isWindows, openLabel, exitLabel, canExit = onExitApplication != null)
+    // 菜单项活得比一次组合长，回调用 rememberUpdatedState 取最新的一份，避免钉死首次组合的闭包
+    val activate by rememberUpdatedState(onActivateWindow)
+    val exitApp by rememberUpdatedState(onExitApplication)
+    DisposableEffect(menuSpec) {
+        val items = menuSpec ?: return@DisposableEffect onDispose { }
+        // PopupMenu 在 headless 下构造即抛 HeadlessException；这里已被 supported 挡住，兜底照 file 里
+        // 其它 AWT 调用的写法用 runCatching，起不来就当没有右键菜单，左键那条路不受影响
+        val built = runCatching {
+            val menu = java.awt.PopupMenu()
+            val wired = items.map { item ->
+                val mi = java.awt.MenuItem(item.label)
+                val l = java.awt.event.ActionListener {
+                    anchor = null // 右键选中即收起左键浮层——两条路不该同时占着屏幕
+                    closedAt = System.currentTimeMillis()
+                    when (item.action) {
+                        TrayMenuAction.OPEN_MAIN -> activate()
+                        TrayMenuAction.EXIT_APP -> exitApp?.invoke()
+                    }
+                }
+                mi.addActionListener(l)
+                menu.add(mi)
+                mi to l
+            }
+            trayIcon.popupMenu = menu
+            menu to wired
+        }.getOrNull()
+        onDispose {
+            if (built != null) {
+                val (menu, wired) = built
+                trayIcon.popupMenu = null // 先摘引用，AWT 才肯放掉 popup 的 isTrayIconPopup 标记
+                wired.forEach { (mi, l) -> mi.removeActionListener(l) }
+                menu.removeAll()
+            }
+        }
+    }
     // every redraw asks the OS afresh; an appearance flip alone lands on the next state change or click
     LaunchedEffect(spec, appearancePing) { trayIcon.image = menuBarImage(spec, darkMenuBar = menuBarIsDark()) }
 
     // ── the anchored popover window ──
+    // 外壳（透明与否 / 谁画投影）在 issue #322 里分叉，探一次逐像素透明能力就够——同一台机器上它不会变
+    val chrome = remember(isWindows) { trayWindowChrome(isWindows, perPixelTranslucencySupported()) }
     val a = anchor
     if (a != null) {
         Window(
@@ -161,12 +212,17 @@ internal fun MenuBarExtra(
                 size = DpSize.Unspecified, // pack to the popover's content
             ),
             undecorated = true,
-            // OPAQUE on purpose: skiko 0.8.18 (CMP 1.7.3) crashes creating the Metal device for a
+            // OPAQUE on purpose ON macOS: skiko 0.8.18 (CMP 1.7.3) crashes creating the Metal device for a
             // TRANSPARENT window on macOS 26 "Tahoe" — EXC_BREAKPOINT in AppKit _NSWindowSetShadowProperties
             // via MetalRedrawer.createMetalDevice (JetBrains CMP-7352 / compose-multiplatform#3171). The
             // main window is undecorated+opaque and renders fine on the same OS, so this popover matches it:
             // the card fills an opaque root (below) and leans on the native window shadow instead of the
             // transparent-gutter self-shadow. Restore transparency (for rounded corners) after a skiko bump.
+            // 那个崩溃是 **macOS 独有的**（Metal/AppKit 路径），Windows 的 DirectX 后端不受影响，所以
+            // issue #322 在这里分叉：Windows 走透明。必须分叉是因为 DWM 只给「有 caption 的窗口」补圆角，
+            // 不透明的无边框窗口在 Win11 上永远是方角——浮层自己画的 8dp 圆角会被那块方角底盖掉，
+            // 发仔复报的「圆角没有正确呈现」就是这个。见 [trayWindowChrome]。
+            transparent = chrome.transparent,
             resizable = false,
             alwaysOnTop = true,
             title = "cc-pocket",
@@ -181,12 +237,14 @@ internal fun MenuBarExtra(
             },
         ) {
             // anchor under the glyph (or above a bottom taskbar); re-place whenever packing/content resizes
-            DisposableEffect(a) {
+            // 透明外壳时窗口比卡片大一圈（自绘投影的留白），落点要把那一圈扣回去——见 [winFlyoutWindowOrigin]
+            val gutter = if (chrome.selfShadow) WIN_FLYOUT_SHADOW_GUTTER else 0
+            DisposableEffect(a, gutter) {
                 val w = window
                 val l = object : java.awt.event.ComponentAdapter() {
-                    override fun componentResized(e: java.awt.event.ComponentEvent?) { placePopover(w, a) }
+                    override fun componentResized(e: java.awt.event.ComponentEvent?) { placePopover(w, a, gutter) }
                 }
-                placePopover(w, a)
+                placePopover(w, a, gutter)
                 w.addComponentListener(l)
                 onDispose { w.removeComponentListener(l) }
             }
@@ -207,9 +265,8 @@ internal fun MenuBarExtra(
             val rowCounts = model.attention.size to model.running.size
             LaunchedEffect(rowCounts) { window.pack() }
             PocketTheme(mode = model.themeMode) {
-                // Opaque root so the borderless window's square corners blend into the card colour; the
-                // OS supplies the drop shadow an opaque window gets for free. flat (elevated=false) card,
-                // no transparent-gutter self-shadow, no pointer triangle (it needs transparency to read).
+                // 两种外壳，见 [trayWindowChrome]：Windows 走透明窗口（圆角/投影归浮层自己），
+                // mac/Linux 走不透明窗口（圆角画不出来，但避开了 skiko 在 Tahoe 上的必崩）。
                 if (a.corner) {
                     // issue #292 — Windows flyout。入场按稿子上升 22dp + 淡入 250ms ease-out，但用
                     // graphicsLayer 而不是 AnimatedVisibility：后者在动画期间内容不参与测量，窗口会先
@@ -217,7 +274,7 @@ internal fun MenuBarExtra(
                     // 关闭那一刻窗口已经没了，没有可以淡的东西。
                     val intro = remember { Animatable(0f) }
                     LaunchedEffect(Unit) { intro.animateTo(1f, tween(250, easing = LinearOutSlowInEasing)) }
-                    Box(Modifier.background(Tok.surface)) {
+                    val flyout: @Composable () -> Unit = {
                         WinTrayFlyout(
                             model,
                             onOpenMain = { anchor = null; onActivateWindow() },
@@ -226,10 +283,19 @@ internal fun MenuBarExtra(
                                 alpha = intro.value
                                 translationY = (1f - intro.value) * 22.dp.toPx()
                             },
+                            // 透明外壳下窗口只是一块透明画布：圆角、描边、投影全由浮层自己画
+                            elevated = chrome.selfShadow,
                             onRelayout = { window.pack() },
                         )
                     }
+                    // issue #322：透明化之后**不能**再包这层不透明底——Tok.surface 会铺满整扇方角窗口，
+                    // 正好把浮层自己的 8dp 圆角填回直角。逐像素透明拿不到时（虚拟机 / 远程桌面 / 老驱动，
+                    // 见 [perPixelTranslucencySupported]）退回旧的不透明底，至少不比改动前差。
+                    if (chrome.transparent) flyout() else Box(Modifier.background(Tok.surface)) { flyout() }
                 } else {
+                    // Opaque root so the borderless window's square corners blend into the card colour; the
+                    // OS supplies the drop shadow an opaque window gets for free. flat (elevated=false) card,
+                    // no transparent-gutter self-shadow, no pointer triangle (it needs transparency to read).
                     Box(Modifier.background(Tok.raised)) {
                         TrayPopover(
                             model,
@@ -253,9 +319,81 @@ internal const val POPOVER_W = 360 // the opaque card's width (placePopover re-c
 /** Windows 浮层与工作区边缘的间距（issue #292 稿子：距右屏边 12px、任务栏上方 12px）。 */
 internal const val WIN_FLYOUT_GAP = 12
 
+/**
+ * 透明外壳下，浮层自绘投影要用的一圈透明外扩（issue #322）。
+ *
+ * 投影画在内容盒**之外**，而承载窗口是 pack 到内容的，不留这一圈就等于把投影整块裁掉——透明白开了。
+ * 取值**故意等于** [WIN_FLYOUT_GAP]：窗口整体外扩 12、落点再往回缩 12（[winFlyoutWindowOrigin]），
+ * 于是卡片与工作区边缘仍是稿子要的 12px，而窗口本身刚好贴齐工作区角、一个像素都不压到任务栏上——
+ * 透明像素照样吃鼠标事件，压过去就会吞掉任务栏上的点击。
+ */
+internal const val WIN_FLYOUT_SHADOW_GUTTER = WIN_FLYOUT_GAP
+
 /** 宿主是否 Windows —— [MenuBarExtra] 的载体分叉默认值（Main.kt 也各自算过一次，两处含义相同）。 */
 internal fun hostIsWindows(): Boolean =
     System.getProperty("os.name").orEmpty().lowercase().contains("windows")
+
+// ── 托盘右键菜单（issue #322） ────────────────────────────────────────────────────────────────────
+
+/** 右键菜单一项对应的出口。 */
+internal enum class TrayMenuAction { OPEN_MAIN, EXIT_APP }
+
+/** 右键菜单的一项：[label] 已本地化，[action] 是它落到哪个出口。 */
+internal data class TrayMenuItem(val action: TrayMenuAction, val label: String)
+
+/**
+ * 托盘图标右键该弹什么 —— **纯函数**，因为另一半（[java.awt.PopupMenu]）在 headless 下构造即抛，
+ * 测不了；把「挂不挂、挂哪几项」的决策搬到 AWT 之外，至少这一半是可断言的。
+ *
+ * `null` = **一个 popupMenu 都不挂**。issue #322 的边界写死「不改 macOS／Linux 行为」：mac 菜单栏图标
+ * 的右键由系统给（等同左键那套），Linux 各家托盘实现也自带右键语义，硬塞一个 AWT 菜单只是多一层
+ * 不属于那个平台的东西。
+ *
+ * Windows 反过来——通知区图标右键弹菜单是刻在肌肉记忆里的，而 #322 之前 [MenuBarExtra] 只监听
+ * BUTTON1，右键**完全没有出口**（发仔复报的「右键无响应」）。走 AWT 原生 [java.awt.PopupMenu] 而不是
+ * 自己监听 BUTTON3 再弹一扇 Compose 窗口：Win32 的托盘右键菜单由系统绘制、定位和消失，自绘的那种
+ * 在多屏 + 任务栏靠侧边时必然错位，还得自己复刻「点别处就关」。
+ *
+ * [canExit] 为假时只留「打开」：[dev.ccpocket.app.main] 只在 Windows 传 onExitApplication（#189，
+ * mac/Linux 的关窗语义不同），菜单里不该长出一个点了没反应的退出项。
+ */
+internal fun trayContextMenu(
+    isWindows: Boolean,
+    openLabel: String,
+    exitLabel: String,
+    canExit: Boolean,
+): List<TrayMenuItem>? {
+    if (!isWindows) return null
+    val items = mutableListOf(TrayMenuItem(TrayMenuAction.OPEN_MAIN, openLabel))
+    if (canExit) items += TrayMenuItem(TrayMenuAction.EXIT_APP, exitLabel)
+    return items
+}
+
+// ── 浮层外壳：透明 / 圆角 / 投影归谁（issue #322） ────────────────────────────────────────────────
+
+/** 承载窗口的外壳形态：[transparent] 交给 Compose 的 Window，[selfShadow] 交给 [WinTrayFlyout]。 */
+internal data class TrayWindowChrome(val transparent: Boolean, val selfShadow: Boolean)
+
+/**
+ * 谁来画圆角和投影。
+ *
+ * - **Windows + 支持逐像素透明** → 透明窗口，圆角/描边/投影全归浮层自己（[WinTrayFlyout] 的
+ *   `elevated`）。DWM 只给带 caption 的窗口补圆角，不透明的无边框窗口在 Win11 上永远是方角，
+ *   浮层画的 8dp 圆角会被那块方角底盖掉——这就是 #322 复报的圆角失真。
+ * - **macOS / Linux** → 一字不动的不透明窗口。macOS 那边不是审美选择而是硬约束：skiko 0.8.18 建
+ *   **透明** Compose 窗口在 macOS 26 "Tahoe" 上必崩（CMP-7352，见 [MenuBarExtra] 里的长注释）。
+ * - **Windows 但拿不到逐像素透明**（虚拟机 / 远程桌面 / 老驱动）→ 退回不透明。宁可维持改动前的
+ *   方角，也不能让 `setBackground(alpha<255)` 在窗口创建时抛异常把整个 App 带崩。
+ */
+internal fun trayWindowChrome(isWindows: Boolean, translucencySupported: Boolean): TrayWindowChrome =
+    if (isWindows && translucencySupported) TrayWindowChrome(transparent = true, selfShadow = true)
+    else TrayWindowChrome(transparent = false, selfShadow = false)
+
+/** 本机窗口系统是否支持逐像素透明。查不到 / 抛异常一律当不支持——见 [trayWindowChrome] 的退路。 */
+internal fun perPixelTranslucencySupported(): Boolean = runCatching {
+    GraphicsEnvironment.getLocalGraphicsEnvironment().defaultScreenDevice
+        .isWindowTranslucencySupported(GraphicsDevice.WindowTranslucency.PERPIXEL_TRANSLUCENT)
+}.getOrDefault(false)
 
 /**
  * Where the popover hangs: the glyph's screen X, the edge Y to grow from, and which way it grows.
@@ -298,10 +436,21 @@ internal fun winFlyoutAnchor(gc: GraphicsConfiguration): TrayAnchor {
     )
 }
 
-/** 角锚定的窗口左上角：工作区右缘 −12 −宽、任务栏顶 −12 −高，并夹在屏幕内（超大浮层不会跑出屏外）。 */
+/** 角锚定的**卡片**左上角：工作区右缘 −12 −宽、任务栏顶 −12 −高，并夹在屏幕内（超大浮层不会跑出屏外）。 */
 internal fun winFlyoutOrigin(a: TrayAnchor, w: Int, h: Int): Pair<Int, Int> =
     (a.workRight - WIN_FLYOUT_GAP - w).coerceAtLeast(a.screen.x + WIN_FLYOUT_GAP) to
         (a.workBottom - WIN_FLYOUT_GAP - h).coerceAtLeast(a.screen.y + WIN_FLYOUT_GAP)
+
+/**
+ * 角锚定的**窗口**左上角（issue #322）。透明外壳下窗口比卡片四周各大 [gutter]（自绘投影的留白），
+ * 所以先按卡片尺寸算贴角落点、再整体外扩一圈；[gutter] = 0 时与 [winFlyoutOrigin] 完全等价。
+ *
+ * 桌面端窗口几何 1 AWT 点 = 1 dp，所以这里的 [gutter] 和 [WinTrayFlyout] 里那圈 padding 是同一个数。
+ */
+internal fun winFlyoutWindowOrigin(a: TrayAnchor, winW: Int, winH: Int, gutter: Int): Pair<Int, Int> {
+    val (x, y) = winFlyoutOrigin(a, winW - 2 * gutter, winH - 2 * gutter)
+    return (x - gutter) to (y - gutter)
+}
 
 private fun screenConfigAt(x: Int, y: Int): GraphicsConfiguration {
     val ge = GraphicsEnvironment.getLocalGraphicsEnvironment()
@@ -310,10 +459,10 @@ private fun screenConfigAt(x: Int, y: Int): GraphicsConfiguration {
 }
 
 /** Center the (now measured) window on the glyph, clamped to the screen, growing down or up per anchor.
- *  角锚定（Windows）走 [winFlyoutOrigin]，与点击点无关。 */
-internal fun placePopover(w: java.awt.Window, a: TrayAnchor) {
+ *  角锚定（Windows）走 [winFlyoutWindowOrigin]，与点击点无关；[gutter] 是透明外壳自绘投影的留白。 */
+internal fun placePopover(w: java.awt.Window, a: TrayAnchor, gutter: Int = 0) {
     if (a.corner) {
-        val (cx, cy) = winFlyoutOrigin(a, w.width, w.height)
+        val (cx, cy) = winFlyoutWindowOrigin(a, w.width, w.height, gutter)
         w.setLocation(cx, cy)
         return
     }

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/WinTrayFlyout.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/WinTrayFlyout.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.ccpocket.app.epochMillis
@@ -85,6 +86,11 @@ import org.jetbrains.compose.resources.stringResource
  * 颜色一律走 [Tok]，不硬编码稿子里的十六进制（稿子的 `#16171B` / `#E2795A` 就是本 App 暗色板的
  * 同位色，只差一两级）。硬编码会同时废掉亮色主题和 Codex 强调色主题——那才是真的改设计。
  * 稿子里的白色叠层（wash / hover fill / 高光线）按 [Tok.tx] 取 alpha，亮色板下自然反相成压暗。
+ *
+ * **issue #322 的两处收敛**（发仔在正式安装包上复报）：
+ * 1. `elevated` 从「窗内浮层的可选投影」变成「透明外壳」的开关——承载窗口透明之后，圆角、描边、
+ *    投影全归这里画，见 [WIN_FLYOUT_SHADOW_GUTTER] 与 [trayWindowChrome]。
+ * 2. 页脚三样东西原本都是裸文字、读作三条等重的链接；现在收敛成两级，形态表在 [winActionLook]。
  */
 @Composable
 fun WinTrayFlyout(
@@ -116,8 +122,13 @@ fun WinTrayFlyout(
 
     val shape = RoundedCornerShape(WIN_FLYOUT_RADIUS)
     Box(
-        modifier.width(360.dp)
-            .then(if (elevated) Modifier.shadow(28.dp, shape) else Modifier)
+        // elevated = 透明外壳（issue #322）。窗口不再给不透明底、Win11 的 DWM 也不给无 caption 窗口补
+        // 圆角和投影，所以圆角/描边/投影全在这一串里自己画。先 padding 出 [WIN_FLYOUT_SHADOW_GUTTER]
+        // 一圈透明外扩：投影落在内容盒之外，而承载窗口 pack 到内容，不留白就等于把投影裁光。投影高度
+        // 取与留白同值——铺开范围约等于 elevation，正好用满这一圈、又不至于外溢成一片糊。
+        (if (elevated) modifier.padding(WIN_FLYOUT_SHADOW_GUTTER.dp) else modifier)
+            .width(360.dp)
+            .then(if (elevated) Modifier.shadow(WIN_FLYOUT_SHADOW_GUTTER.dp, shape) else Modifier)
             .clip(shape).background(Tok.surface).border(1.dp, Tok.hair, shape)
             .then(if (menuOpen && menuH > 0.dp) Modifier.heightIn(min = WIN_MENU_TOP + menuH + 8.dp) else Modifier),
     ) {
@@ -223,9 +234,45 @@ internal val WIN_CTRL_RADIUS = 4.dp
 private val WIN_MENU_TOP = 52.dp
 
 /** 稿子的暖色两档：填充用 [Tok.accent] 本色，hover 暖一阶，标签/计数/溢出行则提亮以便在暗底上认读。
- *  用 lerp 从既有 token 推导，而不是新增 token——亮色板下同样成立。 */
-private val accentHot: Color @Composable get() = lerp(Tok.accent, Tok.tx, 0.12f)
-private val accentSoft: Color @Composable get() = lerp(Tok.accent, Tok.tx, 0.30f)
+ *  用 lerp 从既有 token 推导，而不是新增 token——亮色板下同样成立。
+ *  刻意**不是** `@Composable get()`：[Tok] 是全局 snapshot 对象，在组合里读照样会触发重组，去掉这个
+ *  修饰才能让 [winActionLook] 这张形态表留在组合之外、被单测直接调用（issue #322）。 */
+private val accentHot: Color get() = lerp(Tok.accent, Tok.tx, 0.12f)
+private val accentSoft: Color get() = lerp(Tok.accent, Tok.tx, 0.30f)
+
+// ── 页脚两级动作的形态表（issue #322） ───────────────────────────────────────────────────────────
+
+/** 一级动作长什么样：填充、字色、字重、字号。 */
+internal data class WinActionLook(val fill: Color, val ink: Color, val weight: FontWeight, val size: TextUnit)
+
+/**
+ * 页脚「打开 cc-pocket」/「退出」的两级形态。
+ *
+ * 抽成函数不是为了复用（就两个调用点），是为了让「主操作明显重于次操作」这条**能被断言**：Compose
+ * 的语义树里读不到填充色和字重，形态留在渲染里就只剩真机目验一条路，而 #322 复报的正是「按钮层级
+ * 不协调」——改版前两个动作都是裸文字，只差 1sp 字号和 tx/muted 两级灰，在 42dp 页脚里读作两条等重
+ * 的链接，主操作根本认不出来。
+ *
+ * 现在：主操作是实心 [Tok.accent] 块——整个浮层里只有它和审批行的「允许」是实心的，两者含义一致
+ * （按下去立刻发生事情）；次操作退回 [Tok.muted] 纯文字，只在 hover 时浮出一层极淡 wash 提示可点。
+ * 颜色一律取自 [Tok]，不新增色值，亮暗两套板与 Codex 强调色下都成立。
+ */
+internal fun winActionLook(primary: Boolean, hovered: Boolean): WinActionLook =
+    if (primary) {
+        WinActionLook(
+            fill = if (hovered) accentHot else Tok.accent,
+            ink = Tok.base,
+            weight = FontWeight.SemiBold,
+            size = 12.sp,
+        )
+    } else {
+        WinActionLook(
+            fill = if (hovered) Tok.tx.copy(alpha = 0.07f) else Color.Transparent,
+            ink = if (hovered) Tok.tx2 else Tok.muted,
+            weight = FontWeight.Normal,
+            size = 11.5.sp,
+        )
+    }
 
 // ── 组件 ─────────────────────────────────────────────────────────────────────────────────────────
 
@@ -427,7 +474,13 @@ private fun WinRunningRow(title: String, computer: String, elapsed: String?, onC
     }
 }
 
-/** 页脚 42dp：打开 CC Pocket（左）· +N 个会话（灰，居中）· 退出（右）。 */
+/**
+ * 页脚 42dp：主操作「打开 cc-pocket」（实心 accent，左）· +N 个会话（灰字，居中）· 退出（次级，右）。
+ *
+ * 两级形态见 [winActionLook]。中间那句刻意保持**不可点**——它是状态陈述而不是动作，做成第三个可点
+ * 目标只会稀释「这里只有一个主操作」。三段文字字号不同、又与实心块同排几何居中，所以按项目铁律
+ * 全部带 [tightCenter]（少给一个就会整排错位）。
+ */
 @Composable
 private fun WinFlyoutFooter(moreSessions: Int, onOpenMain: () -> Unit, onExitApp: (() -> Unit)?) {
     WinFlyoutDivider()
@@ -435,22 +488,32 @@ private fun WinFlyoutFooter(moreSessions: Int, onOpenMain: () -> Unit, onExitApp
         Modifier.fillMaxWidth().height(42.dp).background(Tok.tx.copy(alpha = 0.018f)).padding(horizontal = 12.dp),
         verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        Text(
-            stringResource(Res.string.tray_open_app), color = Tok.tx, fontFamily = Dk.ui, fontSize = 12.5.sp,
-            fontWeight = FontWeight.SemiBold, maxLines = 1, modifier = Modifier.clickable(onClick = onOpenMain),
-        )
+        WinActionButton(stringResource(Res.string.tray_open_app), primary = true, onClick = onOpenMain)
         Text(
             if (moreSessions > 0) stringResource(Res.string.win_tray_more_sessions, moreSessions) else "",
-            color = Tok.muted, fontFamily = Dk.ui, fontSize = 11.5.sp, maxLines = 1,
+            color = Tok.muted, fontFamily = Dk.ui, fontSize = 11.5.sp, style = tightCenter(11.5.sp), maxLines = 1,
             overflow = TextOverflow.Ellipsis, textAlign = TextAlign.Center, modifier = Modifier.weight(1f),
         )
         if (onExitApp != null) {
-            Text(
-                stringResource(Res.string.win_tray_exit), color = Tok.muted, fontFamily = Dk.ui, fontSize = 11.5.sp,
-                maxLines = 1, modifier = Modifier.clickable(onClick = onExitApp),
-            )
+            WinActionButton(stringResource(Res.string.win_tray_exit), primary = false, onClick = onExitApp)
         }
     }
+}
+
+/** 页脚动作钮：主/次共用一具排版（28dp 高、方角 [WIN_CTRL_RADIUS]、文字压中），差别全在 [winActionLook]。 */
+@Composable
+private fun WinActionButton(text: String, primary: Boolean, onClick: () -> Unit) {
+    val src = remember { MutableInteractionSource() }
+    val hovered by src.collectIsHoveredAsState()
+    val look = winActionLook(primary, hovered)
+    Text(
+        text, color = look.ink, fontFamily = Dk.ui, fontSize = look.size, fontWeight = look.weight,
+        style = tightCenter(look.size), maxLines = 1,
+        modifier = Modifier.height(28.dp).clip(RoundedCornerShape(WIN_CTRL_RADIUS)).background(look.fill)
+            .hoverable(src).clickable(onClick = onClick)
+            .padding(horizontal = if (primary) 12.dp else 9.dp)
+            .wrapContentHeightCentered(),
+    )
 }
 
 /** (…) 溢出菜单：214dp 宽、[Tok.raised] 面、圆角 8dp。「隐藏此浮层」直接写 `menuBarEnabled` 这个

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/data/ReplayedQuestionRowTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/data/ReplayedQuestionRowTest.kt
@@ -1,0 +1,74 @@
+package dev.ccpocket.app.data
+
+import dev.ccpocket.app.pairing.PairedDaemon
+import dev.ccpocket.protocol.ChatRole
+import dev.ccpocket.protocol.ConvoHistory
+import dev.ccpocket.protocol.HistoryMessage
+import dev.ccpocket.protocol.QuestionAnswer
+import dev.ccpocket.protocol.SessionLive
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * Issue #321: a replayed AskUserQuestion must read as what it is.
+ *
+ * The report was a DeepSeek Harness question you could see and not complete, on a turn that then sat
+ * there. Half of that is the daemon's (see `DshAskLedgerTest`); this is the client half, and it was the
+ * more misleading one: an UNANSWERED question row fell through every question branch and landed on the
+ * generic tool row, so it rendered as a card-ish thing titled "AskUserQuestion" showing the question
+ * text — visually a question, with nothing to tap and nothing saying why.
+ *
+ * The three states are now distinct, and the mapping is backend-agnostic on purpose: every replay path
+ * (Claude's `TranscriptReplay`, dsh's `DshTranscriptReplay`) files the row under the same tool name, and
+ * an interrupted Claude turn leaves exactly the same residue.
+ */
+class ReplayedQuestionRowTest {
+
+    private fun repo() = PocketRepository(CoroutineScope(Dispatchers.Unconfined)).apply {
+        paired.value = PairedDaemon(
+            relay = "wss://test", accountId = "acct-test", daemonPub = "pk", deviceId = "dev", credential = "cred",
+        )
+        convoId.value = "c1"
+        receiveForTest(SessionLive("c1", "/w", "sid-1", executing = false))
+    }
+
+    /** The row the daemon replays for a question: tool name + the question text, answers patched in only
+     *  when a matching tool_result existed. */
+    private fun questionRow(answers: List<QuestionAnswer>? = null) =
+        HistoryMessage(ChatRole.TOOL, "Ship it?", tool = "AskUserQuestion", answers = answers)
+
+    @Test
+    fun an_unanswered_question_is_labelled_unanswered_not_dressed_up_as_a_tool_call() {
+        val r = repo()
+        r.receiveForTest(ConvoHistory("c1", listOf(questionRow()), lastSeq = 2, firstSeq = 1))
+
+        val row = assertIs<ChatItem.QuestionsUnanswered>(
+            r.messages.single(),
+            "an AskUserQuestion with no answers must not fall through to the generic tool row",
+        )
+        assertEquals("Ship it?", row.text)
+    }
+
+    @Test
+    fun an_answered_question_still_replays_as_the_answered_row() {
+        val r = repo()
+        val answered = questionRow(listOf(QuestionAnswer("Ship it?", "Yes")))
+        r.receiveForTest(ConvoHistory("c1", listOf(answered), lastSeq = 2, firstSeq = 1))
+
+        val row = assertIs<ChatItem.QuestionsAnswered>(r.messages.single())
+        assertEquals(listOf("Ship it?" to "Yes"), row.items)
+    }
+
+    /** The new branch keys on the ask tool ALONE, so an ordinary tool row is untouched by it. */
+    @Test
+    fun an_ordinary_tool_row_is_unaffected() {
+        val r = repo()
+        r.receiveForTest(
+            ConvoHistory("c1", listOf(HistoryMessage(ChatRole.TOOL, "ls -la", tool = "Bash")), lastSeq = 2, firstSeq = 1),
+        )
+        assertIs<ChatItem.Tool>(r.messages.single())
+    }
+}

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/WinTrayFlyoutTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/WinTrayFlyoutTest.kt
@@ -1,5 +1,6 @@
 package dev.ccpocket.app.desktop
 
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithContentDescription
@@ -24,16 +25,23 @@ import dev.ccpocket.app.resources.win_tray_notification_settings
 import dev.ccpocket.app.resources.win_tray_running
 import dev.ccpocket.app.str
 import dev.ccpocket.app.theme.PocketTheme
+import dev.ccpocket.app.theme.Tok
 import java.awt.Rectangle
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * Windows 托盘浮层（issue #292）的结构测试。
+ * Windows 托盘浮层（issue #292 / #322）的结构测试。
  *
  * 盯的是「换载体没换内容」这条边界：分段折叠、上限与溢出、空态、菜单写的是哪个开关，以及角锚定的
  * 坐标算术。像素（间距/圆角/投影）不在这里断言——那是设计稿的事，真机目验才算数。
+ *
+ * #322 补进来的三组都是**决策**而不是像素：右键菜单挂不挂（AWT 的 [java.awt.PopupMenu] 在 headless
+ * 下构造即抛，只有这一半测得了）、外壳透不透明、页脚两级动作分不分得开。形态一旦留在渲染里，
+ * Compose 的语义树读不到填充色与字重，就只剩真机目验一条路——而 #322 正是「以构建通过代替真机
+ * 验收」欠出来的单子。
  */
 @OptIn(ExperimentalTestApi::class)
 class WinTrayFlyoutTest {
@@ -210,5 +218,109 @@ class WinTrayFlyoutTest {
         // 长到超过屏幕（极端 DPI / 一堆审批）时夹在屏内，宁可底部被任务栏压住也不整块跑出可视区
         val a = TrayAnchor(0, 0, false, Rectangle(0, 0, 1920, 1080), corner = true, workRight = 1920, workBottom = 1032)
         assertEquals((1920 - 12 - 360) to 12, winFlyoutOrigin(a, 360, 2000))
+    }
+
+    // ── 页脚两级动作（issue #322） ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun footerPrimaryActionOutweighsTheSecondaryOne() {
+        // #322 复报「按钮层级不协调」：改版前「打开」和「退出」都是裸文字，只差 1sp 字号和 tx/muted
+        // 两级灰，在 42dp 页脚里读作两条等重的链接。现在必须一眼分得出谁是主操作
+        val primary = winActionLook(primary = true, hovered = false)
+        val secondary = winActionLook(primary = false, hovered = false)
+        assertEquals(Tok.accent, primary.fill, "主操作是实心 accent——浮层里只有它和审批行的「允许」是实心的")
+        assertEquals(Color.Transparent, secondary.fill, "次操作不给填充，否则两个动作又打平")
+        assertTrue(primary.weight.weight > secondary.weight.weight, "主操作字更重")
+        assertTrue(primary.size.value > secondary.size.value, "主操作字更大")
+        assertTrue(primary.ink != secondary.ink, "字色也分得开")
+    }
+
+    @Test
+    fun bothFooterActionsAnswerTheirOwnHover() {
+        // 次级退成纯文字之后仍要看得出「可点」——hover 才浮出的那层极淡 wash 就是它唯一的可供性
+        assertTrue(winActionLook(true, hovered = true).fill != winActionLook(true, hovered = false).fill)
+        assertTrue(winActionLook(false, hovered = true).fill != winActionLook(false, hovered = false).fill)
+    }
+
+    @Test
+    fun footerPrimaryActionStillOpensTheMainWindow() = runComposeUiTest {
+        // 换了形态不能换行为：收浮层 + 抬主窗，一步都不能少（#322 边界「现有可达能力不得退化」）
+        val model = SeedDesktopModel()
+        model.showTray = true
+        var raised = false
+        setContent { PocketTheme { WinTrayFlyout(model, onOpenMain = { raised = true }) } }
+        onAllNodes(hasText(str(Res.string.tray_open_app))).onFirst().performClick()
+        waitForIdle()
+        assertTrue(raised, "主操作抬主窗")
+        assertTrue(!model.showTray, "并收起托盘浮层")
+    }
+
+    // ── 托盘右键菜单（issue #322，纯决策） ────────────────────────────────────────────────────
+
+    @Test
+    fun windowsTrayGrowsANativeRightClickMenu() {
+        // 改动前 MenuBarExtra 只监听 BUTTON1，Windows 通知区右键**完全没有出口**——发仔复报的「右键无响应」
+        assertEquals(
+            listOf(
+                TrayMenuItem(TrayMenuAction.OPEN_MAIN, "Open cc-pocket"),
+                TrayMenuItem(TrayMenuAction.EXIT_APP, "Exit cc-pocket"),
+            ),
+            trayContextMenu(isWindows = true, openLabel = "Open cc-pocket", exitLabel = "Exit cc-pocket", canExit = true),
+        )
+    }
+
+    @Test
+    fun nonWindowsHostsGetNoPopupMenuAtAll() {
+        // #322 的边界写死「不改 macOS／Linux 行为」：null = 连 popupMenu 都不挂给 TrayIcon，
+        // 那两个平台的右键语义由系统 / 各家托盘实现自己给
+        assertNull(trayContextMenu(isWindows = false, openLabel = "o", exitLabel = "e", canExit = true))
+        assertNull(trayContextMenu(isWindows = false, openLabel = "o", exitLabel = "e", canExit = false))
+    }
+
+    @Test
+    fun contextMenuDropsExitWhenTheHostOffersNoExitPath() {
+        // Main 只在 Windows 传 onExitApplication（#189）；没有出口时不该长出一个点了没反应的退出项
+        assertEquals(
+            listOf(TrayMenuItem(TrayMenuAction.OPEN_MAIN, "o")),
+            trayContextMenu(isWindows = true, openLabel = "o", exitLabel = "e", canExit = false),
+        )
+    }
+
+    // ── 浮层外壳：透明 / 圆角 / 投影归谁（issue #322） ────────────────────────────────────────
+
+    @Test
+    fun onlyWindowsGoesTransparentSoTheCornersCanRead() {
+        val win = trayWindowChrome(isWindows = true, translucencySupported = true)
+        assertTrue(win.transparent, "Win11 的 DWM 不给无 caption 的不透明窗口补圆角，只能画在透明窗上")
+        assertTrue(win.selfShadow, "透明之后系统投影也没了，浮层自己补")
+
+        val mac = trayWindowChrome(isWindows = false, translucencySupported = true)
+        assertTrue(!mac.transparent, "macOS 建透明 Compose 窗口在 26 Tahoe 上必崩（CMP-7352），一字不动")
+        assertTrue(!mac.selfShadow, "不透明窗口用系统投影")
+    }
+
+    @Test
+    fun windowsWithoutPerPixelTranslucencyFallsBackToTheOpaqueShell() {
+        // 虚拟机 / 远程桌面 / 老驱动拿不到逐像素透明时，setBackground(alpha<255) 会在窗口创建时抛异常。
+        // 宁可维持改动前的方角，也不能把整个 App 带崩
+        val degraded = trayWindowChrome(isWindows = true, translucencySupported = false)
+        assertTrue(!degraded.transparent && !degraded.selfShadow)
+    }
+
+    @Test
+    fun transparentShellKeepsTheCardTwelvePxOffTheWorkAreaEdge() {
+        // 透明外壳下窗口比卡片四周各大一圈投影留白，落点必须把那圈扣回去
+        val a = TrayAnchor(0, 0, false, Rectangle(0, 0, 1920, 1080), corner = true, workRight = 1920, workBottom = 1032)
+        val g = WIN_FLYOUT_SHADOW_GUTTER
+        val (x, y) = winFlyoutWindowOrigin(a, 360 + 2 * g, 420 + 2 * g, g)
+        assertEquals(winFlyoutOrigin(a, 360, 420), (x + g) to (y + g), "卡片落点与不透明外壳时一模一样")
+        // 窗口自身刚好贴齐工作区角：透明像素照样吃鼠标事件，压到任务栏上就会吞掉那里的点击
+        assertEquals(1920 to 1032, (x + 360 + 2 * g) to (y + 420 + 2 * g))
+    }
+
+    @Test
+    fun opaqueShellPutsTheWindowExactlyWhereTheCardGoes() {
+        val a = TrayAnchor(0, 0, false, Rectangle(0, 0, 1920, 1080), corner = true, workRight = 1920, workBottom = 1032)
+        assertEquals(winFlyoutOrigin(a, 360, 420), winFlyoutWindowOrigin(a, 360, 420, gutter = 0))
     }
 }

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/ui/UsageCacheScopeUiTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/ui/UsageCacheScopeUiTest.kt
@@ -1,0 +1,136 @@
+package dev.ccpocket.app.ui
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runDesktopComposeUiTest
+import dev.ccpocket.app.assertPresent
+import dev.ccpocket.app.data.PocketRepository
+import dev.ccpocket.app.present
+import dev.ccpocket.app.resources.Res
+import dev.ccpocket.app.resources.usage_cache
+import dev.ccpocket.app.resources.usage_cache_ratio
+import dev.ccpocket.app.resources.usage_scope_all_agents
+import dev.ccpocket.app.resources.usage_scope_no_filter
+import dev.ccpocket.app.str
+import dev.ccpocket.app.theme.PocketTheme
+import dev.ccpocket.protocol.AgentKind
+import dev.ccpocket.protocol.Usage
+import dev.ccpocket.protocol.UsageDay
+import dev.ccpocket.protocol.UsageModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+/**
+ * The cache-hit card must say WHAT its percentage covers (issue #323).
+ *
+ * The reported symptom was "cache hit sits at 50–60% while my own tooling says 90%+" — and re-running the
+ * daemon's own arithmetic over real transcripts put Claude at 99% and Codex at 96%, so nothing was being
+ * mis-parsed. What was actually broken is that the page aggregates every backend it scanned and never named
+ * the mix, so a number dominated by a cache-poor backend was indistinguishable from a parsing bug. These
+ * pin the two things that make it falsifiable: the label always carries the agent dimension (including the
+ * explicit "all agents"), and the raw numerator/denominator ride underneath so the percentage can be
+ * recomputed by hand. Neither may quietly disappear.
+ */
+@OptIn(ExperimentalTestApi::class)
+class UsageCacheScopeUiTest {
+
+    /** A span-1 (Today) reply — no hours, so no trend block, leaving the stat cards as the whole page.
+     *  1.2M / 1.3M is 92%, so the printed percentage and the printed ratio agree by construction. */
+    private fun snapshot(rawTokens: Boolean = true, windowFields: Boolean = true) = Usage(
+        days = listOf(UsageDay("Thu", 1_300_000, date = "2026-08-27")),
+        models = listOf(UsageModel("claude-opus-5", 1_300_000, AgentKind.CLAUDE)),
+        tokensToday = 1_300_000,
+        requestsToday = 12,
+        cacheHitPct = 92,
+        requestsWindow = if (windowFields) 12 else null,
+        cacheHitPctWindow = if (windowFields) 92 else null,
+        cacheReadTokensWindow = if (rawTokens) 1_200_000 else null,
+        cacheBaseTokensWindow = if (rawTokens) 1_300_000 else null,
+    )
+
+    /** A repo already holding [usage] as the ALL-agents reply, as if one fetch had landed. */
+    private fun repoWith(usage: Usage, filterable: Boolean) =
+        PocketRepository(CoroutineScope(Dispatchers.Unconfined)).also {
+            it.usage.value = usage
+            it.daemonUsageAgentFilter.value = filterable
+        }
+
+    /** Renders the page exactly as the phone route does, with the daemon capabilities the test cares about. */
+    private fun harness(repo: PocketRepository): @androidx.compose.runtime.Composable () -> Unit = {
+        PocketTheme { UsageScreen(repo, onBack = {}) }
+    }
+
+    private fun harness(usage: Usage, filterable: Boolean) = harness(repoWith(usage, filterable))
+
+    /** The unfiltered view is the DEFAULT, so it is the one that most needs naming itself — an unlabeled
+     *  aggregate is exactly what made the reported number impossible to argue with. */
+    @Test
+    fun unfilteredCacheCardNamesTheAggregateAndItsRawTokens() = runDesktopComposeUiTest(402, 874) {
+        mainClock.autoAdvance = false
+        setContent(harness(snapshot(), filterable = true))
+        waitForIdle()
+
+        assertPresent(str(Res.string.usage_scope_all_agents), substring = true)
+        assertPresent(str(Res.string.usage_cache_ratio, "1.2M", "1.3M"), substring = true)
+        // a daemon that CAN filter must not also apologize for not filtering
+        assertFalse(present(str(Res.string.usage_scope_no_filter), substring = true))
+    }
+
+    /**
+     * The label follows the REPLY, not the chip. Tapping an agent re-fetches, but the page deliberately
+     * keeps the previous reply on screen meanwhile — so between tap and reply the card still holds the
+     * all-agents numbers, and must still say so. A label wired to the selection would spend that whole
+     * window putting one agent's name over another agent's number, which is the very confusion #323 is
+     * about, just faster.
+     */
+    @Test
+    fun theLabelWaitsForTheReplyInsteadOfFollowingTheChip() = runDesktopComposeUiTest(402, 874) {
+        mainClock.autoAdvance = false
+        val repo = repoWith(snapshot(), filterable = true)
+        setContent(harness(repo))
+        waitForIdle()
+
+        onAllNodes(hasText(agentName(AgentKind.CODEX))).onFirst().performClick()
+        waitForIdle()
+
+        // fetch in flight: the numbers on screen are still the aggregate, so the label still is too
+        assertPresent(str(Res.string.usage_scope_all_agents), substring = true)
+        assertFalse(present(agentName(AgentKind.CODEX) + " ·", substring = true))
+
+        // …and once Codex's own reply lands, the card is relabelled with it
+        repo.receiveForTest(snapshot())
+        waitForIdle()
+
+        assertPresent("${str(Res.string.usage_cache)} · today · ${agentName(AgentKind.CODEX)}", substring = true)
+        assertFalse(present(str(Res.string.usage_scope_all_agents), substring = true))
+    }
+
+    /** The worst case: the daemon ignores the filter, so the chip row is hidden and the reader cannot even
+     *  probe the scope by tapping. The card has to state the scope in prose or nothing on the page does. */
+    @Test
+    fun aDaemonThatCannotFilterSaysSoUnderTheCard() = runDesktopComposeUiTest(402, 874) {
+        mainClock.autoAdvance = false
+        setContent(harness(snapshot(), filterable = false))
+        waitForIdle()
+
+        assertPresent(str(Res.string.usage_scope_no_filter), substring = true)
+        assertPresent(str(Res.string.usage_scope_all_agents), substring = true)
+    }
+
+    /** An old daemon sends no accumulators. The line is dropped rather than faked — a ratio invented on the
+     *  client would be the same unverifiable number the issue is about, with extra confidence. */
+    @Test
+    fun anOldDaemonWithoutRawTokensDrawsNoRatioLine() = runDesktopComposeUiTest(402, 874) {
+        mainClock.autoAdvance = false
+        setContent(harness(snapshot(rawTokens = false, windowFields = false), filterable = true))
+        waitForIdle()
+
+        assertPresent("92%", substring = true) // the percentage itself still renders, from the today fields
+        assertFalse(present(str(Res.string.usage_cache_ratio, "1.2M", "1.3M"), substring = true))
+        assertFalse(present("tokens", substring = true), "no half-built traceability line")
+    }
+}

--- a/protocol/src/commonMain/kotlin/dev/ccpocket/protocol/Messages.kt
+++ b/protocol/src/commonMain/kotlin/dev/ccpocket/protocol/Messages.kt
@@ -800,6 +800,20 @@ data class Usage(
     val requestsWindow: Long? = null,
     val cacheHitPctWindow: Int? = null,
     val costUsdWindow: Double? = null,
+    /**
+     * The raw numerator/denominator behind [cacheHitPctWindow] (issue #323), in tokens: the window's
+     * accumulated cache-read total and (input + cache-read) themselves. Sent so a reader can trace the
+     * percentage back to the columns it was computed from instead of having to take a bare number on
+     * faith — this page aggregates EVERY backend it scanned, and a cache-poor one legitimately drags the
+     * mix far below what a single Anthropic-heavy account sees.
+     * NOTE: the denominator deliberately EXCLUDES cache-creation — tokens spent WRITING the cache were
+     * never a hit opportunity. That is this page's one consistent reading; a rate that also counts
+     * cache-creation in its denominator (a lower number) is a different metric, not a correction of this
+     * one. Trailing optionals: an old daemon omits them (the client drops the line), an old app ignores
+     * them. Non-null exactly when [cacheHitPctWindow] is, so the three never disagree about the window.
+     */
+    val cacheReadTokensWindow: Long? = null,
+    val cacheBaseTokensWindow: Long? = null,
 ) : ToPhone
 
 /**

--- a/protocol/src/commonTest/kotlin/dev/ccpocket/protocol/SerializationRoundTripTest.kt
+++ b/protocol/src/commonTest/kotlin/dev/ccpocket/protocol/SerializationRoundTripTest.kt
@@ -458,6 +458,44 @@ class SerializationRoundTripTest {
         assertFalse("costUsdWindow" in unset, unset)
     }
 
+    /**
+     * issue #323: the raw cache-hit numerator/denominator are TRAILING optionals. The App only draws the
+     * "traced back to these tokens" line when it has BOTH, so the compatibility requirement is the usual
+     * one — an old daemon's frame, which has no such keys, must decode with both null rather than throw
+     * (a throw would drop the whole usage frame and blank a page that used to work).
+     */
+    @Test
+    fun usage_cache_raw_tokens_are_trailing_optionals() {
+        // new daemon → new app: the two accumulators ride alongside the percentage they produced
+        val env = Envelope(
+            id = "u11", ts = 0,
+            body = Usage(
+                days = listOf(UsageDay("Mon", 100, date = "2026-07-06")),
+                requestsWindow = 428, cacheHitPctWindow = 97,
+                cacheReadTokensWindow = 4_388_842_059, cacheBaseTokensWindow = 4_389_087_518,
+            ),
+        )
+        val json = PocketJson.encodeToString(env)
+        assertTrue("\"cacheReadTokensWindow\":4388842059" in json, json)
+        assertTrue("\"cacheBaseTokensWindow\":4389087518" in json, json)
+        assertEquals(env, PocketJson.decodeFromString<Envelope>(json))
+
+        // new app ← OLD daemon (no keys at all): everything around them still decodes and both read null,
+        // so the card keeps its percentage and simply omits the traceability line
+        val old = """{"id":"u12","ts":0,"to":"PEER","body":{"t":"pocket/usage","days":[{"label":"Mon","tokens":100}],
+            "models":[],"tokensToday":100,"requestsToday":2,"requestsWindow":2,"cacheHitPctWindow":50}}"""
+        val back = PocketJson.decodeFromString<Envelope>(old).body as Usage
+        assertEquals(50, back.cacheHitPctWindow, "the neighbouring window fields must survive untouched")
+        assertNull(back.cacheReadTokensWindow)
+        assertNull(back.cacheBaseTokensWindow)
+
+        // unset (null) is omitted on the wire (explicitNulls=false) — byte-identical to an old daemon's frame,
+        // so a daemon with no cache sample sends exactly what a daemon that never knew the field sends
+        val unset = PocketJson.encodeToString(Envelope(id = "u13", ts = 0, body = Usage(days = listOf(UsageDay("Mon", 1)))))
+        assertFalse("cacheReadTokensWindow" in unset, unset)
+        assertFalse("cacheBaseTokensWindow" in unset, unset)
+    }
+
     @Test
     fun sessionGone_roundtrips() {
         val env = Envelope(id = "3", ts = 0, body = SessionGone("c9"))


### PR DESCRIPTION
发仔 08-27 的四条反馈，外加一条无关但已就绪的额度条修复（单独 commit）。

## #320 dsh 会话头只显示 default、看不到 context
新增 `AgentEvent.RuntimeMeta` 承载后端「在自己 wire 上实测到」的会话元信息。dsh 从 `request/context`（contextWindow）、`request/header`（reasoningEffort）与 `assistant/message`（source.model + usage）三处上报；`Conversation` 据此补齐 `SessionLive` 的 model/effort/contextWindow，且只在真的变化时重新 announce。

- ⚠️ `request/header.config.maxTokens` 是**输出上限**（同一模型上报 256k，而窗口是 1,000,000），明确不当 context 窗口用。
- DeepSeek 是 OpenAI 血统，`cacheReadTokens ⊂ inputTokens`，而 `TokenUsage.contextTokens` 把四列当互斥相加——所以减掉缓存前缀，否则占用翻倍。与磁盘侧 `DshUsageScanner` 同一套归一化。
- 非 Claude 后端拿不到模型时显示「未知」而非 default：default 只对**有账号默认档**的 Claude 成立。

## #321 dsh AskUserQuestion 只能看不能答（P1）
实时链路本身查证是好的（帧→卡片有单测、桌面端渲染的确是可作答卡、dsh 仍是 rc.6 无漂移）。修的是两条能产生同样症状的确凿缺陷：

- 回放里**未作答**的 AskUserQuestion 原本落到通用工具卡，看着像提问却点不动、也没有一个字说明为什么。新增 `ChatItem.QuestionsUnanswered` 明确标注。与后端无关——被打断的 Claude 回合留下的是同一种残留。
- dsh **没有任何超时**，被丢弃的 ask ＝ 该回合永久挂起，而此前唯一痕迹是一行手机上看不到的 daemon 日志。无法作答的丢弃改为在会话里明说。
- resume 时 host 会在 mux 订阅那一刻重放待决 ask，早于 `openSession` 写入 `sessionId`，fail-closed 检查会丢掉本属自己的 ask。`ourSessionId()` 用 `resumeId` 兜住该窗口；**新建会话仍严格 fail-closed**（create 返回前我们的会话尚不存在，任何 ask 都不可能是我们的）。

## #322 Windows 托盘右键无响应、浮层圆角与按钮层级失真
- 右键接 AWT 原生 `PopupMenu`（**仅 Windows**，mac/Linux 一字未动）。自绘 Compose 菜单在多屏 + 任务栏靠侧边时必然错位。
- Windows 走透明窗口，圆角/描边/投影由浮层自绘：skiko 建透明窗口在 macOS 26 必崩是 **macOS 独有**约束，而 Win11 的 DWM 不给无 caption 窗口补圆角，不透明底会把 8dp 圆角填回直角。拿不到逐像素透明时退回原不透明方角，不让托盘把整个 App 带崩。
- 页脚收敛成两级：主操作实心 accent，退出为次级纯文字。

## #323 缓存命中率长期只有 50–60%
本机同口径对拍：**Claude 99%、Codex 96%**，排除解析错误。真正的问题是这一页把六个后端混合聚合却从不说明覆盖了谁，也无法追溯回原始 token 字段。**公式一字未改**（issue 明令不得为接近 90% 人为调整）：

- `Usage` 尾部追加 `cacheReadTokensWindow` / `cacheBaseTokensWindow`（纯追加可选字段，老 daemon 解为 null 的用例已钉死）。
- 缓存卡标签带上 agent 维度（含显式「全部 agent」），并打印原始分子/分母。
- daemon 不支持按 agent 过滤时明说这是全机合计——那正是读者连点都点不出来的最坏情况。
- 标签跟着**已到达的回复**走而不是 chip，避免切换 agent 时新名字盖在旧数字上。

## 额外：额度条每晚消失（单独 commit）
`QuotaCredential.Expired` 原被映射成权威语义的 `NO_TOKEN`，客户端据此清掉快照。但 OAuth token 只是在最后一次 claude 运行后 ~8h 过期、下次一跑就续上——改判为暂态的 `NETWORK`，客户端保留正在变旧的快照。

## 验证
`bash scripts/check-all.sh` 全绿（就是本分支这两个 commit 的状态）：protocol 265 / daemon 1743 / relay 54 / mobile-desktop 1130，0 失败 0 错误 0 跳过。

## ⚠️ 未做的验收
**#322 没有 Windows 真机验收**（开发机是 macOS）。右键菜单弹不弹、透明窗圆角在正式安装包里长什么样、Win11 上页脚层级读不读得出，目前只有构建与 headless 测试撑着。issue 明文要求的截图与点击路径回归仍欠。

**#321 未能复现反馈者的具体路径**——修的是两条能产生同样症状的缺陷，不是确认过的那一条。已在小红书私信向发仔索取实时/回放路径、新开/恢复会话、以及 `%USERPROFILE%\.cc-pocket\logs\daemon.log` 里 dsh 相关行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)