### PR TITLE
feat(desktop): 主内容区分屏，多个会话并排且各自可输入 (#311)

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -16,6 +16,7 @@ cc-pocket 移动端设计资料，**统一采用 claude.ai/design**。Stitch 的
 | `APPROVAL-SYSTEM.md` | **审批最终方案，作为实现与评审的唯一依据** —— 现有场景盘点、统一 Approval Coordinator、Task Contract/Grant、Agent 自主参与、审批路由、通知/队列/软超时、自动执行留痕、协议与分期验收 |
 | `SMART-APPROVAL.md` | **风险评估子设计** —— 纳入统一审批系统：确定性行为序列＋Agent 风险建议＋高风险审批升级；不再作为独立审批架构 |
 | `CHANNEL-INTEGRATIONS-EVALUATING.md` | ⚠️ **评估中** —— 官方渠道集成（Claude Channels / Slack、Codex Slack / Linear）机制调研与机会分析。含五条方向层候选，**均未定案、未录台账**；定案后去掉 `-EVALUATING` 后缀 |
+| `SPLIT-PANES.md` | **桌面分屏（issue #311）** —— 主内容区同时放下多个会话，每列独立滚动 / 输入 / 审批。为什么走「一条链路按 convoId 分流」而不是第二条连接、两个挂点各自守什么、一列有什么没什么 |
 | `TASKBOARD-EVALUATING.md` | ⚠️ **评估中** —— 评估 dashi-taskboard 的持久任务能力与 cc-pocket 的适配性；建议原生实现 Task 层、拒绝直接嵌入，并给出 M0/M1 边界、架构、安全与验收条件 |
 
 > 命名约定：文件名带 `-EVALUATING` 后缀 = 调研 / 提案阶段，结论未定，不可作为实现依据。

--- a/docs/design/SPLIT-PANES.md
+++ b/docs/design/SPLIT-PANES.md
@@ -1,0 +1,52 @@
+# 桌面分屏（issue #311）
+
+主内容区同时放下多个会话：最左是聚焦会话，右边每个会话各占一列，每列都能独立滚动、独立输入、独立处理审批。上限 3 列（`MAX_SPLIT_PANES`）。
+
+## 为什么不是「第二条连接」
+
+daemon 对每台设备只保持一条 E2E 会话，第二次握手会让第一条链路失聪（见 `FleetCoordinator` 类注释）。所以同一台机器上的多个列**必须共用一条链路**，靠 `convoId` 分流，不能各开一个 `PocketRepository`。
+
+好在下面两层本来就是多会话的，这次改动没碰它们：
+
+- 协议层：`Messages.kt` 里收发两个方向的帧普遍带 `convoId`。
+- daemon：`session/SessionRegistry.kt` 就是 `convoId -> Conversation` 的表，带按设备分流的 sink 与重连重挂。
+- 客户端本来也在后台留着别的会话：切走时只有空闲会话才发 `CloseSession`，正在跑的留着继续跑。
+
+缺的只是客户端把「当前会话」这一份状态变成多份。
+
+## 结构
+
+| 位置 | 职责 |
+|---|---|
+| `data/ChatTranscript.kt` | 从 `PocketRepository` 原样抽出的会话流构建（thinking 块、replay 回声去重、子 agent 卡片合并、history 回放映射）。repository 持有一份，每个分屏各持有一份，**只有这一份实现** |
+| `data/SplitPanes.kt` | `SidePane`（一列的状态）与 `SidePanes`（帧路由、开/关/发/重挂） |
+| `desktop/SidePaneModel.kt` | `DesktopModel by base`，会话相关成员答自本列，其余透传给外壳 |
+| `desktop/SplitPaneView.kt` | 一列的渲染。用**真正的 `ChatPane`**，不是第二套聊天 UI |
+| `desktop/DesktopApp.kt` | 主内容区按列等分排布 |
+
+## 两个挂点，其余分支一行没动
+
+`PocketRepository.handle` 里 30 多个帧分支都写着 `if (f.convoId == convoId.value)`，一个都没改。加的是：
+
+1. `sidePanes.route(f)`：把属于某列的帧镜像进那一列。**从不消费帧**，原有分支照常执行，所以跨会话的审批收件箱、额度统计这类「与具体聊天无关」的记账全都不受影响。
+2. `acceptsSessionLive` 开头一行 `if (sidePanes.claimsSessionLive(f)) return false`：分屏的 open 回来的是同一种 `SessionLive`，而聚焦侧的接受规则最后一条是「这里还什么都没开」的兜底。没有这行，在主区为空时开一列会把会话开进主区。
+
+手机永远不开分屏，`route` 的第一行是一个普通整数比较（`openCount`，**不是快照状态**）。用快照 list 判空会推进全局快照、在别处不会发生的时刻冲掉待发的 apply 通知——实测会让组合器草稿在用户眼皮底下变空。
+
+## 一列有什么、没什么
+
+有：自己的会话流、自己的输入框、自己的审批卡、自己的重连重挂（按 `lastEventSeq` 只要增量）、open 8 秒不落地就报失败并给重试。
+
+没有：改模型 / 改模式、compact/clear、Changes、Git、rewind/fork、附件。这些动词都作用于**聚焦会话**，放在侧栏里点下去会悄悄改到另一个会话——分屏最不能有的就是这种错。所以列头把它们换成两个属于列自己的动词：`聚焦` 和 `关闭此栏`（`DesktopModel.paneScoped`）。点「聚焦」这列就变成聚焦会话，全套能力当场解锁。
+
+## 晋升为什么不做交换
+
+「聚焦」= 一次普通的 `openSession(resumeId)`，daemon 用它已经持有的会话重挂，不 fork 不重启。让出主区的那个会话**不会**自动搬进空出来的列：`openSession` 在切换时本来就会回收空闲会话，同一口气再把它开成一列，等于让同一个会话的 `CloseSession` 与 `OpenSession` 同时在飞。把它送回列里只差一个手势（侧栏「在分屏中打开」），而那个手势是有序的。
+
+同理，晋升时那一列走 `detach` 而不是 `close`——`close` 会发 `CloseSession`，和紧接着的重挂抢同一个会话。
+
+## 已知边界
+
+- 只做同一台机器。跨机器的列要等卫星会话流（`fleet.md` brief ③）。
+- 等宽纵向等分，没有拖拽改宽、没有瓦片管理。
+- 手机端不做，行为逐字节不变。

--- a/docs/design/claude-design-handoff/fleet.md
+++ b/docs/design/claude-design-handoff/fleet.md
@@ -66,7 +66,7 @@ repo 仍是**单连接**（一次只连一台，`switchDaemon` 整体切换）�
 
 - **跨机审批广播（daemon 侧，下一步）**：daemon 把会话的 PermissionAsk 绑定在「打开它的设备连接（sink）」上——卫星链路收得到 Directories/Sessions，收不到别的设备开的会话的 ask。跨机审批收件箱/横幅要真正点亮，需 daemon 将 ask 广播给账号下所有 attached 设备（+ 显式 resolve 路由与竞态处理），属 daemon+协议改造，走 wire-compat 审查。聚合层已就位，daemon 落地即亮。
 - **连接策略（常驻 vs 按需）**：当前默认全部常驻（桌面无感；手机电量策略见「真并发交互缺口」brief ②）。
-- **卫星会话流（watch pane 数据源）**：卫星可开会话但激活手势未设计（brief ③）——`watch` 仍 null。
+- **卫星会话流（watch pane 数据源）**：卫星可开会话但激活手势未设计（brief ③）——`watch` 仍 null。同机的多会话同览已由 issue #311 的分屏落地（`data/SplitPanes.kt` + `desktop/SplitPaneView.kt`，见 `docs/design/SPLIT-PANES.md`）：那条路走的是「一条链路按 convoId 分流」，不是第二条链路，所以跨机器的列仍待卫星会话流。
 - **机器 OS 与主机名**：配对凭据不含 OS/hostname（QR 只有账号身份），暂按用户命名启发式判断（`osFromName`：win→WIN、linux→LINUX、默认 MAC）；协议层补 hostname/os 上报是后续项（涉及 wire 兼容，须走 protocol-wire-compat 审查）。
 - **"this Mac" 标签**：桌面端无法可靠自识别本机 daemon → 仅 Seed 展示；live 不标。
 - **倒计时**：live attention 行不显示倒计时（`seconds = null`，不臆造 deadline）；PermissionSheet/InlinePermCard 上的真实 30s 倒计时不变。移动端收件箱行沿用 sheet 的 30s 约定本地走表。

--- a/mobile/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -1277,6 +1277,13 @@
     <!-- 窗口边框及杂项 -->
     <string name="exit_fullscreen">退出全屏</string>
     <string name="show_sidebar">显示侧栏</string>
+    <!-- split panes (issue #311) -->
+    <string name="split_pane_focus">聚焦</string>
+    <string name="split_pane_close">关闭此栏</string>
+    <string name="split_open">在分屏中打开</string>
+    <string name="split_full">分屏已满</string>
+    <string name="split_opening">正在打开…</string>
+    <string name="split_session_ended">这个会话已经结束。</string>
     <string name="qa_terminal">打开终端</string>
     <string name="qa_clear_armed">清空会话——再点一次确认</string>
     <string name="popover_where">位置</string>

--- a/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1280,6 +1280,13 @@
     <!-- window chrome & misc -->
     <string name="exit_fullscreen">Exit Full Screen</string>
     <string name="show_sidebar">Show sidebar</string>
+    <!-- split panes (issue #311) -->
+    <string name="split_pane_focus">Focus</string>
+    <string name="split_pane_close">Close column</string>
+    <string name="split_open">Open in split</string>
+    <string name="split_full">Split is full</string>
+    <string name="split_opening">Opening…</string>
+    <string name="split_session_ended">This session has ended.</string>
     <string name="qa_terminal">Open terminal</string>
     <string name="qa_clear_armed">Clear chat — tap again</string>
     <string name="popover_where">Where</string>

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/ChatTranscript.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/ChatTranscript.kt
@@ -1,0 +1,166 @@
+package dev.ccpocket.app.data
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import dev.ccpocket.app.epochMillis
+import dev.ccpocket.protocol.AssistantChunk
+import dev.ccpocket.protocol.ChatRole
+import dev.ccpocket.protocol.HistoryMessage
+import dev.ccpocket.protocol.StreamPiece
+import dev.ccpocket.protocol.ToolEvent
+import dev.ccpocket.protocol.ToolPhase
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+/**
+ * One conversation's message stream, and the small amount of state that building it needs.
+ *
+ * Extracted from [PocketRepository] unchanged (issue #311): the repository still owns exactly one of these
+ * for the conversation it drives, but the desktop's split panes need the SAME stream-assembly for the extra
+ * conversations they keep live beside it. Duplicating the thinking-block, replay-echo and sub-agent-card
+ * rules for a second code path is how those two streams would silently drift apart, so there is one copy
+ * and both paths call it.
+ *
+ * Not thread-safe and not meant to be: every mutation runs on the frame-handling dispatcher, exactly as it
+ * did when these were repository fields.
+ */
+class ChatTranscript {
+    val messages = mutableStateListOf<ChatItem>()
+
+    /** Mid-turn right now. Kept here because [appendChunk] is what flips it on. */
+    val streaming = mutableStateOf(false)
+
+    /** One-shot dedupe armed by a history replay (issue #107) — see [appendChunk] / [onToolEvent]. */
+    var replayEcho = false
+
+    /** Start of the thinking block still being streamed, for the "Thought for 5s" stamp. */
+    private var thinkStartMs: Long? = null
+
+    /** Drop everything — a conversation boundary (open/close/clear). */
+    fun reset() {
+        messages.clear()
+        replayEcho = false
+        thinkStartMs = null
+        streaming.value = false
+    }
+
+    fun appendChunk(c: AssistantChunk) {
+        streaming.value = true
+        when (val p = c.piece) {
+            is StreamPiece.Text -> {
+                finishThinking() // prose starting = the thinking block (if any) is done
+                // one-shot replay-echo dedupe (issue #107): the first block after a merged ConvoHistory
+                // can be the very block the replay already included — appending it would double the
+                // bubble's tail. Only an exact tail match is dropped; anything else streams normally.
+                val echo = replayEcho && TranscriptMerge.isEchoText(messages, p.text)
+                replayEcho = false
+                if (echo) return
+                val last = messages.lastOrNull()
+                if (last is ChatItem.Assistant) messages[messages.lastIndex] = last.copy(text = last.text + p.text)
+                else messages.add(ChatItem.Assistant(p.text))
+            }
+            is StreamPiece.Thinking -> {
+                replayEcho = false // replay carries no thinking rows — a thinking chunk can't be an echo
+                val last = messages.lastOrNull()
+                if (last is ChatItem.Thinking && last.seconds == null) {
+                    messages[messages.lastIndex] = last.copy(text = last.text + p.text)
+                } else {
+                    thinkStartMs = epochMillis()
+                    messages.add(ChatItem.Thinking(p.text))
+                }
+            }
+        }
+    }
+
+    fun onToolEvent(f: ToolEvent) {
+        val parent = f.parentToolUseId
+        // one-shot replay-echo dedupe (issue #107), tool flavor: a START right after a merged
+        // ConvoHistory may duplicate the replayed tail card (which has no taskId). Fold into it —
+        // patching the live toolUseId in even upgrades the card for later RESULT correlation.
+        if (replayEcho) {
+            replayEcho = false
+            if (f.phase == ToolPhase.START && parent == null) {
+                val i = TranscriptMerge.echoToolIndex(messages, f.tool, f.inputPreview)
+                if (i >= 0) {
+                    messages[i] = (messages[i] as ChatItem.Tool).copy(taskId = f.toolUseId)
+                    return
+                }
+            }
+        }
+        fun cardIndex(taskId: String?) =
+            if (taskId == null) -1 else messages.indexOfLast { it is ChatItem.Tool && it.taskId == taskId }
+        when {
+            f.phase == ToolPhase.RESULT -> {
+                val i = cardIndex(f.toolUseId)
+                // no card on screen (opened mid-run): the reattach history replay carries the outcome instead
+                if (i >= 0) messages[i] = (messages[i] as ChatItem.Tool).copy(ok = f.ok, output = f.output)
+            }
+            parent != null -> {
+                val i = cardIndex(parent)
+                if (i >= 0) {
+                    val card = messages[i] as ChatItem.Tool
+                    messages[i] = card.copy(childCount = card.childCount + 1, lastChild = f.tool)
+                } else messages.add(ChatItem.Tool(f.tool, f.inputPreview ?: ""))
+            }
+            // OpenCode's question tool renders as a read-only question card, not a raw JSON row (issue
+            // #210); a parse miss (old truncated preview / malformed) falls back to the plain tool card.
+            else -> OpenCodeQuestionParse.parse(f.tool, f.inputPreview)
+                ?.let { messages.add(ChatItem.OpenCodeQuestion(it)) }
+                ?: messages.add(ChatItem.Tool(f.tool, f.inputPreview ?: "", taskId = f.toolUseId))
+        }
+    }
+
+    /** Stamp the duration onto a still-open Thinking block (design: "Thought for 5s"). */
+    fun finishThinking() {
+        val start = thinkStartMs ?: return
+        thinkStartMs = null
+        val i = messages.indexOfLast { it is ChatItem.Thinking }
+        if (i < 0) return
+        val t = messages[i] as ChatItem.Thinking
+        if (t.seconds == null) {
+            val secs = (((epochMillis() - start) + 500) / 1000).toInt().coerceAtLeast(1)
+            messages[i] = t.copy(seconds = secs)
+        }
+    }
+}
+
+/** One replayed history row as the stream item it should render as. Moved here with [ChatTranscript] so a
+ *  split pane replays its backlog exactly the way the focused conversation does. */
+@OptIn(ExperimentalEncodingApi::class)
+internal fun historyItem(h: HistoryMessage): ChatItem = when (h.role) {
+    // images the prompt carried replay as real tiles (issue #254) — a turn composed at the computer
+    // is no longer text-only here, and an image-ONLY turn is no longer a blank bubble. A base64 blob
+    // the platform can't decode is dropped rather than rendered as a broken tile; the renderer's own
+    // decode-failure card covers bytes that only fail later (on the image decoder).
+    ChatRole.USER -> ChatItem.User(
+        h.text,
+        images = h.images.mapNotNull { runCatching { Base64.Default.decode(it.base64) }.getOrNull() },
+        imagesTruncated = h.imagesTruncated,
+        // rewind/fork anchor coordinates (issue #282) — carried verbatim, including their absence
+        seq = h.seq,
+        uuid = h.uuid,
+    )
+    // a synthetic API-failure placeholder replays as the error it was, not as a normal reply (issue #65).
+    // Attribution follows the placeholder text so the replay reads the same as the daemon live prompt:
+    // an upstream gateway/5xx signal stops blaming context (issue #208).
+    ChatRole.ASSISTANT -> if (h.error) {
+        ChatItem.Sys(
+            "API request failed — the agent wrote a placeholder, not a real reply. " +
+                dev.ccpocket.protocol.SyntheticAttribution.attribution(h.text) +
+                "\n\nplaceholder reply: ${h.text}",
+        )
+    } else {
+        ChatItem.Assistant(h.text)
+    }
+    // an answered AskUserQuestion replays as the same compact answered row the live path leaves, not a
+    // raw-JSON tool card (issue #110); ok/output keep a sub-agent card's outcome + report (issue #77);
+    // workflowRunId binds a Workflow card to its separately-pushed run (issue #106)
+    ChatRole.TOOL -> h.answers?.let { a -> ChatItem.QuestionsAnswered(a.map { it.question to it.answer }) }
+        ?: OpenCodeQuestionParse.parse(h.tool ?: "", h.text)?.let { ChatItem.OpenCodeQuestion(it) }
+        // …and one with NO answers is a question that never got one (issue #321). Falling through to
+        // the plain tool row below made it read as a live-looking card with nothing to tap; say what
+        // it actually is. Every backend's replay names the tool the same way (see the daemon's
+        // TranscriptReplay / DshTranscriptReplay ASK_TOOL), so this needs no per-agent branch.
+        ?: h.text.takeIf { h.tool == ASK_QUESTION_TOOL }?.let { ChatItem.QuestionsUnanswered(it) }
+        ?: ChatItem.Tool(h.tool ?: "tool", h.text, ok = h.ok, output = h.output, workflowRunId = h.workflowRunId)
+}

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
@@ -65,7 +65,6 @@ import dev.ccpocket.protocol.RemoveWorktree
 import dev.ccpocket.protocol.WorktreeList
 import dev.ccpocket.protocol.CLAUDE_QUOTA_NO_TOKEN
 import dev.ccpocket.protocol.CLAUDE_QUOTA_OK
-import dev.ccpocket.protocol.ChatRole
 import dev.ccpocket.protocol.ClaudeQuota
 import dev.ccpocket.protocol.ClaudeQuotaGet
 import dev.ccpocket.protocol.ClearAllowRule
@@ -347,7 +346,7 @@ private data class PendingGrantMutation(
 /** The tool name every backend's transcript replay files an AskUserQuestion under (the daemon's own
  *  `TranscriptReplay.ASK_TOOL` / `DshTranscriptReplay.ASK_TOOL`, and the live `AskQuestions.TOOL`). It is
  *  a display key on the wire, not an enum, so the client matches the same literal. */
-private const val ASK_QUESTION_TOOL = "AskUserQuestion"
+internal const val ASK_QUESTION_TOOL = "AskUserQuestion"
 
 sealed interface ChatItem {
     /** [pending] = sent from this device but the daemon hasn't echoed any evidence back yet (stream
@@ -590,7 +589,6 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
     // a ConvoHistory was just merged (issue #107): the very next stream event may be the block the
     // replay's disk read already caught (chunks parsed during the read race its ConvoHistory on the
     // wire) — one-shot flag; consumed by the first AssistantChunk/ToolEvent, reset at turn boundaries
-    private var replayEcho = false
 
     // ── push notifications: register the device's APNs/FCM token so the relay can wake it while offline ──
     private var pushToken: PushToken? = null
@@ -1105,7 +1103,14 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
      *  answer against the live conversation would drop it exactly when it succeeded. Cleared by the answer
      *  (or by a conversation switch, which orphans it). */
     private var rewindAwaiting: RewindTarget? = null
-    val messages = mutableStateListOf<ChatItem>()
+    /** The open conversation's stream. Extracted to [ChatTranscript] (issue #311) so the desktop's split
+     *  panes assemble their extra conversations with the same code; the field stays the repository's own. */
+    val transcript = ChatTranscript()
+    val messages get() = transcript.messages
+
+    /** Conversations the desktop keeps live BESIDE this one (issue #311). Empty everywhere else — the
+     *  phone opens no panes — which is what makes [SidePanes.route] below a no-op on mobile. */
+    val sidePanes = SidePanes(scope, ::send, ::newPromptId)
     val pendingImages = mutableStateListOf<PendingImage>() // photos staged in the composer (pre-send)
     val pendingFiles = mutableStateListOf<PendingFile>()   // files staged/uploading into the workspace inbox (issue #90)
     private var fileUploadJob: Job? = null                 // the chunk-send loop of the ONE Uploading file
@@ -1114,7 +1119,6 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
     val convoId = mutableStateOf<String?>(null)
     val workdir = mutableStateOf<String?>(null)
     val chatTitle = mutableStateOf<String?>(null)            // session title for the chat header (client-side)
-    private var thinkStartMs: Long? = null                   // first Thinking chunk of the in-progress block
     val pendingAsk = mutableStateOf<PermissionAsk?>(null)
     /** Ordered waiting room behind [pendingAsk] (approval design M1): a same-session ask arriving while a
      * card is already up QUEUES here instead of overwriting it — three back-to-back asks are shown one by
@@ -1310,7 +1314,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
      *  the desktop's open-failed pane offers a retry and must not silently re-open under other flags. */
     private var lastOpenAttempt: OpenAttempt? = null
     val autoFocusComposer = mutableStateOf(false)            // brand-new session: ChatScreen raises the keyboard once on landing (consumed there)
-    val streaming = mutableStateOf(false)
+    val streaming get() = transcript.streaming
     val observing = mutableStateOf(false) // viewing a session running outside the daemon (read-only tail)
     private var currentSessionId: String? = null
 
@@ -2369,6 +2373,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         // §3.2.8: offer/accept/decline/return/recall/expire are all recovered from DAEMON TRUTH after a
         // reconnect — the inbox re-pulls its whole list rather than trusting whatever it held locally.
         if (isCollaboratorInbox) send(ListHandoffs())
+        sidePanes.reopenAll() // #311: every split column re-attaches the same way the focused chat does
         when {
             // daemon finds the still-live conversation by sessionId → reattach + history replay, which the
             // ConvoHistory MERGE turns into a backfill of whatever streamed while the link was down (#107)
@@ -2388,6 +2393,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
 
     /** Drop the live connection and return to the Connect screen (pairing is kept). */
     fun disconnect() {
+        sidePanes.clear() // #311: nothing behind a pane survives the link
         sessionActive.value = false
         // An OpenSession worker belongs to the link/computer that accepted the click. It may still be
         // queued (or suspended on a full reconnect outbox), so invalidating only the claim is insufficient:
@@ -2501,6 +2507,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
      *  This is the COLD path — [FleetCoordinator.switchTo] promotes a hot satellite instead when it can
      *  (issue #103) and only falls back here when no live link to [target] exists yet. */
     fun switchDaemon(target: PairedDaemon) {
+        sidePanes.clear() // #311: panes name sessions on the machine we are leaving
         if (paired.value?.accountId == target.accountId && sessionActive.value) return
         onBeforeSwitch?.invoke(target.accountId)
         disconnect()
@@ -2868,6 +2875,10 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
      *    (cold-start seams and a background announce while browsing both land here harmlessly).
      */
     private fun acceptsSessionLive(f: SessionLive): Boolean {
+        // #311: a split pane's open is answered by the same frame shape. Decided before every rule below,
+        // because the last one is a catch-all for "nothing is open here yet" — without this, opening a
+        // pane while the main area is empty would land the pane's session in the main area instead.
+        if (sidePanes.claimsSessionLive(f)) return false
         // #226: BACK is an authoritative navigation decision. The daemon may already have queued a
         // SessionLive for the chat we just left (turn-state reannounce, close race, reconnect replay).
         // sessionKey still names that chat for draft durability, so reject before consulting identity.
@@ -2909,6 +2920,10 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         // that branch is filtered to the currently-open conversation (chat-state bookkeeping) and would
         // miss a turn finishing in another session/window on the same machine.
         if (f is TurnDone) turnCompletions.value++
+        // #311: a split pane's conversation is not this repository's conversation, so every branch below
+        // filters it out. Mirror it into its pane FIRST, then let the branches run exactly as they always
+        // have — including the machine-wide bookkeeping (approvals inbox, quota) that is not per-chat.
+        sidePanes.route(f)
         when (f) {
             is Directories -> {
                 replace(directories, f.entries); refreshing.value = false
@@ -3315,7 +3330,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
                 // was lost, keep the bubble pending, but the NEXT stream frame can now safely prove that
                 // prompt started; it can no longer be mistaken for output from the preceding turn.
                 if (queuedReceiptStillPending) promptQueued = false
-                replayEcho = false // turn boundary — the next block belongs to a new turn, never a replay echo
+                transcript.replayEcho = false // turn boundary — the next block belongs to a new turn, never a replay echo
                 val turnWasLive = streaming.value // gate the marker/notify on a turn we actually watched run
                 finishThinking(); streaming.value = false
                 // a FAILED turn (API error / synthetic placeholder — issue #65): show the error row where
@@ -3444,7 +3459,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
                         val merged = TranscriptMerge.mergeDelta(localRows, f.messages.map(::historyItem))
                         if (merged != localRows) replace(messages, merged)
                         reconcilePromptReceiptFromHistory(localRows, merged)
-                        replayEcho = true // same replay/stream race as the full path
+                        transcript.replayEcho = true // same replay/stream race as the full path
                     }
                     f.lastSeq?.let { historySeq = it; historySeqSession = currentSessionId }
                 } else {
@@ -3459,7 +3474,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
                     val merged = TranscriptMerge.merge(localRows, f.messages.map(::historyItem))
                     if (merged != localRows) replace(messages, merged)
                     reconcilePromptReceiptFromHistory(localRows, merged)
-                    replayEcho = true // arm the one-shot live-stream dedupe for the replay/stream race
+                    transcript.replayEcho = true // arm the one-shot live-stream dedupe for the replay/stream race
                     // reattach cursor + paging anchors (issue #147); null fields = a pre-#147 daemon
                     historySeq = f.lastSeq
                     historySeqSession = if (f.lastSeq != null) currentSessionId else null
@@ -3725,82 +3740,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
      *  - an event tagged with a parent folds into that parent's card as "N tool uses · latest" progress
      *    (falling back to today's inline card when the parent isn't on screen, e.g. attached mid-run).
      */
-    private fun onToolEvent(f: ToolEvent) {
-        val parent = f.parentToolUseId
-        // one-shot replay-echo dedupe (issue #107), tool flavor: a START right after a merged
-        // ConvoHistory may duplicate the replayed tail card (which has no taskId). Fold into it —
-        // patching the live toolUseId in even upgrades the card for later RESULT correlation.
-        if (replayEcho) {
-            replayEcho = false
-            if (f.phase == ToolPhase.START && parent == null) {
-                val i = TranscriptMerge.echoToolIndex(messages, f.tool, f.inputPreview)
-                if (i >= 0) {
-                    messages[i] = (messages[i] as ChatItem.Tool).copy(taskId = f.toolUseId)
-                    return
-                }
-            }
-        }
-        fun cardIndex(taskId: String?) =
-            if (taskId == null) -1 else messages.indexOfLast { it is ChatItem.Tool && it.taskId == taskId }
-        when {
-            f.phase == ToolPhase.RESULT -> {
-                val i = cardIndex(f.toolUseId)
-                // no card on screen (opened mid-run): the reattach history replay carries the outcome instead
-                if (i >= 0) messages[i] = (messages[i] as ChatItem.Tool).copy(ok = f.ok, output = f.output)
-            }
-            parent != null -> {
-                val i = cardIndex(parent)
-                if (i >= 0) {
-                    val card = messages[i] as ChatItem.Tool
-                    messages[i] = card.copy(childCount = card.childCount + 1, lastChild = f.tool)
-                } else messages.add(ChatItem.Tool(f.tool, f.inputPreview ?: ""))
-            }
-            // OpenCode's question tool renders as a read-only question card, not a raw JSON row (issue
-            // #210); a parse miss (old truncated preview / malformed) falls back to the plain tool card.
-            else -> OpenCodeQuestionParse.parse(f.tool, f.inputPreview)
-                ?.let { messages.add(ChatItem.OpenCodeQuestion(it)) }
-                ?: messages.add(ChatItem.Tool(f.tool, f.inputPreview ?: "", taskId = f.toolUseId))
-        }
-    }
-
-    @OptIn(ExperimentalEncodingApi::class)
-    private fun historyItem(h: HistoryMessage): ChatItem = when (h.role) {
-        // images the prompt carried replay as real tiles (issue #254) — a turn composed at the computer
-        // is no longer text-only here, and an image-ONLY turn is no longer a blank bubble. A base64 blob
-        // the platform can't decode is dropped rather than rendered as a broken tile; the renderer's own
-        // decode-failure card covers bytes that only fail later (on the image decoder).
-        ChatRole.USER -> ChatItem.User(
-            h.text,
-            images = h.images.mapNotNull { runCatching { Base64.Default.decode(it.base64) }.getOrNull() },
-            imagesTruncated = h.imagesTruncated,
-            // rewind/fork anchor coordinates (issue #282) — carried verbatim, including their absence
-            seq = h.seq,
-            uuid = h.uuid,
-        )
-        // a synthetic API-failure placeholder replays as the error it was, not as a normal reply (issue #65).
-        // Attribution follows the placeholder text so the replay reads the same as the daemon live prompt:
-        // an upstream gateway/5xx signal stops blaming context (issue #208).
-        ChatRole.ASSISTANT -> if (h.error) {
-            ChatItem.Sys(
-                "API request failed — the agent wrote a placeholder, not a real reply. " +
-                    dev.ccpocket.protocol.SyntheticAttribution.attribution(h.text) +
-                    "\n\nplaceholder reply: ${h.text}",
-            )
-        } else {
-            ChatItem.Assistant(h.text)
-        }
-        // an answered AskUserQuestion replays as the same compact answered row the live path leaves, not a
-        // raw-JSON tool card (issue #110); ok/output keep a sub-agent card's outcome + report (issue #77);
-        // workflowRunId binds a Workflow card to its separately-pushed run (issue #106)
-        ChatRole.TOOL -> h.answers?.let { a -> ChatItem.QuestionsAnswered(a.map { it.question to it.answer }) }
-            ?: OpenCodeQuestionParse.parse(h.tool ?: "", h.text)?.let { ChatItem.OpenCodeQuestion(it) }
-            // …and one with NO answers is a question that never got one (issue #321). Falling through to
-            // the plain tool row below made it read as a live-looking card with nothing to tap; say what
-            // it actually is. Every backend's replay names the tool the same way (see the daemon's
-            // TranscriptReplay / DshTranscriptReplay ASK_TOOL), so this needs no per-agent branch.
-            ?: h.text.takeIf { h.tool == ASK_QUESTION_TOOL }?.let { ChatItem.QuestionsUnanswered(it) }
-            ?: ChatItem.Tool(h.tool ?: "tool", h.text, ok = h.ok, output = h.output, workflowRunId = h.workflowRunId)
-    }
+    private fun onToolEvent(f: ToolEvent) = transcript.onToolEvent(f)
 
     private fun <T> replace(list: MutableList<T>, items: List<T>) {
         list.clear(); list.addAll(items)
@@ -3814,46 +3754,10 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         viewedWorkflowRunId.value = null
     }
 
-    private fun appendChunk(c: AssistantChunk) {
-        streaming.value = true
-        when (val p = c.piece) {
-            is StreamPiece.Text -> {
-                finishThinking() // prose starting = the thinking block (if any) is done
-                // one-shot replay-echo dedupe (issue #107): the first block after a merged ConvoHistory
-                // can be the very block the replay already included — appending it would double the
-                // bubble's tail. Only an exact tail match is dropped; anything else streams normally.
-                val echo = replayEcho && TranscriptMerge.isEchoText(messages, p.text)
-                replayEcho = false
-                if (echo) return
-                val last = messages.lastOrNull()
-                if (last is ChatItem.Assistant) messages[messages.lastIndex] = last.copy(text = last.text + p.text)
-                else messages.add(ChatItem.Assistant(p.text))
-            }
-            is StreamPiece.Thinking -> {
-                replayEcho = false // replay carries no thinking rows — a thinking chunk can't be an echo
-                val last = messages.lastOrNull()
-                if (last is ChatItem.Thinking && last.seconds == null) {
-                    messages[messages.lastIndex] = last.copy(text = last.text + p.text)
-                } else {
-                    thinkStartMs = dev.ccpocket.app.epochMillis()
-                    messages.add(ChatItem.Thinking(p.text))
-                }
-            }
-        }
-    }
+    private fun appendChunk(c: AssistantChunk) = transcript.appendChunk(c)
 
     /** Stamp the duration onto a still-open Thinking block (design: "Thought for 5s"). */
-    private fun finishThinking() {
-        val start = thinkStartMs ?: return
-        thinkStartMs = null
-        val i = messages.indexOfLast { it is ChatItem.Thinking }
-        if (i < 0) return
-        val t = messages[i] as ChatItem.Thinking
-        if (t.seconds == null) {
-            val secs = (((dev.ccpocket.app.epochMillis() - start) + 500) / 1000).toInt().coerceAtLeast(1)
-            messages[i] = t.copy(seconds = secs)
-        }
-    }
+    private fun finishThinking() = transcript.finishThinking()
 
     /** Pull-to-refresh the project list (re-scans the daemon's directories + live state). */
     fun refreshDirectories() = refreshWithSpinner(refreshing, ListDirectories())
@@ -5294,7 +5198,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         // sessionId and reattaches the still-live conversation (registry live-match), no fork.
         convoId.value?.let { if (observing.value || !streaming.value) send(CloseSession(it)) }
         if (gen != openGen) return // the close send can suspend while a newer navigation decision wins
-        messages.clear(); convoId.value = null; replayEcho = false
+        messages.clear(); convoId.value = null; transcript.replayEcho = false
         resetHistoryPaging() // #147: a fresh open replays in full — a stale cursor must not ask for a delta
         sessionKey.value = resumeId // durable draft key known immediately on resume; null for a brand-new session
         // #219: a brand-new session's SessionLive has no sessionId to recognize it by — arm the workdir
@@ -6407,6 +6311,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
             askBurstTotal--
             updateAskProgress()
         }
+        sidePanes.noteApprovalResolved(key.convoId, askId) // #311: same decision, every surface showing it
         Telemetry.track(TelEvent.ApprovalDecided, mapOf(TelKey.Decision to if (allow) "allow" else "deny"))
         scope.launch {
             send(PermissionVerdict(row.ask.convoId, askId, if (allow) Decision.ALLOW else Decision.DENY))

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/SplitPanes.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/SplitPanes.kt
@@ -1,0 +1,318 @@
+package dev.ccpocket.app.data
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import dev.ccpocket.protocol.AgentKind
+import dev.ccpocket.protocol.AskWithdrawn
+import dev.ccpocket.protocol.AssistantChunk
+import dev.ccpocket.protocol.CloseSession
+import dev.ccpocket.protocol.ConvoHistory
+import dev.ccpocket.protocol.Frame
+import dev.ccpocket.protocol.OpenSession
+import dev.ccpocket.protocol.PermissionAsk
+import dev.ccpocket.protocol.PermissionMode
+import dev.ccpocket.protocol.PocketError
+import dev.ccpocket.protocol.PromptAck
+import dev.ccpocket.protocol.SendPrompt
+import dev.ccpocket.protocol.SessionGone
+import dev.ccpocket.protocol.SessionLive
+import dev.ccpocket.protocol.ToolEvent
+import dev.ccpocket.protocol.TurnDone
+import dev.ccpocket.protocol.isQuestion
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.time.TimeSource
+
+/**
+ * How many conversations the desktop shows side by side, the focused one included (issue #311).
+ *
+ * Three is a product decision, not a technical ceiling: it is the widest split that still leaves each
+ * column readable at a normal window width, and it is what the issue's "左边一个 / 中间一个 / 最右边一个"
+ * asks for. The daemon holds no such limit — [SessionRegistry] keys conversations by id — so raising this
+ * is a one-line change once a layout that stays legible past three exists.
+ */
+const val MAX_SPLIT_PANES = 3
+
+/**
+ * One conversation kept live BESIDE the focused one.
+ *
+ * A side pane is a real, writable view of a session: it replays that session's backlog, streams its output,
+ * accepts prompts, and shows the approvals it raises. What it deliberately does NOT carry is the state that
+ * only ever made sense for one conversation at a time — the Changes browser, the Git panel, rewind/fork,
+ * attachments, model/mode switching. Those stay on the focused pane, and clicking a side pane promotes it
+ * (a plain re-open by session id, which the daemon answers by reattaching the live conversation), so any
+ * pane can reach them without this class having to grow a second copy of them.
+ */
+class SidePane(
+    val paneId: Long,
+    /** Resume identity: what a promotion re-opens, and how this pane recognises its own [SessionLive]. */
+    val sessionId: String,
+    val workdir: String,
+    initialTitle: String,
+    val agent: AgentKind,
+) {
+    /** Filled by this pane's own SessionLive. Null while the open is still in flight. */
+    val convoId = mutableStateOf<String?>(null)
+    val title = mutableStateOf(initialTitle)
+    val transcript = ChatTranscript()
+    val messages get() = transcript.messages
+    val streaming get() = transcript.streaming
+    val composer = mutableStateOf("")
+    val opening = mutableStateOf(true)
+
+    /** The session ended underneath us (daemon-side close / crash) — the pane says so instead of going blank. */
+    val gone = mutableStateOf(false)
+
+    /** The open never landed inside [SidePanes.OPEN_TIMEOUT_MS] (issue #235's problem, one column over):
+     *  a column stuck on "Opening…" forever reads as "my click never happened", so say it failed and
+     *  offer the retry instead. */
+    val openFailed = mutableStateOf(false)
+    val error = mutableStateOf<String?>(null)
+
+    /** The approval this pane's session is blocked on. Resolved through the repository's inbox verbs, so a
+     *  decision made here and one made in the bell popover travel the exact same path. */
+    val pendingAsk = mutableStateOf<PermissionAsk?>(null)
+
+    /** #147 reattach cursor for THIS pane's transcript, so a reconnect replays a delta, not the whole tail. */
+    internal var historySeq: Long? = null
+    internal var turnStartMark: TimeSource.Monotonic.ValueTimeMark? = null
+
+    /** The mode this column was opened under, replayed verbatim by a retry or a reconnect re-attach. */
+    internal var mode: PermissionMode = PermissionMode.DEFAULT
+
+    /** Ties an open's timeout to THAT open — a retry must not be failed by its predecessor's deadline. */
+    internal var openGen = 0
+}
+
+/**
+ * The conversations the desktop keeps live beside the focused one, and the frame routing that feeds them.
+ *
+ * The repository still drives exactly ONE conversation with its full state machine. This sits beside it:
+ * [route] is called for every inbound frame and mirrors the ones belonging to a side pane's conversation
+ * into that pane. It never consumes a frame — every existing branch in `PocketRepository.handle` still runs
+ * exactly as before — which is what keeps the phone (where no pane is ever opened) byte-for-byte unchanged
+ * and keeps machine-wide bookkeeping like the approvals inbox working for panes too.
+ *
+ * The one place the repository has to yield is [claimsSessionLive]: a side pane's open is answered by the
+ * same `SessionLive` frame shape as the focused pane's, and the focused pane's acceptance rule ends in a
+ * catch-all for "nothing is open yet". Without this check, opening a pane while the main area is empty
+ * would hijack the main area instead.
+ */
+class SidePanes(
+    private val scope: CoroutineScope,
+    private val send: suspend (Frame) -> Unit,
+    private val newPromptId: () -> String,
+) {
+    val panes = mutableStateListOf<SidePane>()
+    private var paneSeq = 0L
+
+    /**
+     * [panes.size] as a PLAIN field, not snapshot state — and the only thing [route] and
+     * [claimsSessionLive] consult before deciding they have nothing to do.
+     *
+     * Both run on the inbound frame path, which is every chunk of every turn, and which is not a
+     * composition. Touching a snapshot list there costs more than a field read AND can advance the
+     * global snapshot, flushing pending apply notifications at a moment nothing else would have — which
+     * is exactly the kind of invisible retiming that moves a composer draft under the user. Nobody opens
+     * a pane on the phone, so on mobile this keeps the hook to one integer comparison, forever.
+     */
+    private var openCount = 0
+
+    /** Room for another column, focused pane included. */
+    fun canOpen(): Boolean = panes.size < MAX_SPLIT_PANES - 1
+
+    fun paneFor(sessionId: String): SidePane? = panes.firstOrNull { it.sessionId == sessionId }
+
+    /**
+     * Open [sessionId] into a new column. Returns null when the split is already full or the session is
+     * already in one — both are "nothing to do", not errors, so a repeated gesture is harmless.
+     *
+     * The open rides the ordinary [OpenSession] wire with `lastEventSeq = 0`, which tells the daemon this
+     * client understands delta replays (see the field's contract) while still asking for a full first tail.
+     */
+    fun open(workdir: String, sessionId: String, title: String, agent: AgentKind, mode: PermissionMode): SidePane? {
+        if (!canOpen() || paneFor(sessionId) != null) return null
+        val pane = SidePane(++paneSeq, sessionId, workdir, title, agent)
+        panes.add(pane)
+        openCount = panes.size
+        pane.mode = mode
+        dispatchOpen(pane, lastEventSeq = 0L)
+        return pane
+    }
+
+    /** Re-send a column's open after it timed out — the same request, so a retry cannot land under
+     *  different flags than the gesture that failed. */
+    fun retry(pane: SidePane) {
+        if (pane.convoId.value != null) return
+        pane.openFailed.value = false
+        pane.opening.value = true
+        dispatchOpen(pane, lastEventSeq = 0L)
+    }
+
+    /**
+     * Re-attach every column after the link comes back, the way the focused chat does: resume by session
+     * id and ask for the DELTA past the transcript cursor we already hold (issue #147), so a reconnect
+     * backfills what streamed while the link was down instead of replaying the whole tail per column.
+     */
+    fun reopenAll() {
+        if (openCount == 0) return
+        for (pane in panes.toList()) {
+            if (pane.gone.value) continue
+            pane.opening.value = pane.convoId.value == null
+            dispatchOpen(pane, lastEventSeq = pane.historySeq ?: 0L)
+        }
+    }
+
+    private fun dispatchOpen(pane: SidePane, lastEventSeq: Long) {
+        val gen = ++pane.openGen
+        scope.launch {
+            send(
+                OpenSession(
+                    workdir = pane.workdir, resumeId = pane.sessionId, mode = pane.mode,
+                    agent = pane.agent, lastEventSeq = lastEventSeq,
+                ),
+            )
+        }
+        scope.launch {
+            delay(OPEN_TIMEOUT_MS)
+            // only THIS open's deadline, and only while it is still unanswered
+            if (gen == pane.openGen && pane.convoId.value == null) {
+                pane.opening.value = false
+                pane.openFailed.value = true
+            }
+        }
+    }
+
+    /**
+     * Drop a column. The conversation is reclaimed only when it is IDLE — the same rule the focused pane
+     * uses when switching away, and for the same reason: a running turn belongs to the agent, not to
+     * whether a window is showing it, so closing the column must not kill work in flight.
+     */
+    fun close(paneId: Long) {
+        val i = panes.indexOfFirst { it.paneId == paneId }
+        if (i < 0) return
+        val pane = panes.removeAt(i)
+        openCount = panes.size
+        val convo = pane.convoId.value ?: return
+        if (pane.streaming.value) return
+        scope.launch { send(CloseSession(convo)) }
+    }
+
+    /**
+     * Drop a column WITHOUT reclaiming its session — for a promotion, which re-opens that very session as
+     * the focused chat a moment later. Sending [CloseSession] here would race that re-open on the daemon
+     * and could close the conversation the user just promoted.
+     */
+    fun detach(paneId: Long) {
+        panes.removeAll { it.paneId == paneId }
+        openCount = panes.size
+    }
+
+    /** Drop every column without touching the sessions behind them (disconnect, machine switch, sign-out). */
+    fun clear() {
+        panes.clear()
+        openCount = 0
+    }
+
+    /**
+     * True when [f] answers a side pane's open, so the focused pane must NOT treat it as its own.
+     * See the class doc — this is the single point where side panes take priority.
+     */
+    fun claimsSessionLive(f: SessionLive): Boolean = openCount > 0 && panes.any { pane ->
+        pane.convoId.value?.let { it == f.convoId } ?: (f.sessionId != null && f.sessionId == pane.sessionId)
+    }
+
+    /** Mirror [f] into the pane it belongs to. Never consumes: the caller's own handling runs regardless. */
+    fun route(f: Frame) {
+        if (openCount == 0) return
+        when (f) {
+            is SessionLive -> bind(f)
+            is ConvoHistory -> byConvo(f.convoId)?.let { replay(it, f) }
+            is AssistantChunk -> byConvo(f.convoId)?.transcript?.appendChunk(f)
+            is ToolEvent -> byConvo(f.convoId)?.let { it.transcript.finishThinking(); it.transcript.onToolEvent(f) }
+            is TurnDone -> byConvo(f.convoId)?.let { endTurn(it, f) }
+            is PromptAck -> byConvo(f.convoId)?.let { it.error.value = null }
+            is PermissionAsk -> if (!f.isQuestion) byConvo(f.convoId)?.let { it.pendingAsk.value = f }
+            is AskWithdrawn -> byConvo(f.convoId)?.let { pane ->
+                if (pane.pendingAsk.value?.askId == f.askId) pane.pendingAsk.value = null
+            }
+            is SessionGone -> byConvo(f.convoId)?.let { it.gone.value = true; it.streaming.value = false }
+            is PocketError -> f.convoId?.let { c -> byConvo(c)?.let { it.error.value = f.message } }
+            else -> Unit
+        }
+    }
+
+    /** Resolving an approval anywhere clears the card here too — the pane must not keep offering a decision
+     *  that has already been made (from the bell popover, the phone, or the computer itself). */
+    fun noteApprovalResolved(convoId: String, askId: String) {
+        byConvo(convoId)?.let { if (it.pendingAsk.value?.askId == askId) it.pendingAsk.value = null }
+    }
+
+    /** Send [text] into [pane]'s conversation. False = nothing to send, or the pane's open has not landed. */
+    fun sendPrompt(pane: SidePane, text: String): Boolean {
+        val convo = pane.convoId.value ?: return false
+        if (text.isBlank()) return false
+        val promptId = newPromptId()
+        pane.messages.add(ChatItem.User(text, pending = true, promptId = promptId))
+        pane.composer.value = ""
+        pane.turnStartMark = TimeSource.Monotonic.markNow()
+        pane.streaming.value = true
+        scope.launch { send(SendPrompt(convo, text, promptId = promptId)) }
+        return true
+    }
+
+    private companion object {
+        /** Matches the focused chat's own open window — long enough for a cold resume, short enough that
+         *  a column does not sit on "Opening…" past the point a person decides it is broken. */
+        const val OPEN_TIMEOUT_MS = 8_000L
+    }
+
+    private fun byConvo(convoId: String): SidePane? = panes.firstOrNull { it.convoId.value == convoId }
+
+    private fun bind(f: SessionLive) {
+        val pane = panes.firstOrNull { it.convoId.value == f.convoId }
+            ?: panes.firstOrNull { it.convoId.value == null && f.sessionId != null && f.sessionId == it.sessionId }
+            ?: return
+        pane.convoId.value = f.convoId
+        pane.opening.value = false
+        pane.openFailed.value = false
+        pane.gone.value = false
+        f.executing?.let { pane.streaming.value = it }
+    }
+
+    /** The pane flavour of the focused path's ConvoHistory handling (issue #147 full/delta, issue #107 echo). */
+    private fun replay(pane: SidePane, f: ConvoHistory) {
+        val local = pane.messages.toList()
+        val merged = if (f.delta) {
+            if (f.messages.isEmpty()) return
+            TranscriptMerge.mergeDelta(local, f.messages.map(::historyItem))
+        } else {
+            TranscriptMerge.merge(local, f.messages.map(::historyItem))
+        }
+        if (merged != local) {
+            pane.messages.clear()
+            pane.messages.addAll(merged)
+        }
+        pane.transcript.replayEcho = true // arm the one-shot live-stream dedupe for the replay/stream race
+        f.lastSeq?.let { pane.historySeq = it }
+    }
+
+    private fun endTurn(pane: SidePane, f: TurnDone) {
+        pane.transcript.replayEcho = false // turn boundary — the next block starts a new turn, never an echo
+        val wasLive = pane.streaming.value
+        pane.transcript.finishThinking()
+        pane.streaming.value = false
+        // the turn is over, so no bubble is still "sending" — the pane has no delivery watchdog of its
+        // own, and a bubble stuck at pending would misreport a prompt the agent demonstrably answered
+        for (i in pane.messages.indices) {
+            val row = pane.messages[i]
+            if (row is ChatItem.User && row.pending) pane.messages[i] = row.copy(pending = false)
+        }
+        f.error?.let { pane.messages.add(ChatItem.Sys(it)) }
+        if (wasLive && f.error == null) {
+            pane.messages.add(ChatItem.TurnEnded(pane.turnStartMark?.elapsedNow()?.inWholeSeconds?.toInt()))
+        }
+        pane.turnStartMark = null
+    }
+}

--- a/mobile/composeApp/src/commonTest/kotlin/dev/ccpocket/app/data/ChatTranscriptTest.kt
+++ b/mobile/composeApp/src/commonTest/kotlin/dev/ccpocket/app/data/ChatTranscriptTest.kt
@@ -1,0 +1,91 @@
+package dev.ccpocket.app.data
+
+import dev.ccpocket.protocol.AssistantChunk
+import dev.ccpocket.protocol.StreamPiece
+import dev.ccpocket.protocol.ToolEvent
+import dev.ccpocket.protocol.ToolPhase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The stream-assembly rules, now that they live in [ChatTranscript] rather than inside the repository
+ * (issue #311). The extraction has to be behaviour-preserving — the repository delegates to this and the
+ * split panes each own one, so a rule that quietly changed here would change the main chat too.
+ */
+class ChatTranscriptTest {
+
+    private fun text(s: String) = AssistantChunk("c", 1, StreamPiece.Text(s))
+    private fun thinking(s: String) = AssistantChunk("c", 1, StreamPiece.Thinking(s))
+
+    @Test
+    fun consecutiveTextChunksGrowOneBubble() {
+        val t = ChatTranscript()
+        t.appendChunk(text("Hel"))
+        t.appendChunk(text("lo"))
+        assertEquals(listOf("Hello"), t.messages.filterIsInstance<ChatItem.Assistant>().map { it.text })
+        assertTrue(t.streaming.value) // a chunk means a turn is running
+    }
+
+    @Test
+    fun thinkingCollectsSeparatelyAndIsStampedWhenProseStarts() {
+        val t = ChatTranscript()
+        t.appendChunk(thinking("weighing "))
+        t.appendChunk(thinking("options"))
+        val open = t.messages.filterIsInstance<ChatItem.Thinking>().single()
+        assertEquals("weighing options", open.text)
+        assertNull(open.seconds) // still open
+
+        t.appendChunk(text("Here is the plan"))
+        val stamped = t.messages.filterIsInstance<ChatItem.Thinking>().single()
+        assertNotNull(stamped.seconds) // prose starting closes the block and stamps its duration
+        assertTrue(stamped.seconds!! >= 1) // never "Thought for 0s"
+    }
+
+    @Test
+    fun aToolResultPatchesTheCardItsStartCreated() {
+        val t = ChatTranscript()
+        t.onToolEvent(ToolEvent("c", 1, ToolPhase.START, "Read", "src/App.kt", toolUseId = "t1"))
+        t.onToolEvent(ToolEvent("c", 2, ToolPhase.RESULT, "Read", toolUseId = "t1", ok = false, output = "no such file"))
+        val card = t.messages.filterIsInstance<ChatItem.Tool>().single()
+        assertEquals("Read", card.tool)
+        assertEquals(false, card.ok)
+        assertEquals("no such file", card.output)
+    }
+
+    @Test
+    fun aChildToolEventCountsUpItsParentCardInsteadOfAddingARow() {
+        val t = ChatTranscript()
+        t.onToolEvent(ToolEvent("c", 1, ToolPhase.START, "Task", "explore", toolUseId = "parent"))
+        t.onToolEvent(ToolEvent("c", 2, ToolPhase.START, "Grep", "needle", toolUseId = "k1", parentToolUseId = "parent"))
+        t.onToolEvent(ToolEvent("c", 3, ToolPhase.START, "Read", "file", toolUseId = "k2", parentToolUseId = "parent"))
+        val card = t.messages.filterIsInstance<ChatItem.Tool>().single()
+        assertEquals(2, card.childCount)
+        assertEquals("Read", card.lastChild)
+    }
+
+    @Test
+    fun theReplayEchoDedupeDropsExactlyOneRepeatedTail() {
+        val t = ChatTranscript()
+        t.appendChunk(text("the replayed answer"))
+        t.replayEcho = true // what a merged ConvoHistory arms
+        t.appendChunk(text("the replayed answer")) // the live stream re-sending the block the replay carried
+        assertEquals(listOf("the replayed answer"), t.messages.filterIsInstance<ChatItem.Assistant>().map { it.text })
+
+        t.appendChunk(text(" and more")) // the one-shot is spent — ordinary streaming resumes
+        assertEquals(listOf("the replayed answer and more"), t.messages.filterIsInstance<ChatItem.Assistant>().map { it.text })
+    }
+
+    @Test
+    fun resetDropsEverythingIncludingTheOneShotArm() {
+        val t = ChatTranscript()
+        t.appendChunk(text("gone"))
+        t.replayEcho = true
+        t.reset()
+        assertTrue(t.messages.isEmpty())
+        assertTrue(!t.replayEcho)
+        assertTrue(!t.streaming.value)
+    }
+}

--- a/mobile/composeApp/src/commonTest/kotlin/dev/ccpocket/app/data/SplitPanesTest.kt
+++ b/mobile/composeApp/src/commonTest/kotlin/dev/ccpocket/app/data/SplitPanesTest.kt
@@ -1,0 +1,308 @@
+package dev.ccpocket.app.data
+
+import dev.ccpocket.protocol.AgentKind
+import dev.ccpocket.protocol.AssistantChunk
+import dev.ccpocket.protocol.ChatRole
+import dev.ccpocket.protocol.CloseSession
+import dev.ccpocket.protocol.ConvoHistory
+import dev.ccpocket.protocol.Frame
+import dev.ccpocket.protocol.HistoryMessage
+import dev.ccpocket.protocol.OpenSession
+import dev.ccpocket.protocol.PermissionAsk
+import dev.ccpocket.protocol.PermissionMode
+import dev.ccpocket.protocol.SendPrompt
+import dev.ccpocket.protocol.SessionGone
+import dev.ccpocket.protocol.SessionLive
+import dev.ccpocket.protocol.StreamPiece
+import dev.ccpocket.protocol.ToolEvent
+import dev.ccpocket.protocol.ToolPhase
+import dev.ccpocket.protocol.TurnDone
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The desktop split panes' conversation channel (issue #311).
+ *
+ * The invariant the whole feature rests on: a pane's conversation is routed to THAT pane and nowhere
+ * else, and the repository's own single-conversation state machine is left alone. These tests drive
+ * [SidePanes] with the frames a daemon actually sends, because the failure this design must not have is
+ * a second session's output appearing in the first session's transcript.
+ */
+class SplitPanesTest {
+
+    private val sent = mutableListOf<Frame>()
+    private var promptSeq = 0
+    /** Unconfined by default so a launch runs inline and `sent` is filled by the time a verb returns.
+     *  The open-deadline cases pass a test dispatcher instead, to get virtual time for the 8s window. */
+    private fun panes(scope: CoroutineScope = CoroutineScope(Dispatchers.Unconfined)) = SidePanes(
+        scope = scope,
+        send = { sent += it },
+        newPromptId = { "p${++promptSeq}" },
+    )
+
+    private fun open(p: SidePanes, sid: String = "sid-a") =
+        p.open("/w", sid, "Refactor the parser", AgentKind.CLAUDE, PermissionMode.DEFAULT)!!
+
+    private fun live(convo: String, sid: String) = SessionLive(convoId = convo, workdir = "/w", sessionId = sid)
+
+    private fun text(convo: String, s: String) = AssistantChunk(convo, 1, StreamPiece.Text(s))
+
+    @Test
+    fun openSendsAResumeAndBindsItsOwnSessionLive() {
+        val p = panes()
+        val pane = open(p)
+        val frame = sent.filterIsInstance<OpenSession>().single()
+        assertEquals("/w", frame.workdir)
+        assertEquals("sid-a", frame.resumeId)
+        assertEquals(0L, frame.lastEventSeq) // declares delta-replay support without asking for a delta yet
+        assertTrue(pane.opening.value)
+
+        p.route(live("convo-a", "sid-a"))
+        assertEquals("convo-a", pane.convoId.value)
+        assertFalse(pane.opening.value)
+    }
+
+    @Test
+    fun streamLandsInTheOwningPaneOnly() {
+        val p = panes()
+        val a = open(p, "sid-a")
+        val b = p.open("/w2", "sid-b", "Write the docs", AgentKind.CODEX, PermissionMode.DEFAULT)!!
+        p.route(live("convo-a", "sid-a"))
+        p.route(live("convo-b", "sid-b"))
+
+        p.route(text("convo-a", "hello from A"))
+        p.route(text("convo-b", "hello from B"))
+
+        assertEquals(listOf("hello from A"), a.messages.filterIsInstance<ChatItem.Assistant>().map { it.text })
+        assertEquals(listOf("hello from B"), b.messages.filterIsInstance<ChatItem.Assistant>().map { it.text })
+    }
+
+    @Test
+    fun aFrameForNoPaneChangesNothing() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        p.route(text("convo-elsewhere", "not ours"))
+        assertTrue(pane.messages.isEmpty())
+    }
+
+    @Test
+    fun toolResultPatchesTheCardItStarted() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        p.route(ToolEvent("convo-a", 1, ToolPhase.START, "Bash", "ls -la", toolUseId = "t1"))
+        p.route(ToolEvent("convo-a", 2, ToolPhase.RESULT, "Bash", toolUseId = "t1", ok = true, output = "3 files"))
+        val card = pane.messages.filterIsInstance<ChatItem.Tool>().single()
+        assertEquals(true, card.ok)
+        assertEquals("3 files", card.output)
+    }
+
+    @Test
+    fun turnDoneEndsTheTurnAndSettlesPendingBubbles() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        assertTrue(p.sendPrompt(pane, "run the tests"))
+        assertTrue(pane.streaming.value)
+        assertTrue(pane.messages.filterIsInstance<ChatItem.User>().single().pending)
+
+        p.route(TurnDone("convo-a"))
+        assertFalse(pane.streaming.value)
+        assertFalse(pane.messages.filterIsInstance<ChatItem.User>().single().pending)
+        assertEquals(1, pane.messages.count { it is ChatItem.TurnEnded })
+    }
+
+    @Test
+    fun failedTurnShowsTheErrorAndNoCompletionMarker() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        p.route(text("convo-a", "starting"))
+        p.route(TurnDone("convo-a", error = "API request failed"))
+        assertEquals("API request failed", pane.messages.filterIsInstance<ChatItem.Sys>().single().text)
+        assertEquals(0, pane.messages.count { it is ChatItem.TurnEnded })
+    }
+
+    @Test
+    fun historyReplayFillsThePaneBacklog() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        p.route(
+            ConvoHistory(
+                "convo-a",
+                listOf(
+                    HistoryMessage(ChatRole.USER, "what changed?"),
+                    HistoryMessage(ChatRole.ASSISTANT, "three files"),
+                ),
+                lastSeq = 42,
+            ),
+        )
+        assertEquals(2, pane.messages.size)
+        assertEquals("what changed?", (pane.messages[0] as ChatItem.User).text)
+        assertEquals("three files", (pane.messages[1] as ChatItem.Assistant).text)
+        assertEquals(42L, pane.historySeq)
+    }
+
+    @Test
+    fun sendIsRefusedUntilTheOpenLands() {
+        val p = panes()
+        val pane = open(p)
+        assertFalse(p.sendPrompt(pane, "too early")) // no convoId yet
+        assertTrue(sent.filterIsInstance<SendPrompt>().isEmpty())
+
+        p.route(live("convo-a", "sid-a"))
+        assertTrue(p.sendPrompt(pane, "now"))
+        val prompt = sent.filterIsInstance<SendPrompt>().single()
+        assertEquals("convo-a", prompt.convoId)
+        assertEquals("now", prompt.text)
+    }
+
+    @Test
+    fun blankSendIsIgnored() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        assertFalse(p.sendPrompt(pane, "   "))
+        assertTrue(sent.filterIsInstance<SendPrompt>().isEmpty())
+    }
+
+    @Test
+    fun approvalReachesItsPaneAndAnyDecisionRetiresIt() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        p.route(PermissionAsk("convo-a", "ask-1", "Bash", "rm -rf build"))
+        assertEquals("ask-1", pane.pendingAsk.value?.askId)
+
+        p.noteApprovalResolved("convo-a", "ask-1") // decided from the bell popover / the phone
+        assertNull(pane.pendingAsk.value)
+    }
+
+    @Test
+    fun sessionGoneIsSaidOutLoudRatherThanLeavingABlankColumn() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        p.route(SessionGone("convo-a"))
+        assertTrue(pane.gone.value)
+        assertFalse(pane.streaming.value)
+    }
+
+    @Test
+    fun theSplitIsCappedAndNeverShowsOneSessionTwice() {
+        val p = panes()
+        open(p, "sid-a")
+        assertNotNull(p.open("/w", "sid-b", "B", AgentKind.CLAUDE, PermissionMode.DEFAULT))
+        // MAX_SPLIT_PANES counts the focused conversation, so two side columns fill a three-way split
+        assertFalse(p.canOpen())
+        assertNull(p.open("/w", "sid-c", "C", AgentKind.CLAUDE, PermissionMode.DEFAULT))
+        assertNull(p.open("/w", "sid-a", "A again", AgentKind.CLAUDE, PermissionMode.DEFAULT))
+        assertEquals(2, p.panes.size)
+    }
+
+    @Test
+    fun closingAnIdleColumnReclaimsItsSessionButAStreamingOneKeepsRunning() {
+        val p = panes()
+        val idle = open(p, "sid-a")
+        p.route(live("convo-a", "sid-a"))
+        sent.clear()
+        p.close(idle.paneId)
+        assertEquals("convo-a", sent.filterIsInstance<CloseSession>().single().convoId)
+
+        val busy = p.open("/w", "sid-b", "B", AgentKind.CLAUDE, PermissionMode.DEFAULT)!!
+        p.route(live("convo-b", "sid-b"))
+        p.route(text("convo-b", "mid-turn output")) // a chunk means the turn is live
+        sent.clear()
+        p.close(busy.paneId)
+        assertTrue(sent.filterIsInstance<CloseSession>().isEmpty()) // work in flight outlives its column
+        assertTrue(p.panes.isEmpty())
+    }
+
+    @Test
+    fun aPanesOwnSessionLiveIsClaimedSoTheFocusedChatCannotTakeIt() {
+        val p = panes()
+        val pane = open(p)
+        assertTrue(p.claimsSessionLive(live("convo-a", "sid-a")))   // by session id, before binding
+        p.route(live("convo-a", "sid-a"))
+        assertTrue(p.claimsSessionLive(live("convo-a", "sid-a")))   // by convo id, after binding (reattach)
+        assertFalse(p.claimsSessionLive(live("convo-other", "sid-other")))
+        assertEquals("convo-a", pane.convoId.value)
+    }
+
+    @Test
+    fun anOpenThatNeverLandsFailsInsteadOfHangingOnOpening() = runTest {
+        val p = panes(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+        val pane = open(p)
+        assertTrue(pane.opening.value)
+        advanceTimeBy(9_000)
+        assertFalse(pane.opening.value)
+        assertTrue(pane.openFailed.value) // the column says so, and offers the retry
+
+        sent.clear()
+        p.retry(pane)
+        assertFalse(pane.openFailed.value)
+        val again = sent.filterIsInstance<OpenSession>().single()
+        assertEquals("sid-a", again.resumeId) // the SAME request, not a differently-flagged one
+        p.route(live("convo-a", "sid-a"))
+        advanceTimeBy(9_000)
+        assertFalse(pane.openFailed.value) // the first open's dead deadline cannot fail the retry
+    }
+
+    @Test
+    fun aLandedOpenIsNeverFailedByItsOwnDeadline() = runTest {
+        val p = panes(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        advanceTimeBy(9_000)
+        assertFalse(pane.openFailed.value)
+        assertEquals("convo-a", pane.convoId.value)
+    }
+
+    @Test
+    fun reconnectReattachesEveryColumnAskingOnlyForTheDelta() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        p.route(ConvoHistory("convo-a", listOf(HistoryMessage(ChatRole.ASSISTANT, "earlier")), lastSeq = 77))
+        sent.clear()
+
+        p.reopenAll()
+        val reopen = sent.filterIsInstance<OpenSession>().single()
+        assertEquals("sid-a", reopen.resumeId)
+        assertEquals(77L, reopen.lastEventSeq) // backfill past the cursor, not a whole-tail replay
+    }
+
+    @Test
+    fun detachDropsAColumnWithoutReclaimingItsSession() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        sent.clear()
+        p.detach(pane.paneId)
+        assertTrue(p.panes.isEmpty())
+        // a promotion re-opens this very session next; a CloseSession here would race that open
+        assertTrue(sent.filterIsInstance<CloseSession>().isEmpty())
+    }
+
+    @Test
+    fun clearDropsEveryColumnWithoutTouchingTheSessions() {
+        val p = panes()
+        open(p, "sid-a")
+        p.route(live("convo-a", "sid-a"))
+        sent.clear()
+        p.clear()
+        assertTrue(p.panes.isEmpty())
+        assertTrue(sent.isEmpty()) // a link that died cannot be told anything anyway
+    }
+}

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/ChatPane.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/ChatPane.kt
@@ -109,6 +109,8 @@ import dev.ccpocket.app.data.ImgState
 import dev.ccpocket.app.data.PendingFile
 import dev.ccpocket.app.data.SentFile
 import dev.ccpocket.app.resources.Res
+import dev.ccpocket.app.resources.split_pane_close
+import dev.ccpocket.app.resources.split_pane_focus
 import dev.ccpocket.app.resources.ho_continuing
 import dev.ccpocket.app.resources.ho_copy_invite
 import dev.ccpocket.app.resources.ho_finish_return
@@ -1054,15 +1056,32 @@ private fun ChatSubHeader(model: DesktopModel, onTerminalMenu: () -> Unit = {}) 
                         .padding(horizontal = 9.dp, vertical = 3.dp),
                 )
             }
-            ChangesPill(model) // "± N" — the session's changed files, opens the Changes browser
-            GitPill(model) // "⎇ branch ↑2" — the repository's state, opens the Git panel (issue #280)
-            // the permission-mode switch lives in the ⋯ popover now, mirroring mobile's quick-actions
-            // sheet (the old header pill was display-only and read as a broken control)
-            Icon(
-                Icons.Rounded.MoreHoriz, null, tint = Tok.tx2,
-                modifier = Modifier.size(26.dp).clip(RoundedCornerShape(999.dp))
-                    .clickable { model.showQuickActions = true }.padding(4.dp),
-            )
+            if (model.paneScoped) {
+                // split column (issue #311): Changes / Git / ⋯ all drive the FOCUSED conversation, so from
+                // here they would act on a session the user is not looking at. A column carries its own two
+                // verbs instead — take the focus (which is what unlocks the full set), or close the column.
+                Text(
+                    stringResource(Res.string.split_pane_focus), color = Tok.tx2, fontFamily = Dk.ui, fontSize = 11.sp,
+                    style = tightCenter(11.sp),
+                    modifier = Modifier.clip(RoundedCornerShape(999.dp)).border(1.dp, Tok.hair, RoundedCornerShape(999.dp))
+                        .clickable { model.focusThisPane() }.padding(horizontal = 9.dp, vertical = 3.dp),
+                )
+                Icon(
+                    Icons.Rounded.Close, stringResource(Res.string.split_pane_close), tint = Tok.tx2,
+                    modifier = Modifier.size(26.dp).clip(RoundedCornerShape(999.dp))
+                        .clickable { model.closeThisPane() }.padding(5.dp),
+                )
+            } else {
+                ChangesPill(model) // "± N" — the session's changed files, opens the Changes browser
+                GitPill(model) // "⎇ branch ↑2" — the repository's state, opens the Git panel (issue #280)
+                // the permission-mode switch lives in the ⋯ popover now, mirroring mobile's quick-actions
+                // sheet (the old header pill was display-only and read as a broken control)
+                Icon(
+                    Icons.Rounded.MoreHoriz, null, tint = Tok.tx2,
+                    modifier = Modifier.size(26.dp).clip(RoundedCornerShape(999.dp))
+                        .clickable { model.showQuickActions = true }.padding(4.dp),
+                )
+            }
         }
         val branch = model.chatBranch?.let { "  ·  ⑂ $it" } ?: ""
         // machine-first line: which computer this session lives on leads the mono meta (fleet language)

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopApp.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopApp.kt
@@ -96,13 +96,26 @@ fun DesktopApp(model: DesktopModel, onActivateWindow: () -> Unit = {}) {
                 )
             }
             val watch = model.watch
-            if (watch == null) {
-                ChatPane(model, Modifier.weight(1f))
-            } else {
-                // split: chat with the focused session while watching a second one read-only (Fleet ⑥)
-                ChatPane(model, Modifier.weight(1f), focused = true)
-                Box(Modifier.width(1.dp).fillMaxHeight().background(Tok.hair))
-                WatchPane(watch, model, Modifier.weight(1f))
+            val split = model.sidePanes
+            when {
+                watch != null -> {
+                    // split: chat with the focused session while watching a second one read-only (Fleet ⑥)
+                    ChatPane(model, Modifier.weight(1f), focused = true)
+                    Box(Modifier.width(1.dp).fillMaxHeight().background(Tok.hair))
+                    WatchPane(watch, model, Modifier.weight(1f))
+                }
+                // split panes (issue #311): the focused conversation keeps the leftmost column and the full
+                // chat surface; every other open conversation gets an equal-width column of its own, each
+                // with its own stream, composer and approvals. Equal widths on purpose — the first version
+                // deliberately has no drag-to-resize tiling to get wrong.
+                split.isEmpty() -> ChatPane(model, Modifier.weight(1f))
+                else -> {
+                    ChatPane(model, Modifier.weight(1f), focused = true)
+                    split.forEach { pane ->
+                        Box(Modifier.width(1.dp).fillMaxHeight().background(Tok.hair))
+                        SplitPane(model, pane, Modifier.weight(1f))
+                    }
+                }
             }
             // workflow orchestration (issue #106): a persistent ~360dp docked panel — the chat stays
             // fully usable beside it (docked beats overlay, per the workflow-view handoff)

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopModel.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.ccpocket.app.data.ChatItem
+import dev.ccpocket.app.data.SidePane
 import dev.ccpocket.app.data.PocketRepository
 import dev.ccpocket.app.theme.ThemeMode
 import dev.ccpocket.app.ui.ComposerState
@@ -343,6 +344,54 @@ interface DesktopModel {
     /** On-demand full prompt/return per agent, keyed "runId#index". */
     val workflowAgentDetails: Map<String, dev.ccpocket.protocol.WorkflowAgentDetail> get() = emptyMap()
     fun fetchWorkflowAgentDetail(runId: String, agentIndex: Int, agentId: String?) {}
+
+    // ── split panes (issue #311): more than one conversation open side by side in the main area ────
+    // The shell shows [sidePanes] to the RIGHT of the focused chat, in order. Defaults leave the
+    // seed/preview models with no split at all, so every existing screenshot and UI test is unchanged.
+
+    /** Conversations open beside the focused one, left to right. Empty = the classic single-chat main area. */
+    val sidePanes: List<SidePane> get() = emptyList()
+
+    /** Room for one more column (see [MAX_SPLIT_PANES]) and a live link to open it over. */
+    val canSplit: Boolean get() = false
+
+    /** Put [s] in a new column beside the current chat. A session already shown somewhere is a no-op. */
+    fun openInSplit(s: DkSession) {}
+
+    /** Drop a column. The session keeps running — closing a view never stops an agent. */
+    fun closeSplit(paneId: Long) {}
+
+    /**
+     * Make [pane] the focused conversation, which is what gives it the full chat surface (model/mode
+     * switching, Changes, Git, rewind, attachments). Implemented as an ordinary session open: the daemon
+     * answers by reattaching the conversation it already holds, so nothing forks and nothing restarts.
+     * The outgoing focused session takes the freed column.
+     */
+    fun promoteSplit(pane: SidePane) {}
+
+    /** Re-send a column's open after it timed out — the failure pane's retry. */
+    fun retrySplitOpen(pane: SidePane) {}
+
+    /** Send into a pane's own conversation. False = blank, or its open hasn't landed yet. */
+    fun sendSidePrompt(pane: SidePane, text: String): Boolean = false
+
+    /** Decide a pane's approval through the machine-wide inbox (keyed by convo + ask id). */
+    fun resolvePaneApproval(ask: PermissionAsk, allow: Boolean) {}
+
+    /**
+     * True when this model views ONE split column rather than the whole shell (issue #311).
+     *
+     * The chat header's Changes / Git / ⋯ controls all act on the FOCUSED conversation. Rendered inside a
+     * side column they would look like they act on the column and quietly act on another session, so the
+     * header swaps them for the two verbs that do belong to a column: [focusThisPane] and [closeThisPane].
+     */
+    val paneScoped: Boolean get() = false
+
+    /** Promote the column this model views — see [promoteSplit]. Meaningless unless [paneScoped]. */
+    fun focusThisPane() {}
+
+    /** Close the column this model views. Meaningless unless [paneScoped]. */
+    fun closeThisPane() {}
 
     // fleet: the sidebar's machine groups, the attention queue, and the read-only watch pane
     val machines: List<DkMachine>

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
@@ -12,6 +12,7 @@ import dev.ccpocket.app.data.ConnPhase
 import dev.ccpocket.app.data.FleetCoordinator
 import dev.ccpocket.app.data.FleetRuntime
 import dev.ccpocket.app.data.PocketRepository
+import dev.ccpocket.app.data.SidePane
 import dev.ccpocket.app.pairing.PairedDaemon
 import dev.ccpocket.app.pairing.displayName
 import dev.ccpocket.app.resources.Res
@@ -399,6 +400,42 @@ class RepoDesktopModel(
     }
 
     override val watch: DkWatch? get() = null // needs a second live stream — multi-connection repo work
+
+    // ── split panes (issue #311) ──────────────────────────────────────────────────────────────────
+    // The repository keeps the extra conversations (SidePanes); this maps them onto the shell's verbs.
+    // Everything here rides wire and state that already existed: a pane opens with the same OpenSession
+    // the sidebar sends, and promotion is literally [selectSession] on the pane's session.
+
+    override val sidePanes: List<SidePane> get() = repo.sidePanes.panes
+
+    override val canSplit: Boolean get() = connected && repo.sidePanes.canOpen()
+
+    override fun openInSplit(s: DkSession) {
+        if (s.sessionId == repo.sessionKey.value) return // already the focused chat
+        repo.sidePanes.open(s.cwd, s.sessionId, s.title, s.agent, repo.defaultMode.value)
+    }
+
+    override fun closeSplit(paneId: Long) = repo.sidePanes.close(paneId)
+
+    override fun promoteSplit(pane: SidePane) {
+        // Promotion is an ordinary session open: the daemon answers by reattaching the conversation it
+        // already holds, so nothing forks and nothing restarts. The column is DETACHED rather than closed
+        // — reclaiming the session here would race the open that is about to resume it.
+        //
+        // The outgoing session is deliberately NOT auto-moved into the freed column. openSession already
+        // reclaims an idle conversation as it switches, so re-opening it as a column in the same breath
+        // would put a CloseSession and an OpenSession for one session in flight together. Sending it back
+        // to a column is one gesture away (the sidebar's "Open in split"), and that gesture is ordered.
+        repo.sidePanes.detach(pane.paneId)
+        selectSession(DkSession(pane.sessionId, pane.workdir, pane.title.value, agent = pane.agent))
+    }
+
+    override fun retrySplitOpen(pane: SidePane) = repo.sidePanes.retry(pane)
+
+    override fun sendSidePrompt(pane: SidePane, text: String): Boolean = repo.sidePanes.sendPrompt(pane, text)
+
+    override fun resolvePaneApproval(ask: PermissionAsk, allow: Boolean) =
+        repo.resolvePendingApproval(ask.convoId, ask.askId, allow)
 
     // ── workflow orchestration (issue #106): delegate to the repository; dock state is ui-local ──
     override val workflowRuns: Map<String, dev.ccpocket.protocol.WorkflowRun> get() = repo.workflowRuns

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SidePaneModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SidePaneModel.kt
@@ -1,0 +1,120 @@
+package dev.ccpocket.app.desktop
+
+import dev.ccpocket.app.data.ChatItem
+import dev.ccpocket.app.data.SidePane
+import dev.ccpocket.app.ui.ComposerState
+import dev.ccpocket.protocol.AgentKind
+import dev.ccpocket.protocol.PermissionAsk
+import dev.ccpocket.protocol.PermissionMode
+
+/**
+ * A [DesktopModel] view of ONE split pane's conversation (issue #311).
+ *
+ * The point of the delegation is that a pane renders with the real [ChatPane] — same stream, same tool
+ * cards, same composer, same approval card — instead of a second, thinner chat UI that would drift from
+ * it. Everything conversation-scoped is answered from [pane]; everything else (connection, sidebar,
+ * machines, settings, overlays) falls through to [base], because it describes the window, not the chat.
+ *
+ * What is deliberately inert here, rather than delegated: the verbs that would act on the FOCUSED
+ * conversation while the user is looking at this one. Changing the model, compacting, rewinding or
+ * opening Changes from a side column must not quietly reach into another session, and silently doing
+ * the right thing for the wrong conversation is the one failure a split view must not have. They become
+ * available the moment the pane is promoted (a click), which is also when they start meaning this
+ * conversation. [PANE_INERT] marks every one of them.
+ */
+class SidePaneModel(
+    private val base: DesktopModel,
+    val pane: SidePane,
+) : DesktopModel by base {
+
+    override val composerState = ComposerState()
+
+    override var composer: String
+        get() = composerState.text
+        set(v) = composerState.setText(v)
+
+    // ── this pane's conversation ──────────────────────────────────────────────────────────────────
+    override val hasChat: Boolean get() = !pane.opening.value || pane.messages.isNotEmpty()
+    override val opening: Boolean get() = pane.opening.value
+    override val openFailed: Boolean get() = pane.openFailed.value
+    override val chatTitle: String get() = pane.title.value
+    override val chatAgent: AgentKind get() = pane.agent
+    override val chatWorkdir: String get() = pane.workdir
+    override val chatBranch: String? get() = null
+    override val chatModel: String get() = ""
+    override val chatMode: PermissionMode get() = PermissionMode.DEFAULT
+    override val messages: List<ChatItem> get() = pane.messages
+    override val streaming: Boolean get() = pane.streaming.value
+    override val sessionDegraded: Boolean get() = false
+    override val contextUsed: Long? get() = null
+    override val contextWindow: Long? get() = null
+    override val observing: Boolean get() = false
+    override val selectedSessionId: String get() = pane.sessionId
+
+    /** The approval THIS session raised. Same frame the bell popover shows, so the two never disagree. */
+    override val ask: PermissionAsk? get() = pane.pendingAsk.value
+    override val askTimedOut: Boolean get() = false
+    override val askQueuePosition: Pair<Int, Int>? get() = null
+    override val askRisk: String? get() = null
+
+    override fun send(text: String) {
+        if (base.sendSidePrompt(pane, text)) composerState.clear()
+    }
+
+    /** Allow/Deny rides the machine-wide inbox verb, which is keyed by (convoId, askId) — so a decision
+     *  made here is the same decision, taken the same way, as one made from the bell or the phone. */
+    override fun resolve(allow: Boolean, remember: Boolean) {
+        val a = pane.pendingAsk.value ?: return
+        pane.pendingAsk.value = null
+        base.resolvePaneApproval(a, allow)
+    }
+
+    override fun dismissAsk() {
+        pane.pendingAsk.value = null
+    }
+
+    override val paneScoped: Boolean get() = true
+    override fun focusThisPane() = base.promoteSplit(pane)
+    override fun closeThisPane() = base.closeSplit(pane.paneId)
+
+    // ── PANE_INERT: focused-conversation verbs, deliberately no-ops here (see the class doc) ─────────
+    override val historyHasMore: Boolean get() = false
+    override val historyLoadingOlder: Boolean get() = false
+    override val historyPrependGen: Int get() = 0
+    override val lastHistoryPrependCount: Int get() = 0
+    override fun loadOlderHistory() {}
+    override val sendUndelivered: Boolean get() = false
+    override val turnStalled: Boolean get() = false
+    override val turnQueued: Boolean get() = false
+    override fun canRewind(item: ChatItem.User): Boolean = false
+    override val changedFiles: List<dev.ccpocket.protocol.ChangedFile> get() = emptyList()
+    override val gitStatus: dev.ccpocket.protocol.GitStatus? get() = null
+    override val slashCommands: List<dev.ccpocket.protocol.SlashCommand> get() = emptyList()
+    override val pathListing: dev.ccpocket.protocol.PathEntries? get() = null
+    override fun browsePath(sub: String) {}
+    override fun switchMode(m: PermissionMode) {}
+    override fun switchMode(m: PermissionMode, permissionMode: String?) {}
+    override fun switchModel(name: String) {}
+    override fun switchEffort(level: String?) {}
+    override fun switchServiceTier(tier: String?) {}
+    override fun compactConversation() {}
+    override fun clearConversation() {}
+    override fun retryOpen() = base.retrySplitOpen(pane)
+    override fun takeOver() {}
+    override fun answerQuestions(answers: Map<String, String>?, response: String?) {}
+    override fun workflowRunFor(item: ChatItem.Tool): dev.ccpocket.protocol.WorkflowRun? = null
+    override fun openWorkspaceFile(path: String) {}
+    override fun tightenAutoRun(item: ChatItem.AutoRun) {}
+    override var showQuickActions: Boolean
+        get() = false
+        set(_) {}
+    override var showChanges: Boolean
+        get() = false
+        set(_) {}
+    override var showGit: Boolean
+        get() = false
+        set(_) {}
+    override var showModelPopover: Boolean
+        get() = false
+        set(_) {}
+}

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/Sidebar.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/Sidebar.kt
@@ -113,6 +113,7 @@ import dev.ccpocket.app.resources.new_session_title
 import dev.ccpocket.app.resources.open_folder
 import dev.ccpocket.app.resources.running
 import dev.ccpocket.app.resources.session_rename
+import dev.ccpocket.app.resources.split_open
 import dev.ccpocket.app.resources.session_rename_hint
 import dev.ccpocket.app.resources.settings_title
 import dev.ccpocket.app.resources.support_title
@@ -1044,7 +1045,11 @@ private fun SessionRow(
     }
     // #202 widened this short-circuit: archiving is available on rows that can neither be renamed nor
     // grouped, so "no groups and no rename" no longer means "no menu".
-    if (menuGroups.isEmpty() && !canRename && !canArchive) { SessionRowBody(model, s, selected, indented, onClick); return }
+    // #311 widened it again: "Open in split" is available on any row while the split has room, so a row
+    // with no rename/group/archive verbs still earns a menu.
+    val splittable = model.canSplit && model.sidePanes.none { it.sessionId == s.sessionId } && s.sessionId != model.selectedSessionId
+    if (menuGroups.isEmpty() && !canRename && !canArchive && !splittable) { SessionRowBody(model, s, selected, indented, onClick); return }
+    val openInSplit = stringResource(Res.string.split_open)
     val rename = stringResource(Res.string.session_rename)
     val moveTo = stringResource(Res.string.group_move_to)
     val moveOut = stringResource(Res.string.group_move_out)
@@ -1056,6 +1061,9 @@ private fun SessionRow(
             // "Remove from recents" on purpose: the two are the pair users most need to tell apart, and
             // reading them adjacently is what teaches the difference (persistent+shared vs local+temporary).
             buildList {
+                // #311: the sidebar is where a session is picked, so it is also where one is sent to its
+                // own column. First in the list — it navigates, and navigation outranks editing.
+                if (splittable) add(ContextMenuItem(openInSplit) { model.openInSplit(s) })
                 if (canRename) add(ContextMenuItem(rename) { renaming = true })
                 menuGroups.filter { it.id != s.group }.forEach { grp ->
                     add(ContextMenuItem("$moveTo · ${grp.name}") { model.assignGroup(s.sessionId, grp.id) })

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SplitPaneView.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SplitPaneView.kt
@@ -1,0 +1,72 @@
+package dev.ccpocket.app.desktop
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.ccpocket.app.data.SidePane
+import dev.ccpocket.app.resources.Res
+import dev.ccpocket.app.resources.split_pane_close
+import dev.ccpocket.app.resources.split_session_ended
+import dev.ccpocket.app.theme.Tok
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * One split column (issue #311).
+ *
+ * It renders the real [ChatPane] over a [SidePaneModel], not a second, thinner chat view: a column shows
+ * the same stream, the same tool cards, the same composer and the same approval card as the focused
+ * conversation, because the alternative is two chat UIs that drift apart on every later change.
+ *
+ * The model is remembered against [SidePane.paneId] so the column keeps its composer draft and scroll
+ * position while it exists, and starts clean when a different session takes the slot.
+ */
+@Composable
+fun SplitPane(base: DesktopModel, pane: SidePane, modifier: Modifier = Modifier) {
+    val paneModel = remember(pane.paneId) { SidePaneModel(base, pane) }
+    if (pane.gone.value) {
+        EndedPane(paneModel, modifier)
+        return
+    }
+    ChatPane(paneModel, modifier)
+}
+
+/**
+ * A column whose session ended underneath it (daemon-side close, a crash, a machine that went away).
+ * Said plainly, with the only useful verb, rather than leaving a blank chat that reads as "still loading".
+ */
+@Composable
+private fun EndedPane(model: DesktopModel, modifier: Modifier = Modifier) {
+    Column(
+        modifier.fillMaxSize().background(Tok.base).padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterVertically),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            stringResource(Res.string.split_session_ended),
+            color = Tok.tx2, fontFamily = Dk.ui, fontSize = 13.sp, textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text(
+            stringResource(Res.string.split_pane_close),
+            color = Tok.tx, fontFamily = Dk.ui, fontSize = 12.sp,
+            modifier = Modifier.clip(RoundedCornerShape(999.dp))
+                .background(Tok.surface)
+                .clickable { model.closeThisPane() }
+                .padding(horizontal = 12.dp, vertical = 6.dp),
+        )
+    }
+}

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/SplitPaneUiTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/SplitPaneUiTest.kt
@@ -1,0 +1,113 @@
+package dev.ccpocket.app.desktop
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import dev.ccpocket.app.assertPresent
+import dev.ccpocket.app.data.ChatItem
+import dev.ccpocket.app.data.SidePane
+import dev.ccpocket.app.present
+import dev.ccpocket.app.resources.Res
+import dev.ccpocket.app.resources.split_pane_focus
+import dev.ccpocket.app.resources.split_session_ended
+import dev.ccpocket.app.str
+import dev.ccpocket.app.theme.PocketTheme
+import dev.ccpocket.protocol.AgentKind
+import dev.ccpocket.protocol.PermissionAsk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The desktop split view (issue #311), rendered for real.
+ *
+ * The claims that matter are the ones a screenshot cannot make: that three conversations are on screen at
+ * the same time, that each column has its OWN composer (the whole point — a column you can only read is a
+ * watch pane, which already existed), and that a column does not offer the header verbs that would act on
+ * a different conversation.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SplitPaneUiTest {
+
+    /** A seed shell with [n] extra columns, each carrying one assistant line so it renders a transcript. */
+    private class SplitSeed(private val extra: List<SidePane>) : SeedDesktopModel() {
+        var promoted: SidePane? = null
+        var closed: Long? = null
+        // the seed ships the fleet WATCH pane for screenshots; the live model's watch is always null
+        // (RepoDesktopModel), and that is the shell state a split renders under — match it here
+        override val watch: DkWatch? get() = null
+        override val sidePanes: List<SidePane> get() = extra
+        override val canSplit: Boolean get() = extra.size < 2
+        override fun promoteSplit(pane: SidePane) { promoted = pane }
+        override fun closeSplit(paneId: Long) { closed = paneId }
+        override fun sendSidePrompt(pane: SidePane, text: String): Boolean = true
+    }
+
+    private fun pane(id: Long, title: String, line: String, agent: AgentKind = AgentKind.CLAUDE) =
+        SidePane(id, "sid-$id", "/Users/dev/api", title, agent).apply {
+            convoId.value = "convo-$id"
+            opening.value = false
+            transcript.messages.add(ChatItem.Assistant(line))
+        }
+
+    @Test
+    fun threeConversationsShareTheMainAreaAtOnce() = runComposeUiTest {
+        val model = SplitSeed(listOf(pane(1, "Tidy CI workflow", "CI is green"), pane(2, "Bump maxFrame", "patched to 4MB")))
+        setContent { PocketTheme { DesktopApp(model) } }
+        waitForIdle()
+        assertPresent("Refactor auth module") // the focused conversation keeps the leftmost column
+        assertPresent("CI is green")          // column two's own stream
+        assertPresent("patched to 4MB")       // column three's own stream
+    }
+
+    @Test
+    fun everyColumnHasItsOwnComposer() = runComposeUiTest {
+        val model = SplitSeed(listOf(pane(1, "Tidy CI workflow", "CI is green"), pane(2, "Bump maxFrame", "patched to 4MB")))
+        setContent { PocketTheme { DesktopApp(model) } }
+        waitForIdle()
+        // one text field per column — a column you cannot type into is the read-only watch pane, not this
+        assertEquals(3, onAllNodes(hasSetTextAction()).fetchSemanticsNodes().size)
+    }
+
+    @Test
+    fun aColumnOffersFocusAndCloseInsteadOfTheFocusedConversationsVerbs() = runComposeUiTest {
+        val model = SplitSeed(listOf(pane(1, "Tidy CI workflow", "CI is green")))
+        setContent { PocketTheme { DesktopApp(model) } }
+        waitForIdle()
+        assertPresent(str(Res.string.split_pane_focus))
+        onAllNodes(hasText(str(Res.string.split_pane_focus))).onFirst().performClick()
+        assertEquals("sid-1", model.promoted?.sessionId)
+    }
+
+    @Test
+    fun aSingleChatKeepsTheClassicMainAreaUntouched() = runComposeUiTest {
+        setContent { PocketTheme { DesktopApp(SplitSeed(emptyList())) } }
+        waitForIdle()
+        // no split declared → no column chrome at all, and exactly the one composer the app always had
+        assertTrue(!present(str(Res.string.split_pane_focus)))
+        assertEquals(1, onAllNodes(hasSetTextAction()).fetchSemanticsNodes().size)
+    }
+
+    @Test
+    fun anApprovalRaisedByAColumnIsShownInThatColumn() = runComposeUiTest {
+        val p = pane(1, "Tidy CI workflow", "CI is green")
+        p.pendingAsk.value = PermissionAsk("convo-1", "ask-1", "Bash", "rm -rf build", title = "Run command")
+        val model = SplitSeed(listOf(p))
+        setContent { PocketTheme { DesktopApp(model) } }
+        waitForIdle()
+        assertPresent("rm -rf build", substring = true)
+    }
+
+    @Test
+    fun aColumnWhoseSessionEndedSaysSoAndOffersOnlyTheClose() = runComposeUiTest {
+        val p = pane(1, "Tidy CI workflow", "CI is green").apply { gone.value = true }
+        val model = SplitSeed(listOf(p))
+        setContent { PocketTheme { DesktopApp(model) } }
+        waitForIdle()
+        assertPresent(str(Res.string.split_session_ended))
+        assertTrue(!present("CI is green")) // the dead stream is not left on screen looking live
+    }
+}


### PR DESCRIPTION
Closes #311 (桌面端部分)。

主内容区可以同时放下多个会话：最左是聚焦会话，右边每个会话各占一列，上限 3 列。**每列都能独立滚动、独立输入、独立处理审批**，不是只读的观察面板。

侧栏折叠 #311 也提到，但 #62 已经做完了（拖分隔条 / 双击收起 / reveal strip / 存盘），这个 PR 没碰。

## 为什么不是「开第二条连接」

daemon 对每台设备只保持一条 E2E 会话，第二次握手会让第一条链路失聪（`FleetCoordinator` 类注释里写着）。所以同一台机器上的多列**必须共用一条链路**，按 `convoId` 分流。

好消息是下面两层本来就是多会话的，这个 PR **没有改协议，也没有改 daemon**：

- `Messages.kt` 里收发两个方向的帧普遍带 `convoId`
- `session/SessionRegistry.kt` 就是 `convoId -> Conversation`，带按设备分流的 sink 与重挂
- 客户端本来也在后台留着别的会话：切走时只有空闲会话才发 `CloseSession`

缺的只是客户端把「当前会话」那一份状态变成多份。

## 改动形状

| 文件 | 作用 |
|---|---|
| `data/ChatTranscript.kt` | 从 `PocketRepository` **原样抽出**的会话流构建（thinking 块、#107 replay 回声去重、子 agent 卡片合并、history 回放映射）。repository 持有一份，每列各持有一份，只有这一份实现 |
| `data/SplitPanes.kt` | 一列的状态（`SidePane`）与帧路由（`SidePanes`） |
| `desktop/SidePaneModel.kt` | `DesktopModel by base`：会话相关成员答自本列，其余透传 |
| `desktop/SplitPaneView.kt` | 一列的渲染 |
| `desktop/DesktopApp.kt` | 主内容区按列等分 |

设计说明在 `docs/design/SPLIT-PANES.md`。

## 只有两个挂点，既有分支一行没改

`handle()` 里三十多个 `if (f.convoId == convoId.value)` 分支**一个都没动**。加的是：

1. `sidePanes.route(f)` —— 把属于某列的帧镜像进那一列。**从不消费帧**，原有分支照常跑，所以跨会话的审批收件箱、额度统计这类与具体聊天无关的记账全都不受影响。
2. `acceptsSessionLive` 开头一行 `if (sidePanes.claimsSessionLive(f)) return false` —— 分屏的 open 回来的是同一种 `SessionLive`，而聚焦侧的接受规则最后一条是「这里还什么都没开」的兜底。没有这行，在主区为空时开一列会把会话开进主区。

**手机端行为不变**：永不开分屏，`route()` 第一行是普通整数比较。这里刻意不用快照状态判空——用 `SnapshotStateList.isEmpty()` 会推进全局快照、在别处不会发生的时刻冲掉待发的 apply 通知。这不是理论问题：第一版这么写，`RepoDesktopModelStopTurnTest.stopNeverClobbersATypedDraft` 直接变红（组合器草稿在用户眼皮底下被清空）。改成普通 `Int` 之后绿。

## 一列有什么、没什么

**有**：自己的会话流、输入框、审批卡（走 `resolvePendingApproval` 那条既有的跨会话收件箱路径，所以在列里点和在铃铛里点是同一个决定）、断线后按 `lastEventSeq` 只要增量的重挂、open 8 秒不落地就报失败并给重试。

**没有**：改模型 / 改模式、compact/clear、Changes、Git、rewind/fork、附件。这些动词都作用于**聚焦会话**，摆在侧栏里点下去会悄悄改到另一个会话。所以列头把它们换成两个属于列自己的动词：`聚焦` 和 `关闭此栏`（`DesktopModel.paneScoped`）。点「聚焦」这列就成为聚焦会话，全套能力当场解锁。

## 两个刻意的取舍

- **晋升不做交换**。「聚焦」= 一次普通的 `openSession(resumeId)`，daemon 用已持有的会话重挂，不 fork 不重启。让出主区的会话**不会**自动搬进空出来的列：`openSession` 切换时本来就会回收空闲会话，同一口气再把它开成一列，等于让同一个会话的 `CloseSession` 和 `OpenSession` 同时在飞。把它送回列里只差一个手势，而那个手势是有序的。
- **晋升走 `detach` 不走 `close`**，同理：`close` 会发 `CloseSession`，和紧接着的重挂抢同一个会话。

## 边界

- 只做同机。跨机器的列要等卫星会话流（`fleet.md` brief ③，已在那条 gap note 里交叉引用）。
- 等宽纵向等分，没有拖拽改宽、没有瓦片管理——按 issue 里「首版形态收敛为简单的纵向等分」。
- 手机端不做。

## 验证

- `bash scripts/check-all.sh` 四套全绿（protocol + daemon + relay + mobile Desktop）
- 新增 31 个测试，全绿：
  - `SplitPanesTest` 19 个：帧只落到属主列、tool RESULT 补卡、TurnDone 结算 pending 气泡、history 回放、审批到列与任意处决定后退卡、SessionGone、上限与去重、空闲列关闭回收 / 跑着的不回收、`claimsSessionLive` 两种匹配、open 超时与重试不被前一次的 deadline 误杀、重连只要增量、`detach` 不发 `CloseSession`
  - `ChatTranscriptTest` 6 个：抽取行为不变（分块合并、thinking 计时、tool 补卡、子事件计数、回声一次性去重、reset）
  - `SplitPaneUiTest` 6 个：三栏同屏、**三个独立输入框**、列头是聚焦/关闭而非聚焦会话的动词、无分屏时主区逐字节不变、列内审批、会话结束的列说人话
- 桌面 UI 我没法点，需要维护者在真机上过一眼交互手感。

问题 2 和 3（会话态拆分放哪、有没有人在做）在 issue 评论里问过没等到回复，就先按上面的接缝做了；如果你更想要别的切法，我改。
