### PR TITLE
fix(desktop): 分屏与焦点会话全面平权——认领次序、委托定界、提问承接与机器下沉 (#311)

### DIFF
--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/ChatTranscript.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/ChatTranscript.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import dev.ccpocket.app.epochMillis
 import dev.ccpocket.protocol.AssistantChunk
 import dev.ccpocket.protocol.ChatRole
+import dev.ccpocket.protocol.ConvoHistory
 import dev.ccpocket.protocol.HistoryMessage
 import dev.ccpocket.protocol.StreamPiece
 import dev.ccpocket.protocol.ToolEvent
@@ -73,6 +74,11 @@ class ChatTranscript {
     }
 
     fun onToolEvent(f: ToolEvent) {
+        // a tool starting = the thinking block (if any) is done, same as prose starting in [appendChunk].
+        // Folded in here rather than left to each caller: it was a hand-paired `finishThinking(); onToolEvent(f)`
+        // at both the focused and the split-pane call sites, and a third call site that forgot the pairing
+        // would leave an un-stamped "Thinking…" row that the NEXT turn stamps with an absurd duration.
+        finishThinking()
         val parent = f.parentToolUseId
         // one-shot replay-echo dedupe (issue #107), tool flavor: a START right after a merged
         // ConvoHistory may duplicate the replayed tail card (which has no taskId). Fold into it —
@@ -108,6 +114,63 @@ class ChatTranscript {
                 ?.let { messages.add(ChatItem.OpenCodeQuestion(it)) }
                 ?: messages.add(ChatItem.Tool(f.tool, f.inputPreview ?: "", taskId = f.toolUseId))
         }
+    }
+
+    /**
+     * A turn boundary: close the thinking block, leave streaming, and show [error] where the reply would be.
+     * Returns whether a turn was actually being watched run — the caller's gate for its completion marker,
+     * its notification, and anything else that must not fire for a boundary nobody was streaming through.
+     *
+     * Shared by the focused conversation and every split column (issue #311): the two used to keep private,
+     * line-for-line identical copies of this, which is how the replay-echo disarm and the "Thought for 5s"
+     * stamp would have drifted apart on the first later change. What stays with each caller is what is
+     * genuinely theirs — the focused path's limit offer / notify / sidebar dot / usage, the column's own
+     * TurnEnded marker and turn-start mark.
+     */
+    fun endTurn(error: String?): Boolean {
+        replayEcho = false // turn boundary — the next block belongs to a new turn, never a replay echo
+        val wasLive = streaming.value
+        finishThinking()
+        streaming.value = false
+        // a FAILED turn (API error / synthetic placeholder — issue #65): show the error row where the
+        // reply would be; the caller's completion marker stays off for a turn that produced nothing
+        error?.let { messages.add(ChatItem.Sys(it)) }
+        return wasLive
+    }
+
+    /**
+     * Apply one [ConvoHistory] — full replay or #147 delta — and arm the #107 replay-echo dedupe.
+     * Returns `f.lastSeq` so the caller can advance ITS reattach cursor (the repository keys the cursor by
+     * session, a pane keeps a bare one), or null when the daemon predates #147.
+     *
+     * MERGED, not replaced (issue #107): the replay is the backfill channel for output streamed while the
+     * link was down, but the app may hold rows the transcript doesn't (pending bubbles, dividers, scrollback
+     * past the replay window, a bubble ahead of a lagging disk read) — [TranscriptMerge] reconciles without
+     * flashing, duplicating, or reordering. [onMerged] sees the before/after lists for the receipt
+     * reconciliation the focused path layers on top.
+     *
+     * An empty delta means "already caught up" (the daemon normally does not even send one): nothing merges
+     * and the echo dedupe is NOT armed — there was no replay to echo — but the cursor still advances, which
+     * is the focused path's long-standing semantics and now the column's too.
+     */
+    fun mergeHistory(
+        f: ConvoHistory,
+        onMerged: (before: List<ChatItem>, after: List<ChatItem>) -> Unit = { _, _ -> },
+    ): Long? {
+        val local = messages.toList()
+        val merged = if (f.delta) {
+            if (f.messages.isEmpty()) return f.lastSeq
+            TranscriptMerge.mergeDelta(local, f.messages.map(::historyItem))
+        } else {
+            TranscriptMerge.merge(local, f.messages.map(::historyItem))
+        }
+        if (merged != local) {
+            messages.clear()
+            messages.addAll(merged)
+        }
+        onMerged(local, merged)
+        replayEcho = true // arm the one-shot live-stream dedupe for the replay/stream race
+        return f.lastSeq
     }
 
     /** Stamp the duration onto a still-open Thinking block (design: "Thought for 5s"). */

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
@@ -6307,23 +6307,69 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         }
     }
 
-    /** Resolve any account-wide inbox row directly, without opening or attaching its conversation. */
+    /** Resolve any account-wide inbox ROW directly, without opening or attaching its conversation. The
+     *  row is the subject here: no row, nothing to decide — which is why this may early-return, and why
+     *  a surface holding the ask itself must use [resolveAskDirect] instead. */
     fun resolvePendingApproval(convoId: String?, askId: String, allow: Boolean) {
         // P1-3: exact composite removal; a caller that (legacy) only knows the askId falls back to the
         // first row carrying it — single-session behavior, unchanged
         val key = if (convoId != null) ApprovalKey(convoId, askId)
         else pendingApprovals.keys.firstOrNull { it.askId == askId } ?: return
-        val row = pendingApprovals.remove(key) ?: return
-        if (pendingAsk.value?.let { ApprovalKey(it.convoId, it.askId) } == key) {
-            advanceAsk()
-        } else if (askQueue.removeAll { it.convoId == key.convoId && it.askId == key.askId }) { // resolved from the inbox while queued
-            askBurstTotal--
-            updateAskProgress()
+        val row = pendingApprovals[key] ?: return
+        resolveAskDirect(row.ask, allow)
+    }
+
+    /**
+     * Decide an approval named by the ASK ITSELF rather than by an inbox row (issue #311).
+     *
+     * The distinction is not pedantic. [resolvePendingApproval] answers a bell-popover row, so it gives
+     * up when that row is missing — correct there, fatal for a card that is on screen. A split column
+     * holds its own [PermissionAsk], and the inbox can legitimately not have it: a `PendingApprovals`
+     * reply clears and refills the map wholesale, so an ask arriving in that window is wiped, and an ask
+     * decided elsewhere while we were offline is gone from the refill. The old path then destroyed the
+     * card with NO verdict on the wire and the CLI sat there until it auto-denied — a click that looked
+     * like it worked and did nothing. So the verdict is UNCONDITIONAL here, exactly as it is on the
+     * focused path ([resolve]); the inbox bookkeeping is best-effort on top of it.
+     *
+     * Deliberately absent: the focused path's [allowRules] + `RuleChip` bookkeeping. Those describe the
+     * OPEN conversation's UI — the chip lands in its transcript, the rule list gates its own cards — and
+     * this ask belongs to a different one. The rule the user asked for rides `remember`/`grantScope` on
+     * the verdict, which is where it actually takes effect (daemon-side), so nothing is lost.
+     */
+    fun resolveAskDirect(
+        ask: PermissionAsk,
+        allow: Boolean,
+        remember: Boolean = false,
+        grantScope: String? = null,          // "task" | "session" — 允许本任务 / Session 记忆
+        retrySafer: Boolean = false,         // 换种安全方式 (rides a DENY)
+        constraints: List<String>? = null,
+    ) {
+        val key = ApprovalKey(ask.convoId, ask.askId)
+        if (pendingApprovals.remove(key) != null) {
+            if (pendingAsk.value?.let { ApprovalKey(it.convoId, it.askId) } == key) {
+                advanceAsk()
+            } else if (askQueue.removeAll { it.convoId == key.convoId && it.askId == key.askId }) { // resolved elsewhere while queued
+                askBurstTotal--
+                updateAskProgress()
+            }
         }
-        sidePanes.noteApprovalResolved(key.convoId, askId) // #311: same decision, every surface showing it
-        Telemetry.track(TelEvent.ApprovalDecided, mapOf(TelKey.Decision to if (allow) "allow" else "deny"))
+        sidePanes.noteApprovalResolved(ask.convoId, ask.askId) // #311: same decision, every surface showing it
+        val decisionLabel = when { // same vocabulary as [resolve] — one funnel, whichever surface decided
+            retrySafer -> "retry-safer"
+            grantScope != null -> "allow-$grantScope"
+            remember -> "always"
+            allow -> "allow"
+            else -> "deny"
+        }
+        Telemetry.track(TelEvent.ApprovalDecided, mapOf(TelKey.Decision to decisionLabel))
         scope.launch {
-            send(PermissionVerdict(row.ask.convoId, askId, if (allow) Decision.ALLOW else Decision.DENY))
+            send(
+                PermissionVerdict(
+                    ask.convoId, ask.askId, if (allow) Decision.ALLOW else Decision.DENY,
+                    remember = remember, grantScope = grantScope,
+                    retrySafer = retrySafer, constraints = constraints,
+                ),
+            )
         }
     }
 

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
@@ -2581,6 +2581,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
      * link would open a ghost session nobody is watching.
      */
     internal fun demoteToSatellite() {
+        sidePanes.clear() // #311: a column's conversation must not stay mounted on a headless satellite link
         // The UI open worker is not a transport job and therefore survives the fleet swap unless it is
         // explicitly retired. A headless satellite must never execute a click queued by the old primary.
         openGen++
@@ -5163,6 +5164,14 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         // A DIFFERENT target still goes through — latest-wins switching is unchanged (#165), and the losing
         // open's late SessionLive is still refused by the #219 identity guard.
         if (openInFlightFor(wd, resumeId) || alreadyOpen(wd, resumeId)) return false
+        // #311: a session can never be in a split column AND the focused chat at once. Focusing one that
+        // IS in a column therefore means promote it — whatever the gesture was (sidebar click, promotion,
+        // push tap, deep link), because they all funnel through here. The column must let go BEFORE the
+        // OpenSession goes out: otherwise SidePanes.claimsSessionLive still recognises the answer as that
+        // column's, the focused area's open is never answered, and the click ends in "open failed" with a
+        // Retry that fails the same way forever. Synchronous, and placed AFTER the two refusals above so
+        // an idempotent no-op click never tears a column down.
+        if (resumeId != null) sidePanes.releaseToFocus(resumeId)
         sessionNavigationFenced = false // an explicit tap/push is the only way out of #226's browse fence
         openInFlight = attempt
         lastOpenAttempt = attempt

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
@@ -348,6 +348,15 @@ private data class PendingGrantMutation(
  *  a display key on the wire, not an enum, so the client matches the same literal. */
 internal const val ASK_QUESTION_TOOL = "AskUserQuestion"
 
+/** How long an [OpenSession] may go unanswered before the surface that asked stops saying "Opening…" and
+ *  says it failed instead (issue #41 / #235). Long enough for a cold resume, short enough that nobody sits
+ *  watching a spinner past the point they decide it is broken.
+ *
+ *  ONE constant for the focused chat and the desktop's split columns (issue #311): a column's window was
+ *  documented as "matches the focused chat's own", which a literal `8000` on the other side could not
+ *  actually keep. Tuning it now moves both, which is the only honest meaning of "matches". */
+internal const val SESSION_OPEN_TIMEOUT_MS = 8_000L
+
 sealed interface ChatItem {
     /** [pending] = sent from this device but the daemon hasn't echoed any evidence back yet (stream
      *  chunk / tool event / turn end). Stays true while the link is down so the UI can say so —
@@ -3232,7 +3241,9 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
             // be dropped — else it renders into whatever convo is now open. Reopening the source replays its
             // full transcript via ConvoHistory, so nothing is actually lost. (Matches the BackgroundJobs guard.)
             is AssistantChunk -> if (f.convoId == convoId.value) { promptEvidence(); appendChunk(f) }
-            is ToolEvent -> if (f.convoId == convoId.value) { promptEvidence(); finishThinking(); onToolEvent(f) }
+            // (the thinking block's stamp is [ChatTranscript.onToolEvent]'s own first act now — it was a
+            // hand-paired call here and one more in the split panes, i.e. a convention waiting to be forgotten)
+            is ToolEvent -> if (f.convoId == convoId.value) { promptEvidence(); onToolEvent(f) }
             is PendingApprovals -> {
                 pendingApprovals.clear()
                 f.items.filterNot { it.ask.isQuestion }.forEach { pendingApprovals[ApprovalKey(it.ask.convoId, it.ask.askId)] = it }
@@ -3331,12 +3342,11 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
                 // was lost, keep the bubble pending, but the NEXT stream frame can now safely prove that
                 // prompt started; it can no longer be mistaken for output from the preceding turn.
                 if (queuedReceiptStillPending) promptQueued = false
-                transcript.replayEcho = false // turn boundary — the next block belongs to a new turn, never a replay echo
-                val turnWasLive = streaming.value // gate the marker/notify on a turn we actually watched run
-                finishThinking(); streaming.value = false
-                // a FAILED turn (API error / synthetic placeholder — issue #65): show the error row where
-                // the reply would be; no green ✓ marker for a turn that produced nothing
-                f.error?.let { messages.add(ChatItem.Sys(it)) }
+                // the turn-boundary core (echo disarm → was-it-live → thinking stamp → leave streaming →
+                // error row) is [ChatTranscript.endTurn]; a split column runs the very same one. What stays
+                // here is what is genuinely the focused conversation's — the limit offer, the notification,
+                // the sidebar dot and the usage statusline.
+                val turnWasLive = transcript.endTurn(f.error) // gate the marker/notify on a turn we actually watched run
                 // usage-limit hit with a parsed reset moment (issue #137): light the one-tap
                 // "auto-continue after reset" banner. Null (ordinary error / old daemon) = no offer.
                 if (f.error != null) {
@@ -3451,34 +3461,23 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
             // scrollback past the replay window, a bubble ahead of a lagging disk read) — TranscriptMerge
             // reconciles without flashing, duplicating, or reordering.
             is ConvoHistory -> if (f.convoId == convoId.value) {
+                // an EMPTY full replay is only ever the daemon's explicit /clear wipe (every other emit
+                // site guards isNotEmpty) — the fresh session's window is empty, so the "Context NN%"
+                // statusline resets and hides until the first new turn reports usage (issue #149).
+                // Without this a composer-typed /clear pinned the badge at the wiped session's % forever:
+                // TurnDone deliberately ignores zero-usage frames, and the menu path's optimistic reset
+                // (clearConversation) never runs for a typed command.
+                if (!f.delta && f.messages.isEmpty()) contextUsed.value = null
+                // the merge itself (full or #147 delta) + the #107 echo arming is [ChatTranscript.mergeHistory],
+                // shared with the split columns. Only the bookkeeping AROUND it is this conversation's:
+                // the receipt reconciliation and the session-keyed cursor / paging anchors.
+                val lastSeq = transcript.mergeHistory(f, ::reconcilePromptReceiptFromHistory)
                 if (f.delta) {
-                    // incremental reattach (issue #147): only the rows past the cursor we sent — merged at
-                    // the tail (or into the live-received overlap), NEVER a wipe/replace. An empty delta
-                    // means "already caught up" (the daemon normally doesn't even send one).
-                    if (f.messages.isNotEmpty()) {
-                        val localRows = messages.toList()
-                        val merged = TranscriptMerge.mergeDelta(localRows, f.messages.map(::historyItem))
-                        if (merged != localRows) replace(messages, merged)
-                        reconcilePromptReceiptFromHistory(localRows, merged)
-                        transcript.replayEcho = true // same replay/stream race as the full path
-                    }
-                    f.lastSeq?.let { historySeq = it; historySeqSession = currentSessionId }
+                    lastSeq?.let { historySeq = it; historySeqSession = currentSessionId }
                 } else {
-                    // an EMPTY full replay is only ever the daemon's explicit /clear wipe (every other emit
-                    // site guards isNotEmpty) — the fresh session's window is empty, so the "Context NN%"
-                    // statusline resets and hides until the first new turn reports usage (issue #149).
-                    // Without this a composer-typed /clear pinned the badge at the wiped session's % forever:
-                    // TurnDone deliberately ignores zero-usage frames, and the menu path's optimistic reset
-                    // (clearConversation) never runs for a typed command.
-                    if (f.messages.isEmpty()) contextUsed.value = null
-                    val localRows = messages.toList()
-                    val merged = TranscriptMerge.merge(localRows, f.messages.map(::historyItem))
-                    if (merged != localRows) replace(messages, merged)
-                    reconcilePromptReceiptFromHistory(localRows, merged)
-                    transcript.replayEcho = true // arm the one-shot live-stream dedupe for the replay/stream race
                     // reattach cursor + paging anchors (issue #147); null fields = a pre-#147 daemon
-                    historySeq = f.lastSeq
-                    historySeqSession = if (f.lastSeq != null) currentSessionId else null
+                    historySeq = lastSeq
+                    historySeqSession = if (lastSeq != null) currentSessionId else null
                     historyFirstSeq = f.firstSeq
                     historyHasMore.value = f.hasMore && f.firstSeq != null
                     // a full replay re-anchors the window; a page still in flight against the OLD anchor
@@ -5207,7 +5206,12 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         // sessionId and reattaches the still-live conversation (registry live-match), no fork.
         convoId.value?.let { if (observing.value || !streaming.value) send(CloseSession(it)) }
         if (gen != openGen) return // the close send can suspend while a newer navigation decision wins
-        messages.clear(); convoId.value = null; transcript.replayEcho = false
+        // the conversation boundary the transcript itself defines (rows + echo arming + thinking clock +
+        // streaming), instead of the hand-rolled subset that used to live here: that subset left the
+        // half-open thinking block and the streaming flag of the session we are LEAVING armed, so the next
+        // session's first tool call could stamp a duration onto a block from a different conversation.
+        transcript.reset()
+        convoId.value = null
         resetHistoryPaging() // #147: a fresh open replays in full — a stale cursor must not ask for a delta
         sessionKey.value = resumeId // durable draft key known immediately on resume; null for a brand-new session
         // #219: a brand-new session's SessionLive has no sessionId to recognize it by — arm the workdir
@@ -5294,7 +5298,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
                 serviceTier = openServiceTier,
             ),
         )
-        delay(8000) // safety: clear if the daemon never answers (matches `switching`)
+        delay(SESSION_OPEN_TIMEOUT_MS) // safety: clear if the daemon never answers (matches `switching`)
         if (gen == openGen && opening.value) {
             openJob = null
             opening.value = false

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
@@ -6343,6 +6343,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         grantScope: String? = null,          // "task" | "session" — 允许本任务 / Session 记忆
         retrySafer: Boolean = false,         // 换种安全方式 (rides a DENY)
         constraints: List<String>? = null,
+        message: String? = null,             // the note that rides a question SKIP (#57)
     ) {
         val key = ApprovalKey(ask.convoId, ask.askId)
         if (pendingApprovals.remove(key) != null) {
@@ -6366,7 +6367,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
             send(
                 PermissionVerdict(
                     ask.convoId, ask.askId, if (allow) Decision.ALLOW else Decision.DENY,
-                    remember = remember, grantScope = grantScope,
+                    message = message, remember = remember, grantScope = grantScope,
                     retrySafer = retrySafer, constraints = constraints,
                 ),
             )
@@ -6386,12 +6387,45 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         val a = pendingAsk.value ?: return
         val c = convoId.value ?: return
         advanceAsk()
-        val items = response?.takeIf { it.isNotBlank() }?.let { listOf("" to it.trim()) }
-            ?: a.questions.orEmpty().mapNotNull { q -> answers?.get(q.question)?.takeIf { it.isNotBlank() }?.let { q.question to it } }
-        messages.add(ChatItem.QuestionsAnswered(items))
+        messages.add(ChatItem.QuestionsAnswered(answeredItems(a, answers, response)))
         Telemetry.track(TelEvent.ApprovalDecided, mapOf(TelKey.Decision to "answered"))
         scope.launch { send(PermissionVerdict(c, a.askId, Decision.ALLOW, answers = answers, response = response)) }
     }
+
+    /**
+     * Answer an AskUserQuestion named by the ASK ITSELF rather than by the focused card (issue #311).
+     *
+     * Same reason [resolveAskDirect] exists: a split column holds its own ask, and answering it must not
+     * consult — let alone consume — whatever the focused conversation happens to be blocked on. The wire
+     * is byte-identical to [answerQuestions]: an ALLOW carrying the `answers` map keyed by the EXACT
+     * question text, which is what the daemon merges into claude's `updatedInput.answers`. Any other shape
+     * reads to the CLI as "the user did not answer" (#57), so this must stay one construction with the
+     * focused path, never a parallel one.
+     */
+    fun answerQuestionsDirect(ask: PermissionAsk, answers: Map<String, String>?, response: String? = null) {
+        // the note lands in the column that showed the card, and that column's queue advances — both live
+        // in SidePanes so there is exactly one place a pane's card is retired
+        sidePanes.noteQuestionsAnswered(ask.convoId, ask.askId, answeredItems(ask, answers, response))
+        Telemetry.track(TelEvent.ApprovalDecided, mapOf(TelKey.Decision to "answered"))
+        scope.launch {
+            send(PermissionVerdict(ask.convoId, ask.askId, Decision.ALLOW, answers = answers, response = response))
+        }
+    }
+
+    /** Skip a question named by the ask itself (issue #311): a DENY carrying the note, so claude learns the
+     *  user opted out instead of waiting out the timeout — the focused path's skip, one column over. */
+    fun skipQuestionsDirect(ask: PermissionAsk, message: String) =
+        resolveAskDirect(ask, allow = false, message = message)
+
+    /** The stream note for an answered question: a freeform reply stands alone (no question owns it),
+     *  otherwise one row per question the user actually picked something for. */
+    private fun answeredItems(
+        ask: PermissionAsk,
+        answers: Map<String, String>?,
+        response: String?,
+    ): List<Pair<String, String>> =
+        response?.takeIf { it.isNotBlank() }?.let { listOf("" to it.trim()) }
+            ?: ask.questions.orEmpty().mapNotNull { q -> answers?.get(q.question)?.takeIf { it.isNotBlank() }?.let { q.question to it } }
 
     /** Timeout: the daemon already auto-denied; clear the prompt without re-sending, show the next queued ask. */
     fun dismissAsk() { if (pendingAsk.value != null) advanceAsk() }

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/SplitPanes.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/SplitPanes.kt
@@ -108,7 +108,19 @@ class SidePanes(
     private var paneSeq = 0L
 
     /**
-     * [panes.size] as a PLAIN field, not snapshot state — and the only thing [route] and
+     * Sessions whose column was closed while its open was still in flight — see [close].
+     *
+     * The daemon cannot be told to stop an open it has not answered yet, so the answer arrives for a
+     * column that no longer exists. Without a record of that, the focused pane's last acceptance rule
+     * ("nothing is open here yet") would take it and the session the user just closed would open itself
+     * in the main area. Membership is consumed once, by whichever comes first: the late `SessionLive`
+     * (which is answered with a [CloseSession], handing the conversation back), or the user re-opening
+     * that session — in a column ([open]) or as the focused chat ([releaseToFocus]).
+     */
+    private val disowned = mutableSetOf<String>()
+
+    /**
+     * `panes.size + disowned.size` as a PLAIN field, not snapshot state — and the only thing [route] and
      * [claimsSessionLive] consult before deciding they have nothing to do.
      *
      * Both run on the inbound frame path, which is every chunk of every turn, and which is not a
@@ -116,8 +128,13 @@ class SidePanes(
      * global snapshot, flushing pending apply notifications at a moment nothing else would have — which
      * is exactly the kind of invisible retiming that moves a composer draft under the user. Nobody opens
      * a pane on the phone, so on mobile this keeps the hook to one integer comparison, forever.
+     *
+     * [disowned] counts into it because a disowned session's late answer must still be recognised after
+     * its column is gone — the whole point of the record.
      */
     private var openCount = 0
+
+    private fun recount() { openCount = panes.size + disowned.size }
 
     /** Room for another column, focused pane included. */
     fun canOpen(): Boolean = panes.size < MAX_SPLIT_PANES - 1
@@ -133,9 +150,10 @@ class SidePanes(
      */
     fun open(workdir: String, sessionId: String, title: String, agent: AgentKind, mode: PermissionMode): SidePane? {
         if (!canOpen() || paneFor(sessionId) != null) return null
+        disowned.remove(sessionId) // asking for it again withdraws any pending disowning of this session
         val pane = SidePane(++paneSeq, sessionId, workdir, title, agent)
         panes.add(pane)
-        openCount = panes.size
+        recount()
         pane.mode = mode
         dispatchOpen(pane, lastEventSeq = 0L)
         return pane
@@ -154,12 +172,23 @@ class SidePanes(
      * Re-attach every column after the link comes back, the way the focused chat does: resume by session
      * id and ask for the DELTA past the transcript cursor we already hold (issue #147), so a reconnect
      * backfills what streamed while the link was down instead of replaying the whole tail per column.
+     *
+     * Every live column goes back to "opening", convoId included, because the answer may name a DIFFERENT
+     * conversation: a daemon that restarted while we were away resumes the session under a fresh convoId.
+     * Holding the old one would freeze the column forever — [bind]'s session-id fallback only fires while
+     * convoId is null, [claimsSessionLive] would match neither id, and the orphaned answer would be taken
+     * by the focused area instead. Nothing is lost by clearing it: the link that carried the old
+     * conversation's frames is gone, so none can still arrive. The transcript and its [SidePane.historySeq]
+     * cursor stay, which is what keeps the re-attach a delta. Clearing [SidePane.openFailed] alongside also
+     * retires the contradictory "opening AND failed" state a reconnect used to leave behind.
      */
     fun reopenAll() {
         if (openCount == 0) return
         for (pane in panes.toList()) {
             if (pane.gone.value) continue
-            pane.opening.value = pane.convoId.value == null
+            pane.convoId.value = null
+            pane.opening.value = true
+            pane.openFailed.value = false
             dispatchOpen(pane, lastEventSeq = pane.historySeq ?: 0L)
         }
     }
@@ -193,7 +222,11 @@ class SidePanes(
         val i = panes.indexOfFirst { it.paneId == paneId }
         if (i < 0) return
         val pane = panes.removeAt(i)
-        openCount = panes.size
+        // Closed before the open landed: there is no conversation to reclaim YET, but one is on its way.
+        // Record the session as disowned so the answer is recognised when it arrives — see [disowned].
+        // A pane whose session is already gone has no answer coming and needs no record.
+        if (pane.convoId.value == null && !pane.gone.value) disowned += pane.sessionId
+        recount()
         val convo = pane.convoId.value ?: return
         if (pane.streaming.value) return
         scope.launch { send(CloseSession(convo)) }
@@ -202,16 +235,32 @@ class SidePanes(
     /**
      * Drop a column WITHOUT reclaiming its session — for a promotion, which re-opens that very session as
      * the focused chat a moment later. Sending [CloseSession] here would race that re-open on the daemon
-     * and could close the conversation the user just promoted.
+     * and could close the conversation the user just promoted. For the same reason this never disowns:
+     * the session is about to be wanted, so its answer must reach the focused chat, not a [CloseSession].
      */
     fun detach(paneId: Long) {
         panes.removeAll { it.paneId == paneId }
-        openCount = panes.size
+        recount()
+    }
+
+    /**
+     * The focused chat is taking [sessionId] over. Called from the repository's one open chokepoint, so
+     * EVERY way of focusing a session — a sidebar click, a promotion, a push tap, a deep link — means the
+     * same thing when that session is currently in a column: promote it. The column lets go first, without
+     * reclaiming the session ([detach]'s rule), so the answering `SessionLive` is no longer claimed here
+     * and reaches the focused chat. Re-opening a just-disowned session also withdraws the disowning: the
+     * user changed their mind, and that answer must not be met with a [CloseSession].
+     */
+    fun releaseToFocus(sessionId: String) {
+        disowned.remove(sessionId)
+        paneFor(sessionId)?.let { detach(it.paneId) }
+        recount()
     }
 
     /** Drop every column without touching the sessions behind them (disconnect, machine switch, sign-out). */
     fun clear() {
         panes.clear()
+        disowned.clear()
         openCount = 0
     }
 
@@ -219,9 +268,13 @@ class SidePanes(
      * True when [f] answers a side pane's open, so the focused pane must NOT treat it as its own.
      * See the class doc — this is the single point where side panes take priority.
      */
-    fun claimsSessionLive(f: SessionLive): Boolean = openCount > 0 && panes.any { pane ->
-        pane.convoId.value?.let { it == f.convoId } ?: (f.sessionId != null && f.sessionId == pane.sessionId)
-    }
+    fun claimsSessionLive(f: SessionLive): Boolean = openCount > 0 && (
+        panes.any { pane ->
+            pane.convoId.value?.let { it == f.convoId } ?: (f.sessionId != null && f.sessionId == pane.sessionId)
+        } ||
+            // a column closed mid-open: its answer belongs to nobody, and least of all to the focused area
+            (f.sessionId != null && f.sessionId in disowned)
+        )
 
     /** Mirror [f] into the pane it belongs to. Never consumes: the caller's own handling runs regardless. */
     fun route(f: Frame) {
@@ -273,7 +326,17 @@ class SidePanes(
     private fun bind(f: SessionLive) {
         val pane = panes.firstOrNull { it.convoId.value == f.convoId }
             ?: panes.firstOrNull { it.convoId.value == null && f.sessionId != null && f.sessionId == it.sessionId }
-            ?: return
+        if (pane == null) {
+            // Nobody is waiting for this answer, but it may be the one we disowned in [close]: the daemon
+            // has now mounted a conversation with no viewer at all. Hand it straight back — the record is
+            // consumed here, so a legitimate later open of the same session binds normally.
+            val orphan = f.sessionId ?: return
+            if (disowned.remove(orphan)) {
+                recount()
+                scope.launch { send(CloseSession(f.convoId)) }
+            }
+            return
+        }
         pane.convoId.value = f.convoId
         pane.opening.value = false
         pane.openFailed.value = false

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/SplitPanes.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/SplitPanes.kt
@@ -60,13 +60,12 @@ class SidePane(
     val transcript = ChatTranscript()
     val messages get() = transcript.messages
     val streaming get() = transcript.streaming
-    val composer = mutableStateOf("")
     val opening = mutableStateOf(true)
 
     /** The session ended underneath us (daemon-side close / crash) — the pane says so instead of going blank. */
     val gone = mutableStateOf(false)
 
-    /** The open never landed inside [SidePanes.OPEN_TIMEOUT_MS] (issue #235's problem, one column over):
+    /** The open never landed inside [SESSION_OPEN_TIMEOUT_MS] (issue #235's problem, one column over):
      *  a column stuck on "Opening…" forever reads as "my click never happened", so say it failed and
      *  offer the retry instead. */
     val openFailed = mutableStateOf(false)
@@ -102,6 +101,12 @@ class SidePane(
     /** #147 reattach cursor for THIS pane's transcript, so a reconnect replays a delta, not the whole tail. */
     internal var historySeq: Long? = null
     internal var turnStartMark: TimeSource.Monotonic.ValueTimeMark? = null
+
+    /** A prompt sent from THIS column is still showing as unsent — the focused path's `promptPending`, one
+     *  column over, and for the same reason: a turn boundary only has a bubble to settle when this device
+     *  actually sent one. Most TurnDone frames (a reattached turn, work started at the computer) have none,
+     *  and scanning the whole transcript for a bubble that cannot be there is pure waste on every turn. */
+    internal var promptOutstanding = false
 
     /** The mode this column was opened under, replayed verbatim by a retry or a reconnect re-attach. */
     internal var mode: PermissionMode = PermissionMode.DEFAULT
@@ -229,7 +234,7 @@ class SidePanes(
             )
         }
         scope.launch {
-            delay(OPEN_TIMEOUT_MS)
+            delay(SESSION_OPEN_TIMEOUT_MS)
             // only THIS open's deadline, and only while it is still unanswered
             if (gen == pane.openGen && pane.convoId.value == null) {
                 pane.opening.value = false
@@ -308,7 +313,7 @@ class SidePanes(
             is SessionLive -> bind(f)
             is ConvoHistory -> byConvo(f.convoId)?.let { replay(it, f) }
             is AssistantChunk -> byConvo(f.convoId)?.transcript?.appendChunk(f)
-            is ToolEvent -> byConvo(f.convoId)?.let { it.transcript.finishThinking(); it.transcript.onToolEvent(f) }
+            is ToolEvent -> byConvo(f.convoId)?.transcript?.onToolEvent(f)
             is TurnDone -> byConvo(f.convoId)?.let { endTurn(it, f) }
             is PromptAck -> byConvo(f.convoId)?.let { it.error.value = null }
             // Questions route here too. Filtering them out left AskUserQuestion in a column with NO surface
@@ -421,7 +426,7 @@ class SidePanes(
         if (text.isBlank()) return false
         val promptId = newPromptId()
         pane.messages.add(ChatItem.User(text, pending = true, promptId = promptId))
-        pane.composer.value = ""
+        pane.promptOutstanding = true // there is now a bubble for the next turn boundary to settle
         pane.turnStartMark = TimeSource.Monotonic.markNow()
         pane.streaming.value = true
         scope.launch { send(SendPrompt(convo, text, promptId = promptId)) }
@@ -441,12 +446,6 @@ class SidePanes(
         val convo = pane.convoId.value ?: return
         if (!pane.streaming.value) return
         scope.launch { send(CancelTurn(convo)) }
-    }
-
-    private companion object {
-        /** Matches the focused chat's own open window — long enough for a cold resume, short enough that
-         *  a column does not sit on "Opening…" past the point a person decides it is broken. */
-        const val OPEN_TIMEOUT_MS = 8_000L
     }
 
     private fun byConvo(convoId: String): SidePane? = panes.firstOrNull { it.convoId.value == convoId }
@@ -469,38 +468,38 @@ class SidePanes(
         pane.opening.value = false
         pane.openFailed.value = false
         pane.gone.value = false
-        f.executing?.let { pane.streaming.value = it }
+        // daemon truth beats the local guess, exactly as the focused path takes it — the stamp included:
+        // a turn killed MID-THINKING has no TurnDone coming to close its block, so a reattach that reports
+        // idle is the only chance to stamp it. Without this the column keeps an eternal "Thinking…" row
+        // (no history replay can fix it — a replay carries no thinking rows at all) and, worse, leaves the
+        // thinking clock armed, so the NEXT turn's first tool call stamps that stale row with the wall time
+        // since the dead turn.
+        f.executing?.let { exec ->
+            pane.streaming.value = exec
+            if (!exec) pane.transcript.finishThinking()
+        }
     }
 
-    /** The pane flavour of the focused path's ConvoHistory handling (issue #147 full/delta, issue #107 echo). */
+    /** This column's ConvoHistory, merged by the same [ChatTranscript.mergeHistory] the focused chat uses
+     *  (issue #147 full/delta, issue #107 echo). Only the cursor is the pane's own — it keeps a bare one,
+     *  where the repository keys its cursor by session. */
     private fun replay(pane: SidePane, f: ConvoHistory) {
-        val local = pane.messages.toList()
-        val merged = if (f.delta) {
-            if (f.messages.isEmpty()) return
-            TranscriptMerge.mergeDelta(local, f.messages.map(::historyItem))
-        } else {
-            TranscriptMerge.merge(local, f.messages.map(::historyItem))
-        }
-        if (merged != local) {
-            pane.messages.clear()
-            pane.messages.addAll(merged)
-        }
-        pane.transcript.replayEcho = true // arm the one-shot live-stream dedupe for the replay/stream race
-        f.lastSeq?.let { pane.historySeq = it }
+        pane.transcript.mergeHistory(f)?.let { pane.historySeq = it }
     }
 
     private fun endTurn(pane: SidePane, f: TurnDone) {
-        pane.transcript.replayEcho = false // turn boundary — the next block starts a new turn, never an echo
-        val wasLive = pane.streaming.value
-        pane.transcript.finishThinking()
-        pane.streaming.value = false
         // the turn is over, so no bubble is still "sending" — the pane has no delivery watchdog of its
-        // own, and a bubble stuck at pending would misreport a prompt the agent demonstrably answered
-        for (i in pane.messages.indices) {
-            val row = pane.messages[i]
-            if (row is ChatItem.User && row.pending) pane.messages[i] = row.copy(pending = false)
+        // own, and a bubble stuck at pending would misreport a prompt the agent demonstrably answered.
+        // Gated and tail-scanned exactly like the focused path's promptEvidence: a TurnDone with nothing
+        // outstanding (a reattached turn, work started at the computer) settles nothing at all.
+        if (pane.promptOutstanding) {
+            pane.promptOutstanding = false
+            val i = pane.messages.indexOfLast { it is ChatItem.User && it.pending }
+            (pane.messages.getOrNull(i) as? ChatItem.User)?.let { pane.messages[i] = it.copy(pending = false) }
         }
-        f.error?.let { pane.messages.add(ChatItem.Sys(it)) }
+        // …and the boundary itself is the shared one (see [ChatTranscript.endTurn]); the completion marker
+        // and its stopwatch stay here, because each path times ITS OWN turn from its own send.
+        val wasLive = pane.transcript.endTurn(f.error)
         if (wasLive && f.error == null) {
             pane.messages.add(ChatItem.TurnEnded(pane.turnStartMark?.elapsedNow()?.inWholeSeconds?.toInt()))
         }

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/SplitPanes.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/SplitPanes.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import dev.ccpocket.protocol.AgentKind
 import dev.ccpocket.protocol.AskWithdrawn
+import dev.ccpocket.protocol.AskWithdrawnReason
 import dev.ccpocket.protocol.AssistantChunk
 import dev.ccpocket.protocol.CancelTurn
 import dev.ccpocket.protocol.CloseSession
@@ -71,9 +72,32 @@ class SidePane(
     val openFailed = mutableStateOf(false)
     val error = mutableStateOf<String?>(null)
 
-    /** The approval this pane's session is blocked on. Resolved through the repository's inbox verbs, so a
-     *  decision made here and one made in the bell popover travel the exact same path. */
+    /** The approval — or the AskUserQuestion — this pane's session is blocked on. Resolved through the
+     *  repository's ask-keyed verbs, so a decision made here and one made in the bell popover travel the
+     *  exact same path. Questions belong here too: the bell inbox deliberately excludes them (they are
+     *  conversation, answered inside their own session), so this slot is the ONLY surface a column's
+     *  question can ever reach. */
     val pendingAsk = mutableStateOf<PermissionAsk?>(null)
+
+    /**
+     * The asks that arrived while [pendingAsk] was already showing one (approval design M1, one column over).
+     *
+     * The daemon's ApprovalCoordinator lets one conversation hold SEVERAL open asks at once, and on a
+     * reattach it resurfaces every one of them back to back. A single-value slot kept only the last —
+     * every other question and approval was destroyed before it was ever drawn, and the agent sat waiting
+     * for a verdict no surface would ever offer. So they wait in line, exactly as the focused chat's do.
+     */
+    val askQueue = mutableStateListOf<PermissionAsk>()
+
+    /**
+     * The askId the daemon reported TIMED_OUT (issue #100), for THIS column's current card.
+     *
+     * Kept as an id rather than a flag for the same reason the focused path keeps one: matched against the
+     * card actually on screen, a stale value cannot bleed onto the next ask. A bare askId is enough here
+     * (the focused path needs the composite key) because a pane only ever holds its own conversation's
+     * asks, and askIds are unique within one.
+     */
+    val timedOutAskId = mutableStateOf<String?>(null)
 
     /** #147 reattach cursor for THIS pane's transcript, so a reconnect replays a delta, not the whole tail. */
     internal var historySeq: Long? = null
@@ -287,20 +311,108 @@ class SidePanes(
             is ToolEvent -> byConvo(f.convoId)?.let { it.transcript.finishThinking(); it.transcript.onToolEvent(f) }
             is TurnDone -> byConvo(f.convoId)?.let { endTurn(it, f) }
             is PromptAck -> byConvo(f.convoId)?.let { it.error.value = null }
-            is PermissionAsk -> if (!f.isQuestion) byConvo(f.convoId)?.let { it.pendingAsk.value = f }
-            is AskWithdrawn -> byConvo(f.convoId)?.let { pane ->
-                if (pane.pendingAsk.value?.askId == f.askId) pane.pendingAsk.value = null
+            // Questions route here too. Filtering them out left AskUserQuestion in a column with NO surface
+            // at all — the bell inbox excludes questions by design, and the focused question card is gated
+            // on the focused conversation — so the column streamed until the daemon timed the ask out and
+            // the turn died in silence. That is exactly the "lost ask" class v1.9.5 just closed (#321/#326),
+            // reappearing one column over.
+            is PermissionAsk -> byConvo(f.convoId)?.let { fileAsk(it, f) }
+            is AskWithdrawn -> byConvo(f.convoId)?.let { withdrawAsk(it, f) }
+            is SessionGone -> byConvo(f.convoId)?.let {
+                it.gone.value = true
+                it.streaming.value = false
+                // no verdict can be delivered to a conversation that no longer exists, so nothing may keep
+                // offering one — a card left behind here answers into the void and reads as "it worked"
+                clearAsks(it)
             }
-            is SessionGone -> byConvo(f.convoId)?.let { it.gone.value = true; it.streaming.value = false }
             is PocketError -> f.convoId?.let { c -> byConvo(c)?.let { it.error.value = f.message } }
             else -> Unit
         }
     }
 
-    /** Resolving an approval anywhere clears the card here too — the pane must not keep offering a decision
-     *  that has already been made (from the bell popover, the phone, or the computer itself). */
+    /**
+     * File [f] into [pane]'s card slot, with the focused chat's M1 queueing semantics (see [SidePane.askQueue]).
+     *
+     * The four cases are the focused path's, one for one: a duplicate of the card on screen (the daemon
+     * resurfaces pending asks on every reattach) refreshes it in place, a duplicate of a QUEUED one
+     * refreshes there, an empty slot takes the ask, and anything else waits its turn.
+     */
+    private fun fileAsk(pane: SidePane, f: PermissionAsk) {
+        // a card sitting in its terminal "timed out" display must not dam the queue: a NEW live ask retires
+        // it, which is also the only way that terminal state is ever left behind by something other than a tap
+        pane.pendingAsk.value?.let { if (pane.timedOutAskId.value == it.askId) advanceAsk(pane) }
+        val current = pane.pendingAsk.value
+        val queuedAt = pane.askQueue.indexOfFirst { it.askId == f.askId }
+        when {
+            current?.askId == f.askId -> pane.pendingAsk.value = f
+            queuedAt >= 0 -> pane.askQueue[queuedAt] = f
+            current == null -> pane.pendingAsk.value = f
+            else -> pane.askQueue.add(f)
+        }
+    }
+
+    /** The daemon retired one of [pane]'s asks — mirrors the focused path's AskWithdrawn handling. */
+    private fun withdrawAsk(pane: SidePane, f: AskWithdrawn) {
+        val current = pane.pendingAsk.value
+        if (current?.askId != f.askId) {
+            // a queued card the user never saw was retired (agent cancel / timeout) — drop it silently,
+            // there is nothing to explain about a card that was never drawn
+            pane.askQueue.removeAll { it.askId == f.askId }
+            return
+        }
+        if (f.reason == AskWithdrawnReason.TIMED_OUT && !current.isQuestion) {
+            // issue #100, one column over: hold the card in its terminal "timed out" state instead of
+            // letting it vanish — a card that silently disappears reads as "my decision went through"
+            pane.timedOutAskId.value = f.askId
+            return
+        }
+        // agent moved on / session closed / a question timed out. A question leaves a muted note, because
+        // a question card that just evaporates leaves the column looking like the agent stopped talking
+        // for no reason; then whatever queued behind it comes up.
+        if (current.isQuestion) pane.messages.add(ChatItem.QuestionsWithdrawn)
+        advanceAsk(pane)
+    }
+
+    /** Retire [pane]'s current card and surface the next queued ask, if any. The terminal timeout state
+     *  dies with the card it described. */
+    private fun advanceAsk(pane: SidePane) {
+        pane.timedOutAskId.value = null
+        pane.pendingAsk.value = pane.askQueue.removeFirstOrNull()
+    }
+
+    /** Drop every ask a pane is holding — for the paths where no verdict can land anymore. */
+    private fun clearAsks(pane: SidePane) {
+        pane.askQueue.clear()
+        pane.timedOutAskId.value = null
+        pane.pendingAsk.value = null
+    }
+
+    /** Resolving an approval anywhere retires the card here too — the pane must not keep offering a decision
+     *  that has already been made (from the bell popover, the phone, or the computer itself). Also how a
+     *  column's OWN verdict retires its card: the decision goes out through the repository, which lands
+     *  back here, so one path advances the queue no matter which surface decided. */
     fun noteApprovalResolved(convoId: String, askId: String) {
-        byConvo(convoId)?.let { if (it.pendingAsk.value?.askId == askId) it.pendingAsk.value = null }
+        val pane = byConvo(convoId) ?: return
+        if (pane.pendingAsk.value?.askId == askId) advanceAsk(pane)
+        else pane.askQueue.removeAll { it.askId == askId }
+    }
+
+    /**
+     * The user answered a column's question card: note the picks in THAT column's stream, then advance.
+     *
+     * The note is what makes the answer readable afterwards — the agent's next turn quotes nothing back,
+     * so without it the transcript shows a question and then, apparently, nothing. Mirrors the focused
+     * path's `ChatItem.QuestionsAnswered`, and lives here (not in the repository) because it belongs to
+     * the pane's own transcript, and because the queue must advance in exactly one place.
+     */
+    fun noteQuestionsAnswered(convoId: String, askId: String, items: List<Pair<String, String>>) {
+        val pane = byConvo(convoId) ?: return
+        if (pane.pendingAsk.value?.askId != askId) {
+            pane.askQueue.removeAll { it.askId == askId }
+            return
+        }
+        pane.messages.add(ChatItem.QuestionsAnswered(items))
+        advanceAsk(pane)
     }
 
     /** Send [text] into [pane]'s conversation. False = nothing to send, or the pane's open has not landed. */

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/SplitPanes.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/SplitPanes.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import dev.ccpocket.protocol.AgentKind
 import dev.ccpocket.protocol.AskWithdrawn
 import dev.ccpocket.protocol.AssistantChunk
+import dev.ccpocket.protocol.CancelTurn
 import dev.ccpocket.protocol.CloseSession
 import dev.ccpocket.protocol.ConvoHistory
 import dev.ccpocket.protocol.Frame
@@ -313,6 +314,21 @@ class SidePanes(
         pane.streaming.value = true
         scope.launch { send(SendPrompt(convo, text, promptId = promptId)) }
         return true
+    }
+
+    /**
+     * Interrupt [pane]'s OWN turn — the column's ■ button and its Esc, which used to reach the focused
+     * conversation's `cancelTurn` through the delegating pane model and stop whatever the user was
+     * watching in the other column instead.
+     *
+     * Nothing flips locally: the answering `TurnDone` ends the column's streaming state, exactly as it
+     * does for the focused chat. Guessing here would only mean a column that says "idle" while the agent
+     * is still writing, and the frame that tells the truth is milliseconds away.
+     */
+    fun stopTurn(pane: SidePane) {
+        val convo = pane.convoId.value ?: return
+        if (!pane.streaming.value) return
+        scope.launch { send(CancelTurn(convo)) }
     }
 
     private companion object {

--- a/mobile/composeApp/src/commonTest/kotlin/dev/ccpocket/app/data/ChatTranscriptTest.kt
+++ b/mobile/composeApp/src/commonTest/kotlin/dev/ccpocket/app/data/ChatTranscriptTest.kt
@@ -1,6 +1,9 @@
 package dev.ccpocket.app.data
 
 import dev.ccpocket.protocol.AssistantChunk
+import dev.ccpocket.protocol.ChatRole
+import dev.ccpocket.protocol.ConvoHistory
+import dev.ccpocket.protocol.HistoryMessage
 import dev.ccpocket.protocol.StreamPiece
 import dev.ccpocket.protocol.ToolEvent
 import dev.ccpocket.protocol.ToolPhase
@@ -87,5 +90,78 @@ class ChatTranscriptTest {
         assertTrue(t.messages.isEmpty())
         assertTrue(!t.replayEcho)
         assertTrue(!t.streaming.value)
+    }
+
+    /** A conversation boundary must also disarm the THINKING clock, or the next session's first tool call
+     *  stamps a row that belongs to a conversation the user already left. */
+    @Test
+    fun resetDisarmsTheThinkingClockToo() {
+        val t = ChatTranscript()
+        t.appendChunk(thinking("mid-thought when the user switched away"))
+        t.reset()
+        t.appendChunk(thinking("a brand-new block"))
+        t.onToolEvent(ToolEvent("c", 1, ToolPhase.START, "Read", "src/App.kt", toolUseId = "t1"))
+        // exactly one block, stamped by ITS OWN start — nothing carried over the boundary
+        assertEquals(1, t.messages.count { it is ChatItem.Thinking })
+        assertNotNull(t.messages.filterIsInstance<ChatItem.Thinking>().single().seconds)
+    }
+
+    /** A tool starting closes the thinking block — the transcript's own rule now, not a convention each
+     *  caller had to remember to hand-pair with [ChatTranscript.onToolEvent]. */
+    @Test
+    fun aToolStartingStampsTheOpenThinkingBlock() {
+        val t = ChatTranscript()
+        t.appendChunk(thinking("which file?"))
+        t.onToolEvent(ToolEvent("c", 1, ToolPhase.START, "Read", "src/App.kt", toolUseId = "t1"))
+        assertNotNull(t.messages.filterIsInstance<ChatItem.Thinking>().single().seconds)
+    }
+
+    @Test
+    fun endTurnReportsWhetherATurnWasWatchedAndShowsAnErrorWhereTheReplyWouldBe() {
+        val t = ChatTranscript()
+        t.appendChunk(thinking("about to fail"))
+        t.replayEcho = true
+        assertTrue(t.endTurn("API request failed"), "a turn that was streaming counts as watched")
+        assertTrue(!t.streaming.value)
+        assertTrue(!t.replayEcho, "a turn boundary disarms the echo — the next block starts a new turn")
+        assertNotNull(t.messages.filterIsInstance<ChatItem.Thinking>().single().seconds)
+        assertEquals("API request failed", t.messages.filterIsInstance<ChatItem.Sys>().single().text)
+
+        // a second boundary with nothing running is NOT a watched turn (no completion marker for it)
+        assertTrue(!t.endTurn(null))
+    }
+
+    @Test
+    fun mergeHistoryReturnsTheCursorAndArmsTheEchoDedupe() {
+        val t = ChatTranscript()
+        val full = ConvoHistory(
+            "c",
+            listOf(HistoryMessage(ChatRole.USER, "what changed?"), HistoryMessage(ChatRole.ASSISTANT, "three files")),
+            lastSeq = 42,
+        )
+        assertEquals(42L, t.mergeHistory(full))
+        assertEquals(2, t.messages.size)
+        assertTrue(t.replayEcho)
+
+        // an EMPTY delta merges nothing and arms nothing — but still carries the cursor forward
+        t.replayEcho = false
+        assertEquals(77L, t.mergeHistory(ConvoHistory("c", emptyList(), delta = true, lastSeq = 77)))
+        assertEquals(2, t.messages.size)
+        assertTrue(!t.replayEcho)
+    }
+
+    /** The receipt hook the focused path layers on top sees the lists as they were and as they became. */
+    @Test
+    fun mergeHistoryHandsTheCallerTheBeforeAndAfterRows() {
+        val t = ChatTranscript()
+        t.appendChunk(text("already on screen"))
+        var before: List<ChatItem>? = null
+        var after: List<ChatItem>? = null
+        t.mergeHistory(ConvoHistory("c", listOf(HistoryMessage(ChatRole.USER, "typed at the computer")))) { b, a ->
+            before = b
+            after = a
+        }
+        assertEquals(1, before?.size)
+        assertEquals(t.messages.toList(), after)
     }
 }

--- a/mobile/composeApp/src/commonTest/kotlin/dev/ccpocket/app/data/SplitPanesTest.kt
+++ b/mobile/composeApp/src/commonTest/kotlin/dev/ccpocket/app/data/SplitPanesTest.kt
@@ -284,6 +284,107 @@ class SplitPanesTest {
     }
 
     @Test
+    fun aColumnRebindsWhenTheReconnectAnswersWithADifferentConversation() {
+        // The daemon restarted while the link was down, so the resume lands on a FRESH convoId. Holding
+        // the dead one used to freeze the column forever: it matched neither the bind fallback nor the
+        // claim, and the answer was taken by the focused chat instead.
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-old", "sid-a"))
+        p.route(ConvoHistory("convo-old", listOf(HistoryMessage(ChatRole.ASSISTANT, "earlier")), lastSeq = 12))
+        sent.clear()
+
+        p.reopenAll()
+        assertNull(pane.convoId.value, "the conversation died with the link it was announced on")
+        assertTrue(pane.opening.value)
+        assertEquals(12L, sent.filterIsInstance<OpenSession>().single().lastEventSeq) // still a delta
+
+        p.route(live("convo-new", "sid-a"))
+        assertEquals("convo-new", pane.convoId.value)
+        assertFalse(pane.opening.value)
+        assertTrue(p.claimsSessionLive(live("convo-new", "sid-a")))
+
+        // and the new conversation's frames route into THIS pane (streaming appends to the replayed tail)
+        p.route(text("convo-new", " back online"))
+        assertEquals(
+            listOf("earlier back online"),
+            pane.messages.filterIsInstance<ChatItem.Assistant>().map { it.text },
+        )
+    }
+
+    @Test
+    fun aReconnectClearsTheFailedOpenItIsAboutToReplace() = runTest {
+        val p = panes(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+        val pane = open(p)
+        advanceTimeBy(9_000)
+        assertTrue(pane.openFailed.value)
+
+        p.reopenAll()
+        // "opening AND failed" is a contradiction the user can see — the re-attach owns the state now
+        assertFalse(pane.openFailed.value)
+        assertTrue(pane.opening.value)
+    }
+
+    @Test
+    fun closingAColumnMidOpenHandsTheLateAnswerBackToTheDaemon() {
+        val p = panes()
+        val pane = open(p)
+        sent.clear()
+        p.close(pane.paneId)
+        assertTrue(p.panes.isEmpty())
+        assertTrue(sent.isEmpty(), "no conversation exists yet, so there is nothing to close")
+
+        // the answer to an open nobody can call back: it must not be adopted by the focused chat…
+        assertTrue(p.claimsSessionLive(live("convo-a", "sid-a")))
+        p.route(live("convo-a", "sid-a"))
+        // …and it must not be left mounted on the daemon with no viewer either
+        assertEquals("convo-a", sent.filterIsInstance<CloseSession>().single().convoId)
+        assertTrue(p.panes.isEmpty(), "a disowned answer never manufactures a column")
+
+        // consumed once: asking for the same session again binds normally
+        sent.clear()
+        val again = open(p, "sid-a")
+        p.route(live("convo-a2", "sid-a"))
+        assertEquals("convo-a2", again.convoId.value)
+        assertTrue(sent.filterIsInstance<CloseSession>().isEmpty())
+    }
+
+    @Test
+    fun detachingAColumnMidOpenLeavesTheAnswerForTheFocusedChat() {
+        // A promotion clicked before the column's own open landed: the session is WANTED, so this must
+        // stay the mirror image of close() — no claim, and above all no CloseSession racing the promotion.
+        val p = panes()
+        val pane = open(p)
+        sent.clear()
+        p.detach(pane.paneId)
+        assertFalse(p.claimsSessionLive(live("convo-a", "sid-a")))
+        p.route(live("convo-a", "sid-a"))
+        assertTrue(sent.filterIsInstance<CloseSession>().isEmpty())
+        assertTrue(p.panes.isEmpty())
+    }
+
+    @Test
+    fun focusingASessionReleasesItsColumnAndUndoesADisowning() {
+        val p = panes()
+        val bound = open(p, "sid-a")
+        p.route(live("convo-a", "sid-a"))
+        sent.clear()
+        p.releaseToFocus(bound.sessionId)
+        assertTrue(p.panes.isEmpty())
+        assertTrue(sent.filterIsInstance<CloseSession>().isEmpty(), "a promotion never reclaims the session")
+        assertFalse(p.claimsSessionLive(live("convo-a", "sid-a")), "the focused chat may have its answer")
+
+        // …and the change of mind: closed while opening, then focused anyway
+        val b = p.open("/w", "sid-b", "B", AgentKind.CLAUDE, PermissionMode.DEFAULT)!!
+        p.close(b.paneId)
+        p.releaseToFocus("sid-b")
+        assertFalse(p.claimsSessionLive(live("convo-b", "sid-b")))
+        sent.clear()
+        p.route(live("convo-b", "sid-b"))
+        assertTrue(sent.filterIsInstance<CloseSession>().isEmpty(), "the focused chat is waiting for this one")
+    }
+
+    @Test
     fun detachDropsAColumnWithoutReclaimingItsSession() {
         val p = panes()
         val pane = open(p)

--- a/mobile/composeApp/src/commonTest/kotlin/dev/ccpocket/app/data/SplitPanesTest.kt
+++ b/mobile/composeApp/src/commonTest/kotlin/dev/ccpocket/app/data/SplitPanesTest.kt
@@ -167,6 +167,63 @@ class SplitPanesTest {
         assertEquals(42L, pane.historySeq)
     }
 
+    /** An EMPTY delta is the daemon saying "already caught up". It carries no rows, but it DOES carry the
+     *  cursor — dropping it (the column's old behaviour) left the pane re-asking from a stale seq forever
+     *  while the focused chat, on the identical frame, moved on. One shared [ChatTranscript.mergeHistory],
+     *  one answer. */
+    @Test
+    fun anEmptyDeltaStillAdvancesTheReattachCursor() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        p.route(ConvoHistory("convo-a", listOf(HistoryMessage(ChatRole.ASSISTANT, "earlier")), lastSeq = 5))
+        p.route(ConvoHistory("convo-a", emptyList(), delta = true, lastSeq = 9))
+        assertEquals(9L, pane.historySeq)
+        assertEquals(1, pane.messages.size) // …and nothing was merged, appended or wiped
+    }
+
+    /**
+     * A turn killed MID-THINKING never sends TurnDone, so the reattach that reports `executing = false` is
+     * the only chance to stamp its block — the focused path has always taken it, the column did not.
+     *
+     * Without the stamp the row renders "Thinking…" forever (no history replay can repair it: a replay
+     * carries no thinking rows at all) AND the thinking clock stays armed, so the next turn's first tool
+     * call stamps that stale row with the wall time since the dead turn.
+     */
+    @Test
+    fun aReattachThatReportsIdleStampsAThinkingBlockNoTurnDoneWillEverClose() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        p.route(AssistantChunk("convo-a", 1, StreamPiece.Thinking("weighing the options")))
+        assertNull(pane.messages.filterIsInstance<ChatItem.Thinking>().single().seconds)
+
+        // link came back; the daemon says that turn is over
+        p.route(SessionLive(convoId = "convo-a", workdir = "/w", sessionId = "sid-a", executing = false))
+        assertFalse(pane.streaming.value)
+        assertNotNull(
+            pane.messages.filterIsInstance<ChatItem.Thinking>().single().seconds,
+            "the block is stamped, not left mid-thought",
+        )
+
+        // …and the clock is disarmed: the NEXT turn's first tool call must not re-stamp the old row
+        val stamped = pane.messages.filterIsInstance<ChatItem.Thinking>().single().seconds
+        p.route(ToolEvent("convo-a", 2, ToolPhase.START, "Bash", "ls", toolUseId = "t1"))
+        assertEquals(stamped, pane.messages.filterIsInstance<ChatItem.Thinking>().single().seconds)
+    }
+
+    /** A reattach that reports a turn STILL running leaves the block open — it is genuinely mid-thought. */
+    @Test
+    fun aReattachThatReportsRunningLeavesTheThinkingBlockOpen() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        p.route(AssistantChunk("convo-a", 1, StreamPiece.Thinking("still weighing")))
+        p.route(SessionLive(convoId = "convo-a", workdir = "/w", sessionId = "sid-a", executing = true))
+        assertTrue(pane.streaming.value)
+        assertNull(pane.messages.filterIsInstance<ChatItem.Thinking>().single().seconds)
+    }
+
     @Test
     fun sendIsRefusedUntilTheOpenLands() {
         val p = panes()

--- a/mobile/composeApp/src/commonTest/kotlin/dev/ccpocket/app/data/SplitPanesTest.kt
+++ b/mobile/composeApp/src/commonTest/kotlin/dev/ccpocket/app/data/SplitPanesTest.kt
@@ -1,6 +1,10 @@
 package dev.ccpocket.app.data
 
 import dev.ccpocket.protocol.AgentKind
+import dev.ccpocket.protocol.AskOption
+import dev.ccpocket.protocol.AskQuestion
+import dev.ccpocket.protocol.AskWithdrawn
+import dev.ccpocket.protocol.AskWithdrawnReason
 import dev.ccpocket.protocol.AssistantChunk
 import dev.ccpocket.protocol.ChatRole
 import dev.ccpocket.protocol.CloseSession
@@ -55,6 +59,15 @@ class SplitPanesTest {
     private fun live(convo: String, sid: String) = SessionLive(convoId = convo, workdir = "/w", sessionId = sid)
 
     private fun text(convo: String, s: String) = AssistantChunk(convo, 1, StreamPiece.Text(s))
+
+    private fun ask(convo: String, askId: String, tool: String = "Edit") =
+        PermissionAsk(convo, askId, tool, inputPreview = "…", rule = tool)
+
+    /** An AskUserQuestion: same frame type, `questions` non-null — which is the whole difference. */
+    private fun question(convo: String, askId: String) = PermissionAsk(
+        convo, askId, "AskUserQuestion", inputPreview = "…",
+        questions = listOf(AskQuestion("Which parser?", options = listOf(AskOption("recursive descent"), AskOption("PEG")))),
+    )
 
     @Test
     fun openSendsAResumeAndBindsItsOwnSessionLive() {
@@ -187,6 +200,150 @@ class SplitPanesTest {
 
         p.noteApprovalResolved("convo-a", "ask-1") // decided from the bell popover / the phone
         assertNull(pane.pendingAsk.value)
+    }
+
+    // ── AskUserQuestion + the ask life cycle in a column (W3) ─────────────────────────────────────────
+
+    @Test
+    fun aQuestionReachesItsPaneInsteadOfDyingInSilence() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+
+        p.route(question("convo-a", "q-1"))
+
+        // Filtered out, this frame had NO surface anywhere: the machine-wide bell inbox excludes questions
+        // by design, and the focused question card is gated on the focused conversation. The column just
+        // streamed until the daemon timed the ask out — the turn died without a word.
+        assertEquals("q-1", pane.pendingAsk.value?.askId)
+    }
+
+    @Test
+    fun aSecondAskQueuesBehindTheCardAndSurfacesWhenItIsDecided() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+
+        p.route(ask("convo-a", "ask-1"))
+        p.route(ask("convo-a", "ask-2"))
+        // the daemon holds several asks per conversation at once; overwriting kept only the last, and the
+        // agent waited out a verdict for the first that no surface would ever offer
+        assertEquals("ask-1", pane.pendingAsk.value?.askId)
+        assertEquals(listOf("ask-2"), pane.askQueue.map { it.askId })
+
+        p.noteApprovalResolved("convo-a", "ask-1")
+        assertEquals("ask-2", pane.pendingAsk.value?.askId)
+        assertTrue(pane.askQueue.isEmpty())
+
+        p.noteApprovalResolved("convo-a", "ask-2")
+        assertNull(pane.pendingAsk.value)
+    }
+
+    @Test
+    fun aResurfacedAskRefreshesInPlaceInsteadOfQueueingTwice() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        p.route(ask("convo-a", "ask-1"))
+        p.route(ask("convo-a", "ask-2"))
+
+        // a reattach resurfaces EVERY pending ask of the conversation, current card included
+        p.route(ask("convo-a", "ask-1", tool = "Bash"))
+        p.route(ask("convo-a", "ask-2", tool = "Write"))
+
+        assertEquals("Bash", pane.pendingAsk.value?.tool, "the card on screen refreshes where it stands")
+        assertEquals(listOf("ask-2" to "Write"), pane.askQueue.map { it.askId to it.tool })
+    }
+
+    @Test
+    fun aTimedOutCardStaysUpUntilANewAskOrATapRetiresIt() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        p.route(ask("convo-a", "ask-1"))
+
+        p.route(AskWithdrawn("convo-a", "ask-1", AskWithdrawnReason.TIMED_OUT))
+        // issue #100: a card that simply vanishes reads as "my decision went through"
+        assertEquals("ask-1", pane.pendingAsk.value?.askId)
+        assertEquals("ask-1", pane.timedOutAskId.value)
+
+        p.route(ask("convo-a", "ask-2"))
+        assertEquals("ask-2", pane.pendingAsk.value?.askId, "a live ask retires the terminal card")
+        assertNull(pane.timedOutAskId.value, "and the terminal state dies with the card it described")
+        assertTrue(pane.askQueue.isEmpty(), "the timed-out card must not dam the queue")
+
+        p.route(AskWithdrawn("convo-a", "ask-2", AskWithdrawnReason.TIMED_OUT))
+        p.noteApprovalResolved("convo-a", "ask-2") // the terminal card's Dismiss
+        assertNull(pane.pendingAsk.value)
+        assertNull(pane.timedOutAskId.value)
+    }
+
+    @Test
+    fun aWithdrawnQuestionLeavesANoteAndSurfacesTheNextAsk() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        p.route(question("convo-a", "q-1"))
+        p.route(ask("convo-a", "ask-2"))
+
+        // a question has no "timed out" card state — it goes, and says so, so the column does not look
+        // like the agent stopped talking for no reason
+        p.route(AskWithdrawn("convo-a", "q-1", AskWithdrawnReason.TIMED_OUT))
+
+        assertTrue(pane.messages.any { it is ChatItem.QuestionsWithdrawn })
+        assertEquals("ask-2", pane.pendingAsk.value?.askId)
+        assertNull(pane.timedOutAskId.value)
+    }
+
+    @Test
+    fun aQueuedAskWithdrawnBeforeItWasEverDrawnGoesSilently() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        p.route(ask("convo-a", "ask-1"))
+        p.route(question("convo-a", "q-2"))
+
+        p.route(AskWithdrawn("convo-a", "q-2", AskWithdrawnReason.WITHDRAWN))
+
+        assertEquals("ask-1", pane.pendingAsk.value?.askId, "the card on screen is untouched")
+        assertTrue(pane.askQueue.isEmpty())
+        // nothing to explain about a card the user never saw — a note here would be about a question that
+        // was never asked of them
+        assertTrue(pane.messages.none { it is ChatItem.QuestionsWithdrawn })
+    }
+
+    @Test
+    fun answeringAQuestionNotesThePicksInThatColumnAndAdvances() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        p.route(question("convo-a", "q-1"))
+        p.route(ask("convo-a", "ask-2"))
+
+        p.noteQuestionsAnswered("convo-a", "q-1", listOf("Which parser?" to "recursive descent"))
+
+        assertEquals(
+            listOf(listOf("Which parser?" to "recursive descent")),
+            pane.messages.filterIsInstance<ChatItem.QuestionsAnswered>().map { it.items },
+        )
+        assertEquals("ask-2", pane.pendingAsk.value?.askId)
+    }
+
+    @Test
+    fun sessionGoneRetiresEveryAskTheColumnWasHolding() {
+        val p = panes()
+        val pane = open(p)
+        p.route(live("convo-a", "sid-a"))
+        p.route(ask("convo-a", "ask-1"))
+        p.route(question("convo-a", "q-2"))
+        p.route(AskWithdrawn("convo-a", "ask-1", AskWithdrawnReason.TIMED_OUT))
+
+        p.route(SessionGone("convo-a"))
+
+        // no verdict can reach a conversation that is gone, so nothing may keep offering one
+        assertNull(pane.pendingAsk.value)
+        assertTrue(pane.askQueue.isEmpty())
+        assertNull(pane.timedOutAskId.value)
     }
 
     @Test

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/ChatPane.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/ChatPane.kt
@@ -269,7 +269,15 @@ fun ChatPane(model: DesktopModel, modifier: Modifier = Modifier, focused: Boolea
         Column(modifier.fillMaxSize().background(Tok.base)) {
             when {
                 model.opening -> OpeningChat(model.chatTitle)
-                model.openFailed -> FailedChat(model.chatTitle) { model.retryOpen() }
+                // the open that never landed (issue #235) — named by the session the user actually asked for
+                model.openFailed -> ChatNotice(
+                    title = model.chatTitle.takeIf { it.isNotBlank() }
+                        ?.let { stringResource(Res.string.chat_open_failed_named, it) }
+                        ?: stringResource(Res.string.chat_open_failed),
+                    hint = stringResource(Res.string.chat_open_failed_hint),
+                    actionLabel = stringResource(Res.string.action_retry),
+                    onAction = { model.retryOpen() },
+                )
                 else -> EmptyChat(model)
             }
         }
@@ -1001,30 +1009,52 @@ private fun OpeningChat(title: String) {
     }
 }
 
-/** The open that never landed (issue #235). Same two-line shape as [EmptyChat] — this replaces it, it does
- *  not add a layer — but it names the session the user actually asked for and offers the one action that
- *  can help. Sticky by design: the desktop has nowhere else to put this, so it stays until the user retries
- *  or opens something else. */
+/**
+ * The centred "this chat has nothing to show, and here is why" state: a headline, an optional line of
+ * explanation, and the one action that can help.
+ *
+ * Two states share it — the open that never landed (issue #235) and the column whose session ended under
+ * it (issue #311). The column used to hand-rebuild this shape a file away and got it subtly wrong: no
+ * hover feedback on the only clickable thing on screen, and a capsule label without [tightCenter], which
+ * is the alignment rule this project has now re-learned four times. One composable, one set of answers.
+ *
+ * Sticky by design: the desktop has nowhere else to put this, so it stays until the user acts or opens
+ * something else.
+ */
 @Composable
-private fun FailedChat(title: String, onRetry: () -> Unit) {
-    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+internal fun ChatNotice(
+    title: String,
+    modifier: Modifier = Modifier,
+    hint: String? = null,
+    actionLabel: String? = null,
+    onAction: (() -> Unit)? = null,
+) {
+    Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            Modifier.padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
             Text(
-                if (title.isBlank()) stringResource(Res.string.chat_open_failed) else stringResource(Res.string.chat_open_failed_named, title),
+                title,
                 color = Tok.tx, fontFamily = Dk.ui, fontSize = 16.sp, fontWeight = FontWeight.SemiBold,
                 textAlign = TextAlign.Center, maxLines = 2, overflow = TextOverflow.Ellipsis,
             )
-            Text(
-                stringResource(Res.string.chat_open_failed_hint),
-                color = Tok.muted, fontFamily = Dk.ui, fontSize = 13.sp, textAlign = TextAlign.Center,
-            )
-            Text(
-                stringResource(Res.string.action_retry),
-                color = Tok.accent, fontFamily = Dk.ui, fontSize = 12.5.sp, fontWeight = FontWeight.Medium,
-                modifier = Modifier.padding(top = 2.dp).clip(RoundedCornerShape(7.dp))
-                    .hoverFill(RoundedCornerShape(7.dp))
-                    .clickable(onClick = onRetry).padding(horizontal = 10.dp, vertical = 5.dp),
-            )
+            hint?.let {
+                Text(it, color = Tok.muted, fontFamily = Dk.ui, fontSize = 13.sp, textAlign = TextAlign.Center)
+            }
+            if (actionLabel != null && onAction != null) {
+                Text(
+                    actionLabel,
+                    color = Tok.accent, fontFamily = Dk.ui, fontSize = 12.5.sp, fontWeight = FontWeight.Medium,
+                    // a capsule's height is its 5dp padding plus the line box, so the label must not sit
+                    // wherever the platform's fallback font's metrics put it (see [tightCenter]'s KDoc)
+                    style = tightCenter(12.5.sp),
+                    modifier = Modifier.padding(top = 2.dp).clip(RoundedCornerShape(7.dp))
+                        .hoverFill(RoundedCornerShape(7.dp))
+                        .clickable(onClick = onAction).padding(horizontal = 10.dp, vertical = 5.dp),
+                )
+            }
         }
     }
 }

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopModel.kt
@@ -375,8 +375,19 @@ interface DesktopModel {
     /** Send into a pane's own conversation. False = blank, or its open hasn't landed yet. */
     fun sendSidePrompt(pane: SidePane, text: String): Boolean = false
 
-    /** Decide a pane's approval through the machine-wide inbox (keyed by convo + ask id). */
-    fun resolvePaneApproval(ask: PermissionAsk, allow: Boolean) {}
+    /** Interrupt a pane's OWN turn (its ■ / Esc). Without this the column's stop reached the focused
+     *  conversation and killed the turn the user was watching one column over. */
+    fun stopSideTurn(pane: SidePane) {}
+
+    /** Decide a pane's approval. Keyed by the ASK the column is holding — not by whatever the focused
+     *  conversation happens to be blocked on, and not by an inbox row that may not be there. */
+    fun resolvePaneApproval(ask: PermissionAsk, allow: Boolean, remember: Boolean = false) {}
+
+    /** 允许本任务 on a pane's card: a TASK grant for THAT ask (approval design M2). */
+    fun resolvePaneTaskGrant(ask: PermissionAsk) {}
+
+    /** 换种安全方式 on a pane's card: a constrained DENY back to THAT ask's agent. */
+    fun retryPaneSafer(ask: PermissionAsk, constraints: List<String>) {}
 
     /**
      * True when this model views ONE split column rather than the whole shell (issue #311).

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopModel.kt
@@ -389,6 +389,17 @@ interface DesktopModel {
     /** 换种安全方式 on a pane's card: a constrained DENY back to THAT ask's agent. */
     fun retryPaneSafer(ask: PermissionAsk, constraints: List<String>) {}
 
+    /** Answer a pane's AskUserQuestion — the picks/free text ride an ALLOW verdict for THAT ask. A column
+     *  is the ONLY surface its questions have (the bell inbox excludes them), so this cannot be inert. */
+    fun answerPaneQuestions(ask: PermissionAsk, answers: Map<String, String>?, response: String?) {}
+
+    /** Skip a pane's AskUserQuestion: a DENY carrying the note, for THAT ask. */
+    fun skipPaneQuestions(ask: PermissionAsk, message: String) {}
+
+    /** Retire a pane's card locally, sending nothing — the timed-out card's Dismiss. The daemon already
+     *  answered that ask, so a verdict now would be a decision nobody is waiting for. */
+    fun dismissPaneAsk(ask: PermissionAsk) {}
+
     /**
      * True when this model views ONE split column rather than the whole shell (issue #311).
      *

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
@@ -434,8 +434,21 @@ class RepoDesktopModel(
 
     override fun sendSidePrompt(pane: SidePane, text: String): Boolean = repo.sidePanes.sendPrompt(pane, text)
 
-    override fun resolvePaneApproval(ask: PermissionAsk, allow: Boolean) =
-        repo.resolvePendingApproval(ask.convoId, ask.askId, allow)
+    override fun stopSideTurn(pane: SidePane) = repo.sidePanes.stopTurn(pane)
+
+    // The three verdict verbs all ride [PocketRepository.resolveAskDirect]: the ask the COLUMN is showing
+    // decides, and the verdict goes out whether or not the machine-wide inbox still carries a row for it
+    // (it legitimately may not — see that function's doc). The verdict fields mirror the focused path's
+    // [resolveTaskGrant] / [retrySafer] one-for-one, so a decision means the same thing on the wire
+    // wherever it was taken.
+    override fun resolvePaneApproval(ask: PermissionAsk, allow: Boolean, remember: Boolean) =
+        repo.resolveAskDirect(ask, allow, remember = remember)
+
+    override fun resolvePaneTaskGrant(ask: PermissionAsk) =
+        repo.resolveAskDirect(ask, allow = true, grantScope = "task")
+
+    override fun retryPaneSafer(ask: PermissionAsk, constraints: List<String>) =
+        repo.resolveAskDirect(ask, allow = false, retrySafer = true, constraints = constraints)
 
     // ── workflow orchestration (issue #106): delegate to the repository; dock state is ui-local ──
     override val workflowRuns: Map<String, dev.ccpocket.protocol.WorkflowRun> get() = repo.workflowRuns

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
@@ -450,6 +450,15 @@ class RepoDesktopModel(
     override fun retryPaneSafer(ask: PermissionAsk, constraints: List<String>) =
         repo.resolveAskDirect(ask, allow = false, retrySafer = true, constraints = constraints)
 
+    // AskUserQuestion in a column (W3): same wire as the focused card — answers ride an ALLOW, a skip
+    // denies with the note — but addressed by the column's own ask.
+    override fun answerPaneQuestions(ask: PermissionAsk, answers: Map<String, String>?, response: String?) =
+        repo.answerQuestionsDirect(ask, answers, response)
+
+    override fun skipPaneQuestions(ask: PermissionAsk, message: String) = repo.skipQuestionsDirect(ask, message)
+
+    override fun dismissPaneAsk(ask: PermissionAsk) = repo.sidePanes.noteApprovalResolved(ask.convoId, ask.askId)
+
     // ── workflow orchestration (issue #106): delegate to the repository; dock state is ui-local ──
     override val workflowRuns: Map<String, dev.ccpocket.protocol.WorkflowRun> get() = repo.workflowRuns
     override val dockedWorkflowRunId: String? get() = repo.viewedWorkflowRunId.value

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SidePaneModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SidePaneModel.kt
@@ -58,10 +58,26 @@ class SidePaneModel(
     override val observing: Boolean get() = false
     override val selectedSessionId: String get() = pane.sessionId
 
-    /** The approval THIS session raised. Same frame the bell popover shows, so the two never disagree. */
+    /** The approval — or question — THIS session raised. Same frame the bell popover shows for approvals,
+     *  so the two never disagree; for questions this column is the only surface there is. */
     override val ask: PermissionAsk? get() = pane.pendingAsk.value
-    override val askTimedOut: Boolean get() = false
-    override val askQueuePosition: Pair<Int, Int>? get() = null
+
+    /** issue #100 in a column: matched against the card actually on screen, exactly as the focused model
+     *  matches its own id, so a stale timeout can never grey out the NEXT ask. */
+    override val askTimedOut: Boolean
+        get() = pane.timedOutAskId.value?.let { it == pane.pendingAsk.value?.askId } ?: false
+
+    /**
+     * "n / m" for this column's own burst.
+     *
+     * The focused path counts a burst UP (1/3 → 2/3) from counters it keeps across resolutions; a column
+     * keeps no such history, so it reports what it can prove: this card, plus everything still waiting
+     * behind it. Both answer the one question the chip exists for — "is there more after this one" — and
+     * neither can outlive its queue.
+     */
+    override val askQueuePosition: Pair<Int, Int>?
+        get() = pane.askQueue.size.takeIf { it > 0 }?.let { 1 to (1 + it) }
+
     override val askRisk: String? get() = null
 
     override fun send(text: String) {
@@ -78,24 +94,36 @@ class SidePaneModel(
      *  (as the first cut did) demoted 始终允许 to a one-off allow with no sign anything was lost. */
     override fun resolve(allow: Boolean, remember: Boolean) {
         val a = pane.pendingAsk.value ?: return
-        pane.pendingAsk.value = null
         base.resolvePaneApproval(a, allow, remember)
     }
 
     override fun resolveTaskGrant() {
         val a = pane.pendingAsk.value ?: return
-        pane.pendingAsk.value = null
         base.resolvePaneTaskGrant(a)
     }
 
     override fun retrySafer(constraints: List<String>) {
         val a = pane.pendingAsk.value ?: return
-        pane.pendingAsk.value = null
         base.retryPaneSafer(a, constraints)
     }
 
+    /** Answering is a verdict like any other, addressed to THIS column's ask. Delegated, it read the
+     *  repository's own pendingAsk: the column drew its question and answered the focused session's. */
+    override fun answerQuestions(answers: Map<String, String>?, response: String?) {
+        val a = pane.pendingAsk.value ?: return
+        base.answerPaneQuestions(a, answers, response)
+    }
+
+    override fun skipQuestions(message: String) {
+        val a = pane.pendingAsk.value ?: return
+        base.skipPaneQuestions(a, message)
+    }
+
+    /** The timed-out card's Dismiss: nothing goes on the wire (the daemon already auto-denied), the card
+     *  is simply retired and whatever queued behind it comes up. */
     override fun dismissAsk() {
-        pane.pendingAsk.value = null
+        val a = pane.pendingAsk.value ?: return
+        base.dismissPaneAsk(a)
     }
 
     override val paneScoped: Boolean get() = true
@@ -148,10 +176,6 @@ class SidePaneModel(
     // absolute deadline was always the real one), never a lease bought for the wrong ask.
     override fun askHeartbeat() {}
     override fun askHeartbeatRelease() {}
-    /** AskUserQuestion has no pane surface yet: `SidePanes.route` never files a question into a pane, so
-     *  this could only ever have skipped the FOCUSED session's questions. Upgrade it when a column can
-     *  hold a question of its own. */
-    override fun skipQuestions(message: String) {}
     override fun canRewind(item: ChatItem.User): Boolean = false
     override val chatModelId: String get() = ""
     override val chatPermissionMode: String? get() = null
@@ -171,7 +195,6 @@ class SidePaneModel(
     override fun clearConversation() {}
     override fun retryOpen() = base.retrySplitOpen(pane)
     override fun takeOver() {}
-    override fun answerQuestions(answers: Map<String, String>?, response: String?) {}
     override fun workflowRunFor(item: ChatItem.Tool): dev.ccpocket.protocol.WorkflowRun? = null
     override fun openWorkspaceFile(path: String) {}
     override fun tightenAutoRun(item: ChatItem.AutoRun) {}

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SidePaneModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SidePaneModel.kt
@@ -20,7 +20,14 @@ import dev.ccpocket.protocol.PermissionMode
  * opening Changes from a side column must not quietly reach into another session, and silently doing
  * the right thing for the wrong conversation is the one failure a split view must not have. They become
  * available the moment the pane is promoted (a click), which is also when they start meaning this
- * conversation. [PANE_INERT] marks every one of them.
+ * conversation. `PANE_INERT` marks every one of them.
+ *
+ * The hazard of `by base` is that it is SILENT: a member added to [DesktopModel] tomorrow is delegated
+ * without anyone deciding it should be, and the first sign is a click in one column landing in another.
+ * That is what took seven members through review here — stop, the four attachment verbs, and both M2
+ * verdict verbs — so the contract is no longer a comment: `SidePaneModelDelegationGuardTest` enumerates
+ * [DesktopModel]'s methods by reflection and fails until each one is filed under pane-scoped, inert, or
+ * window-level. Add a member, classify it there.
  */
 class SidePaneModel(
     private val base: DesktopModel,
@@ -61,12 +68,30 @@ class SidePaneModel(
         if (base.sendSidePrompt(pane, text)) composerState.clear()
     }
 
-    /** Allow/Deny rides the machine-wide inbox verb, which is keyed by (convoId, askId) — so a decision
-     *  made here is the same decision, taken the same way, as one made from the bell or the phone. */
+    /** ■ / Esc stops THIS column's turn. The bare `stopTurn` it used to inherit cancelled the focused
+     *  conversation, i.e. it reliably interrupted the one turn the user had not asked it to. */
+    override fun stopTurn() = base.stopSideTurn(pane)
+
+    /** Every verdict names the ask THIS column is holding. Deciding by "whatever is pending" — which is
+     *  what delegation did for the two M2 verbs below — showed this pane's card and answered another
+     *  session's question, silently and with the user's own click. [remember] rides along: dropping it
+     *  (as the first cut did) demoted 始终允许 to a one-off allow with no sign anything was lost. */
     override fun resolve(allow: Boolean, remember: Boolean) {
         val a = pane.pendingAsk.value ?: return
         pane.pendingAsk.value = null
-        base.resolvePaneApproval(a, allow)
+        base.resolvePaneApproval(a, allow, remember)
+    }
+
+    override fun resolveTaskGrant() {
+        val a = pane.pendingAsk.value ?: return
+        pane.pendingAsk.value = null
+        base.resolvePaneTaskGrant(a)
+    }
+
+    override fun retrySafer(constraints: List<String>) {
+        val a = pane.pendingAsk.value ?: return
+        pane.pendingAsk.value = null
+        base.retryPaneSafer(a, constraints)
     }
 
     override fun dismissAsk() {
@@ -86,7 +111,52 @@ class SidePaneModel(
     override val sendUndelivered: Boolean get() = false
     override val turnStalled: Boolean get() = false
     override val turnQueued: Boolean get() = false
+    override fun resendStalled() {}
+    // rewind/fork is a focused-pane affordance ([canRewind] false already hides the menu); these are its
+    // BANNERS, which delegation would have filled with the focused conversation's lineage and refusals —
+    // a "branched from …" line over a column that was never branched.
+    override val rewindBlockedByTurn: Boolean get() = false
+    override fun startRewind(item: ChatItem.User, mode: String) {}
+    override val rewindError: String? get() = null
+    override fun dismissRewindError() {}
+    override val sessionLineage: dev.ccpocket.app.data.PocketRepository.SessionLineage? get() = null
+    // Same story for the handoff banner ChatPane renders above the stream: delegated, a column showed the
+    // FOCUSED session's handoff and its Recall/Cancel/Reviewed buttons acted on it. Nulling the handoff
+    // itself is what closes that — the verbs are unreachable from a column once no banner is drawn.
+    override val activeHandoff: dev.ccpocket.protocol.SessionHandoff? get() = null
+    override fun handoffIsRecipient(): Boolean = false
+    // ── attachments: the focused pane's, by construction (see SidePane's KDoc — "attachments … stay on
+    //    the focused pane"). Delegated, the focused session's staged images/files rendered into EVERY
+    //    column's composer, a paste or a drop inside a column hung its file on the focused session's next
+    //    prompt, and an upload running over there disabled this column's send button ([uploadsBusy] gates
+    //    submit). Doing visibly nothing here beats doing the right thing to the wrong conversation; the
+    //    affordance comes back the moment the column is promoted, which is when it starts meaning this
+    //    conversation.
+    override val pendingImages: List<dev.ccpocket.app.data.PendingImage> get() = emptyList()
+    override fun attachImages(raw: List<ByteArray>) {}
+    override fun removePendingImage(id: Long) {}
+    override fun hasReadyImages(): Boolean = false
+    override val pendingFiles: List<dev.ccpocket.app.data.PendingFile> get() = emptyList()
+    override fun attachFiles(files: List<dev.ccpocket.app.media.PickedFile>) {}
+    override fun removePendingFile(id: Long) {}
+    override fun retryPendingFile(id: Long) {}
+    override fun uploadsBusy(): Boolean = false
+    override fun hasLandedFiles(): Boolean = false
+    // The AttentionLease heartbeat is keyed to the repository's OWN pendingAsk, so a column's card would
+    // have extended the focused ask's reading budget instead of its own. Inert until a pane-scoped
+    // heartbeat exists; the cost is only that a pane's card gets no lease extension (the daemon's
+    // absolute deadline was always the real one), never a lease bought for the wrong ask.
+    override fun askHeartbeat() {}
+    override fun askHeartbeatRelease() {}
+    /** AskUserQuestion has no pane surface yet: `SidePanes.route` never files a question into a pane, so
+     *  this could only ever have skipped the FOCUSED session's questions. Upgrade it when a column can
+     *  hold a question of its own. */
+    override fun skipQuestions(message: String) {}
     override fun canRewind(item: ChatItem.User): Boolean = false
+    override val chatModelId: String get() = ""
+    override val chatPermissionMode: String? get() = null
+    override val chatEffort: String? get() = null
+    override val chatServiceTier: String? get() = null
     override val changedFiles: List<dev.ccpocket.protocol.ChangedFile> get() = emptyList()
     override val gitStatus: dev.ccpocket.protocol.GitStatus? get() = null
     override val slashCommands: List<dev.ccpocket.protocol.SlashCommand> get() = emptyList()

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SplitPaneView.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SplitPaneView.kt
@@ -1,22 +1,9 @@
 package dev.ccpocket.app.desktop
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import dev.ccpocket.app.data.SidePane
 import dev.ccpocket.app.resources.Res
 import dev.ccpocket.app.resources.split_pane_close
@@ -47,26 +34,17 @@ fun SplitPane(base: DesktopModel, pane: SidePane, modifier: Modifier = Modifier)
 /**
  * A column whose session ended underneath it (daemon-side close, a crash, a machine that went away).
  * Said plainly, with the only useful verb, rather than leaving a blank chat that reads as "still loading".
+ *
+ * Rendered by the focused chat's own [ChatNotice] rather than a look-alike rebuilt here: the hand-made
+ * copy had drifted from it in exactly the ways a second copy always does — no hover feedback on the one
+ * clickable thing, and a capsule label missing `tightCenter`.
  */
 @Composable
 private fun EndedPane(model: DesktopModel, modifier: Modifier = Modifier) {
-    Column(
-        modifier.fillMaxSize().background(Tok.base).padding(24.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterVertically),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Text(
-            stringResource(Res.string.split_session_ended),
-            color = Tok.tx2, fontFamily = Dk.ui, fontSize = 13.sp, textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        Text(
-            stringResource(Res.string.split_pane_close),
-            color = Tok.tx, fontFamily = Dk.ui, fontSize = 12.sp,
-            modifier = Modifier.clip(RoundedCornerShape(999.dp))
-                .background(Tok.surface)
-                .clickable { model.closeThisPane() }
-                .padding(horizontal = 12.dp, vertical = 6.dp),
-        )
-    }
+    ChatNotice(
+        title = stringResource(Res.string.split_session_ended),
+        modifier = modifier.background(Tok.base), // a column is not opaque on its own
+        actionLabel = stringResource(Res.string.split_pane_close),
+        onAction = { model.closeThisPane() },
+    )
 }

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/data/SplitPanePromotionTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/data/SplitPanePromotionTest.kt
@@ -1,0 +1,92 @@
+package dev.ccpocket.app.data
+
+import dev.ccpocket.app.pairing.PairedDaemon
+import dev.ccpocket.protocol.AgentKind
+import dev.ccpocket.protocol.CloseSession
+import dev.ccpocket.protocol.Frame
+import dev.ccpocket.protocol.OpenSession
+import dev.ccpocket.protocol.PermissionMode
+import dev.ccpocket.protocol.SessionLive
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Issue #311 — one session is EITHER the focused chat or a column, never both at once.
+ *
+ * The failure this pins down is not visible from [SidePanes] alone: clicking the sidebar row of a session
+ * that already has a column ran an ordinary open, whose answering `SessionLive` was then claimed by that
+ * column ([SidePanes.claimsSessionLive] decides before every focused-chat rule). The focused area's open
+ * was therefore never answered, and the click ended on "Opening…" for eight seconds and then on an open
+ * failure whose Retry failed identically, forever. Fixing it at [PocketRepository.openSession] rather than
+ * at the desktop's promote verb is deliberate: openSession is the one chokepoint every way of focusing a
+ * session goes through, so a sidebar click, a promotion, a push tap and a deep link all mean "promote it".
+ */
+class SplitPanePromotionTest {
+    private val sent = mutableListOf<Frame>()
+    private val repo = PocketRepository(CoroutineScope(Dispatchers.Unconfined)).apply {
+        paired.value = PairedDaemon(
+            relay = "wss://test", accountId = "acct-test", daemonPub = "pk", deviceId = "dev", credential = "cred",
+        )
+        sessionsDir.value = "/w/proj"
+        onSendForTest = { sent += it }
+    }
+
+    private fun column(sid: String = "sid-a") =
+        repo.sidePanes.open("/w/proj", sid, "Refactor the parser", AgentKind.CLAUDE, PermissionMode.DEFAULT)!!
+
+    @Test
+    fun focusingASessionThatIsInAColumnPromotesItInsteadOfStrandingTheOpen() {
+        val pane = column()
+        repo.receiveForTest(SessionLive("convo-a", "/w/proj", "sid-a", executing = false))
+        assertEquals("convo-a", pane.convoId.value)
+        sent.clear()
+
+        assertTrue(repo.openSession("/w/proj", resumeId = "sid-a"))
+        assertTrue(repo.sidePanes.panes.isEmpty(), "the column lets go BEFORE the open goes on the wire")
+        assertEquals("sid-a", sent.filterIsInstance<OpenSession>().single().resumeId)
+        // detached, not closed: a CloseSession here would race the open that is promoting this very session
+        assertTrue(sent.none { it is CloseSession })
+
+        assertFalse(repo.sidePanes.claimsSessionLive(SessionLive("convo-a", "/w/proj", "sid-a")))
+        repo.receiveForTest(SessionLive("convo-a", "/w/proj", "sid-a", executing = false))
+        assertEquals("convo-a", repo.convoId.value, "the answer reaches the focused chat")
+        assertFalse(repo.opening.value)
+    }
+
+    @Test
+    fun focusingAColumnWhoseOpenIsStillInFlightAlsoPromotesIt() {
+        // Same gesture, one beat earlier: the column has no convoId yet, so the claim runs off sessionId.
+        val pane = column()
+        assertNull(pane.convoId.value)
+        sent.clear()
+
+        assertTrue(repo.openSession("/w/proj", resumeId = "sid-a"))
+        assertTrue(repo.sidePanes.panes.isEmpty())
+        repo.receiveForTest(SessionLive("convo-a", "/w/proj", "sid-a", executing = false))
+        assertEquals("convo-a", repo.convoId.value)
+    }
+
+    @Test
+    fun aSecondClickOnThePromotedRowIsStillTheNoOpItAlwaysWas() {
+        // The release rides AFTER openSession's two synchronous refusals, so a repeated gesture stays
+        // idempotent: one open on the wire, and no second teardown of anything.
+        column()
+        repo.receiveForTest(SessionLive("convo-a", "/w/proj", "sid-a", executing = false))
+        sent.clear()
+
+        assertTrue(repo.openSession("/w/proj", resumeId = "sid-a"))
+        assertFalse(repo.openSession("/w/proj", resumeId = "sid-a"), "the same target is already in flight")
+        assertEquals(1, sent.filterIsInstance<OpenSession>().size)
+
+        // an unrelated column is never disturbed by a promotion of a different session
+        val other = repo.sidePanes.open("/w/proj", "sid-b", "B", AgentKind.CLAUDE, PermissionMode.DEFAULT)!!
+        repo.receiveForTest(SessionLive("convo-b", "/w/proj", "sid-b", executing = false))
+        assertEquals(listOf(other), repo.sidePanes.panes.toList())
+        assertEquals("convo-b", other.convoId.value)
+    }
+}

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/SidePaneModelDelegationGuardTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/SidePaneModelDelegationGuardTest.kt
@@ -1,0 +1,229 @@
+package dev.ccpocket.app.desktop
+
+import java.lang.reflect.Method
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Issue #311 — every [DesktopModel] member is explicitly filed as pane-scoped, inert, or window-level.
+ *
+ * [SidePaneModel] is a `DesktopModel by base` delegate, and the hazard of that keyword is that it is
+ * SILENT: a member added to the interface tomorrow is forwarded to the FOCUSED conversation without
+ * anyone deciding it should be, and the first sign is a click in one column acting on another session.
+ * That is not hypothetical — it is how seven members shipped in the first cut (the stop button, all four
+ * attachment verbs, and both approval-design-M2 verdict verbs), each of them a control that renders in a
+ * column, reads that column's state, and then acted one column over.
+ *
+ * A comment on the class could not have caught it, so this does. The three sets below ARE the contract;
+ * the test only checks that they cover [DesktopModel] exactly and do not overlap. Adding a member without
+ * classifying it fails here, which is the point: the classification is the review.
+ *
+ * Where the line falls:
+ *  - [PANE_SCOPED] — answered from [dev.ccpocket.app.data.SidePane]: this column's own conversation.
+ *  - [PANE_INERT] — overridden to a neutral value / no-op ON PURPOSE, because delegating would describe
+ *    or act on the focused conversation. Visibly nothing beats invisibly right-for-the-wrong-session.
+ *  - [WINDOW_DELEGATED] — describes the WINDOW, the machine or the app (connection, sidebar, fleet,
+ *    settings, overlays), so `by base` is not a leak but the only correct answer.
+ *
+ * [PANE_SCOPED] + [PANE_INERT] is, by construction, exactly [SidePaneModel]'s list of `override`s —
+ * a one-line check when reviewing a change here, and the reason the sets cannot quietly drift from the
+ * class. What the test itself cannot verify is which of the two a member belongs in: `by` synthesises a
+ * forwarder for every member, so the delegate's bytecode looks identical either way (see [members]).
+ *
+ * The practical litmus for the third set: a [SidePaneModel] is handed to exactly one composable tree
+ * ([SplitPane] → [ChatPane]). Anything ChatPane itself reads or calls therefore has to be pane-scoped or
+ * inert. The rest — the Changes/Git/workflow/rewind overlays, the sidebar, Settings — is raised from
+ * window chrome holding the BASE model, and `paneScoped` strips those controls out of a column's header,
+ * so delegation there can never be reached with a pane. Wire a new verb into ChatPane and this set is
+ * where you must NOT put it.
+ */
+class SidePaneModelDelegationGuardTest {
+
+    /** This column's own conversation: read off [dev.ccpocket.app.data.SidePane], or acted on through a
+     *  pane-taking verb on the base model (`sendSidePrompt` / `stopSideTurn` / `resolvePane…`). */
+    private val PANE_SCOPED = setOf(
+        "hasChat", "opening", "openFailed", "retryOpen",
+        "chatTitle", "chatAgent", "chatWorkdir",
+        "messages", "streaming", "selectedSessionId",
+        "composerState", "composer", "send", "stopTurn",
+        "ask", "resolve", "resolveTaskGrant", "retrySafer", "dismissAsk",
+        "paneScoped", "focusThisPane", "closeThisPane",
+    )
+
+    /** Deliberately inert. Each one is a control ChatPane renders (or a value it renders FROM) whose
+     *  delegated answer would have come from — or landed on — the focused conversation instead. */
+    private val PANE_INERT = setOf(
+        // conversation identity a column does not track (it is the focused pane that owns model/mode
+        // switching, so a column claiming a model would be claiming someone else's)
+        "chatBranch", "chatModel", "chatModelId", "chatMode",
+        "chatPermissionMode", "chatEffort", "chatServiceTier",
+        "sessionDegraded", "contextUsed", "contextWindow", "observing", "takeOver",
+        // transcript paging + delivery watchdogs: a column has neither, and the focused pane's answers
+        // would put another session's loader/warning/resend cue over this stream
+        "historyHasMore", "historyLoadingOlder", "historyPrependGen", "lastHistoryPrependCount",
+        "loadOlderHistory", "sendUndelivered", "turnStalled", "turnQueued", "resendStalled",
+        // rewind/fork: the menu is already hidden by canRewind=false; these are its BANNERS
+        "canRewind", "rewindBlockedByTurn", "startRewind", "rewindError", "dismissRewindError",
+        "sessionLineage",
+        // the handoff banner ChatPane draws above the stream, with verbs that acted on the focused session
+        "activeHandoff", "handoffIsRecipient",
+        // header/composer surfaces that belong to the focused conversation
+        "changedFiles", "gitStatus", "slashCommands", "pathListing", "browsePath",
+        "switchMode", "switchModel", "switchEffort", "switchServiceTier",
+        "compactConversation", "clearConversation",
+        "workflowRunFor", "openWorkspaceFile", "tightenAutoRun",
+        "showQuickActions", "showChanges", "showGit", "showModelPopover",
+        // attachments are the focused pane's by construction (SidePane's KDoc); uploadsBusy() even gated
+        // this column's send button on the OTHER session's uploads
+        "pendingImages", "attachImages", "removePendingImage", "hasReadyImages",
+        "pendingFiles", "attachFiles", "removePendingFile", "retryPendingFile",
+        "uploadsBusy", "hasLandedFiles",
+        // the approval card: the ask is this column's, but these three reach the repository's own
+        // pendingAsk, i.e. the focused one. Answers/lease upgrade when a column can hold a question (W3).
+        "askTimedOut", "askQueuePosition", "askRisk",
+        "askHeartbeat", "askHeartbeatRelease",
+        "answerQuestions", "skipQuestions",
+    )
+
+    /** The window, the machine, the app. None of these is reachable holding a [SidePaneModel] — see the
+     *  class doc's litmus — and every one of them means the same thing in a column as anywhere else. */
+    private val WINDOW_DELEGATED = setOf(
+        // connection + computer switcher
+        "connected", "connGen", "activeComputer", "computers", "selectComputer", "addComputer",
+        "renameComputer", "removeComputer", "activeIsThisMachine",
+        // window-level overlay flags
+        "switcherOpen", "showNewSession", "showTray", "palette", "showSettings", "showAddComputer",
+        "showPermissionModal", "showAttention", "showWorktrees", "showSkills", "showHandoff",
+        "showReviewCenter", "showFolderPicker", "showQuotaPopover",
+        "anyOverlayOpen", "dismissOverlays",
+        // session handoff + collaborator links (raised from window chrome; the pane's banner is inert)
+        "handoffInvite", "handoffCreating", "handoffError", "handoffIsInitiator", "handoffCreate",
+        "handoffCancel", "handoffRecall", "handoffComplete", "handoffReturn", "dismissHandoffInvite",
+        "collaborators", "collaboratorTicket", "lastCollaboratorConnected", "collaboratorError",
+        "listCollaborators", "createCollaboratorTicket", "removeCollaborator",
+        // Review Center + usage dashboard (the live repository, handed over whole)
+        "reviewRepo", "usageRepo", "reviewPending", "openReviewCenter", "refreshReviews",
+        // sidebar: pins, projects, sessions, groups, archive, rename, RECENT
+        "pins", "pin", "unpin", "movePin", "openPin", "jumpPin", "isPinned", "pinsFull",
+        "projectPins", "pinProject", "unpinProject", "isProjectPinned", "projectListReveal",
+        "openProjectPin", "browseProjects",
+        "projects", "sessions", "openProject", "selectSession", "hideSession",
+        "sessionGroups", "clearRecent", "sessionsRefreshing", "refresh", "liveSession",
+        "customGroups", "canEditGroups", "createGroup", "renameGroup", "deleteGroup", "assignGroup",
+        "groupCollapsed",
+        "archivedSessions", "canArchiveSessions", "archiveSession", "unarchiveSession",
+        "refreshArchived", "browseArchived",
+        "canRenameSessions", "renameSession", "renameError", "dismissRenameError",
+        // the rewind CONFIRMATION lives in window chrome (the sheet), unlike the banners above
+        "rewindSheet", "confirmRewind", "cancelRewind",
+        // new-session flows (they create a session; they do not act on one)
+        "newSessionDir", "newSessionSeed", "openNewSession", "newSession", "openFolderPath",
+        "newSessionPrompt", "startingSession", "newSessionPromptError", "startSessionWithPrompt",
+        "dismissNewSessionPromptError",
+        // remote directory browser (issues #218/#214)
+        "browseListing", "browseRoots", "browseDirectories", "requestBrowse",
+        // fleet
+        "machines", "attention", "watch", "resolveAttention", "jumpMachine",
+        "running", "runningVisible", "openRunning", "browseRunning",
+        // split-pane plumbing itself: these take the pane as an argument, so they are already explicit
+        "sidePanes", "canSplit", "openInSplit", "closeSplit", "promoteSplit", "retrySplitOpen",
+        "sendSidePrompt", "stopSideTurn", "resolvePaneApproval", "resolvePaneTaskGrant", "retryPaneSafer",
+        // workflow orchestration panel (docked at window level)
+        "workflowRuns", "dockedWorkflowRunId", "openWorkflowPanel", "closeWorkflowPanel",
+        "workflowAgentDetails", "fetchWorkflowAgentDetail",
+        // capability tables — machine/daemon facts, not conversation state
+        "effortOptions", "serviceTierOptions", "effortOptionsFor", "serviceTierOptionsFor",
+        "permissionModeAvailable", "modelsForAgent", "fetchModels", "pathSep",
+        "gatewayBaseUrl", "gatewayModels", "availableAgents",
+        // Changes browser / Git panel / worktrees: overlays, raised from the focused header only
+        "changedFilesLoading", "changedFilesStale", "fetchChangedFiles", "selectedChangedPath",
+        "selectedDiff", "selectedContent", "selectedContentProgress", "selectChangedFile", "openChanges",
+        "gitStatusLoading", "gitStatusStale", "gitDiff", "gitDiffPath", "gitDiffStaged", "gitBusyOp",
+        "gitError", "gitPendingConfirm", "fetchGitStatus", "openGitDiff", "gitAct", "confirmPendingGit",
+        "dismissGitConfirm", "dismissGitError", "openGit",
+        "worktrees", "worktreesLoading", "worktreesStale", "fetchWorktrees", "addWorktree",
+        "worktreeCreated", "dismissWorktreeCreated", "openWorktreeSession", "removeWorktree",
+        "openWorktrees",
+        // machine catalogs
+        "skillCatalog", "skillCatalogLoading", "skillCatalogStale", "fetchSkillCatalog", "openSkills",
+        "bridges", "bridgesLoaded", "bridgesStale", "bridgeBusy", "bridgeError", "bridgeMergeLost",
+        "bridgeCredential", "fetchBridges", "createBridge", "revokeBridge", "controlBridgeRunner",
+        "configureBridgeRunner", "clearBridgeCredential",
+        // app + self-update
+        "appVersion", "relayUrl", "updateState", "daemonVersion", "daemonUpdateCommand",
+        "checkForUpdates", "applyUpdate", "updateCommand", "updateReleasesUrl",
+        // settings / preferences
+        "defaultAgent", "defaultMode", "defaultPermissionMode", "defaultEffort", "defaultServiceTier",
+        "defaultModelFor", "contextWindowOverride", "terminalApp", "terminalDefaultEmbedded",
+        "terminalPanel", "menuBarEnabled", "themeMode", "accentTheme", "chatAlignment",
+        "phonePush", "refreshPushPrefs",
+        "approvalNoAutoDeny", "refreshApprovalPrefs", "approvalFullControlExpiryMs",
+        "fullControlExpiryMs",
+        // folder-share + schedules
+        "shares", "sharesLoaded", "lastShareInvite", "refreshShares", "createShare", "revokeShare",
+        "clearLastShare", "redeemShareInvite",
+        "schedules", "schedulesLoaded", "schedulesStale", "refreshSchedules", "cancelSchedule",
+        // account + API presets
+        "authState", "refreshAuth", "switchAccount", "stopAuthBlocker", "submitAuthCode",
+        "cancelAuthLogin", "logoutAccount",
+        "presetsState", "presetsRev", "refreshPresets", "savePreset", "deletePreset", "activatePreset",
+        "stopPresetBlocker", "stopPresetDeleteBlocker",
+    )
+
+    @Test
+    fun everyDesktopModelMemberIsClassified() {
+        val classified = PANE_SCOPED + PANE_INERT + WINDOW_DELEGATED
+        val unclassified = (members() - classified).sorted()
+        assertTrue(
+            unclassified.isEmpty(),
+            "New DesktopModel member(s) with no split-pane decision: $unclassified\n" +
+                "A `by base` delegate forwards them to the FOCUSED conversation silently. Decide what " +
+                "each one means inside a split column, override it in SidePaneModel if that answer is " +
+                "not `base`, and add it to PANE_SCOPED / PANE_INERT / WINDOW_DELEGATED here.",
+        )
+    }
+
+    @Test
+    fun theThreeSetsDoNotOverlapAndDescribeNothingThatIsGone() {
+        assertTrue(
+            (PANE_SCOPED intersect PANE_INERT).isEmpty() &&
+                (PANE_SCOPED intersect WINDOW_DELEGATED).isEmpty() &&
+                (PANE_INERT intersect WINDOW_DELEGATED).isEmpty(),
+            "a member is filed twice: " + listOf(
+                PANE_SCOPED intersect PANE_INERT,
+                PANE_SCOPED intersect WINDOW_DELEGATED,
+                PANE_INERT intersect WINDOW_DELEGATED,
+            ).flatten().sorted(),
+        )
+        // A renamed or deleted member must not leave its old classification behind as reassuring dead
+        // text — the sets are only a contract while they still name the interface.
+        val stale = ((PANE_SCOPED + PANE_INERT + WINDOW_DELEGATED) - members()).sorted()
+        assertTrue(stale.isEmpty(), "classified name(s) that DesktopModel no longer has: $stale")
+    }
+
+    /**
+     * Every public method of the interface, property accessors included, as Kotlin member names.
+     *
+     * Reflection is over [DesktopModel], never over [SidePaneModel]: `by` synthesises a forwarder for
+     * EVERY member, so the delegate's own bytecode cannot tell an explicit override from an implicit
+     * hand-off. The sets above are the contract precisely because the compiler has no way to be.
+     */
+    private fun members(): Set<String> =
+        DesktopModel::class.java.methods
+            .filterNot { it.isSynthetic || '$' in it.name }
+            .map(::memberName)
+            .toSet() - setOf("equals", "hashCode", "toString")
+
+    /** `getFoo`/`setFoo` → `foo`, so the sets read as the Kotlin source does. A `setX(…)` FUNCTION folds
+     *  into the `x` property's entry, which is the right granularity: both are the same member family
+     *  and must get the same answer. `isFoo` is left alone — Kotlin only emits it for a property already
+     *  spelled that way, and this interface's `is…` names are plain functions. */
+    private fun memberName(m: Method): String {
+        val n = m.name
+        val head = when {
+            n.length > 3 && n[3].isUpperCase() && (n.startsWith("get") || n.startsWith("set")) -> n.substring(3)
+            else -> return n
+        }
+        return head.replaceFirstChar { it.lowercase() }
+    }
+}

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/SidePaneModelDelegationGuardTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/SidePaneModelDelegationGuardTest.kt
@@ -47,6 +47,11 @@ class SidePaneModelDelegationGuardTest {
         "messages", "streaming", "selectedSessionId",
         "composerState", "composer", "send", "stopTurn",
         "ask", "resolve", "resolveTaskGrant", "retrySafer", "dismissAsk",
+        // W3: the column's ask has a full life cycle of its own — its queue position, its issue-#100
+        // terminal timeout state, and (for an AskUserQuestion, which the bell inbox deliberately never
+        // carries) the answer/skip verbs. Inert, a column drew its own question and answered the FOCUSED
+        // session's, or drew the focused burst's "2 / 3" over a single card of its own.
+        "askTimedOut", "askQueuePosition", "answerQuestions", "skipQuestions",
         "paneScoped", "focusThisPane", "closeThisPane",
     )
 
@@ -79,10 +84,9 @@ class SidePaneModelDelegationGuardTest {
         "pendingFiles", "attachFiles", "removePendingFile", "retryPendingFile",
         "uploadsBusy", "hasLandedFiles",
         // the approval card: the ask is this column's, but these three reach the repository's own
-        // pendingAsk, i.e. the focused one. Answers/lease upgrade when a column can hold a question (W3).
-        "askTimedOut", "askQueuePosition", "askRisk",
-        "askHeartbeat", "askHeartbeatRelease",
-        "answerQuestions", "skipQuestions",
+        // pendingAsk, i.e. the FOCUSED one — an advisory risk badge read off another session's assessment,
+        // and a lease heartbeat that bought reading time for another session's ask.
+        "askRisk", "askHeartbeat", "askHeartbeatRelease",
     )
 
     /** The window, the machine, the app. None of these is reachable holding a [SidePaneModel] — see the
@@ -128,6 +132,7 @@ class SidePaneModelDelegationGuardTest {
         // split-pane plumbing itself: these take the pane as an argument, so they are already explicit
         "sidePanes", "canSplit", "openInSplit", "closeSplit", "promoteSplit", "retrySplitOpen",
         "sendSidePrompt", "stopSideTurn", "resolvePaneApproval", "resolvePaneTaskGrant", "retryPaneSafer",
+        "answerPaneQuestions", "skipPaneQuestions", "dismissPaneAsk",
         // workflow orchestration panel (docked at window level)
         "workflowRuns", "dockedWorkflowRunId", "openWorkflowPanel", "closeWorkflowPanel",
         "workflowAgentDetails", "fetchWorkflowAgentDetail",

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/SidePaneVerbScopeTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/SidePaneVerbScopeTest.kt
@@ -1,0 +1,173 @@
+package dev.ccpocket.app.desktop
+
+import dev.ccpocket.app.data.PocketRepository
+import dev.ccpocket.app.data.SidePane
+import dev.ccpocket.app.pairing.PairedDaemon
+import dev.ccpocket.protocol.AgentKind
+import dev.ccpocket.protocol.CancelTurn
+import dev.ccpocket.protocol.Decision
+import dev.ccpocket.protocol.Frame
+import dev.ccpocket.protocol.PendingApprovals
+import dev.ccpocket.protocol.PermissionAsk
+import dev.ccpocket.protocol.PermissionMode
+import dev.ccpocket.protocol.PermissionVerdict
+import dev.ccpocket.protocol.SessionLive
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Issue #311 — a split column's controls act on the COLUMN's conversation, on the wire.
+ *
+ * [SidePaneModel] is a `DesktopModel by base` delegate, so anything it does not override reaches the
+ * FOCUSED conversation. The card renders the column's ask, the ■ renders the column's streaming state —
+ * and then the click landed one column over, which is the single worst way for a split view to fail: it
+ * looks like it worked. Every case below therefore asserts on the frames, with the focused session
+ * deliberately live and blocked at the same time, so a regression to plain delegation cannot pass.
+ *
+ * Drive is [PocketRepository.onSendForTest] / [PocketRepository.receiveForTest], as in
+ * [dev.ccpocket.app.data.SplitPanePromotionTest]: outbound frames are collected, inbound ones are fed
+ * straight to `handle`, and Unconfined makes both synchronous.
+ */
+class SidePaneVerbScopeTest {
+
+    private val sent = mutableListOf<Frame>()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    private val repo = PocketRepository(scope).apply {
+        paired.value = PairedDaemon(
+            relay = "wss://test", accountId = "acct-test", daemonPub = "pk", deviceId = "dev", credential = "cred",
+        )
+        sessionsDir.value = "/w/proj"
+        onSendForTest = { sent += it }
+    }
+
+    // Production order: the model exists before any session opens, so its init collectors' first pass
+    // sees a null sessionKey (see RepoDesktopModelStopTurnTest's note).
+    private val model = RepoDesktopModel(repo, scope, store = FakeDesktopStore())
+
+    /** The focused conversation: live, running a turn, and blocked on its own approval. Everything a
+     *  leaked verb would land on is real here — that is what makes the assertions mean something. */
+    private fun focusedSession(): PermissionAsk {
+        repo.openSession("/w/proj", resumeId = "sid-focused")
+        repo.receiveForTest(SessionLive("convo-focused", "/w/proj", "sid-focused", executing = true))
+        repo.streaming.value = true
+        val ask = ask("convo-focused", "ask-focused", "Bash")
+        repo.receiveForTest(ask)
+        return ask
+    }
+
+    private fun column(streaming: Boolean = false): SidePane {
+        val pane = repo.sidePanes.open("/w/proj", "sid-pane", "Column", AgentKind.CLAUDE, PermissionMode.DEFAULT)!!
+        repo.receiveForTest(SessionLive("convo-pane", "/w/proj", "sid-pane", executing = streaming))
+        return pane
+    }
+
+    private fun ask(convoId: String, askId: String, tool: String) =
+        PermissionAsk(convoId = convoId, askId = askId, tool = tool, inputPreview = "…", rule = tool)
+
+    private fun verdicts() = sent.filterIsInstance<PermissionVerdict>()
+
+    @Test
+    fun stopInAColumnCancelsThatColumnsTurnAndLeavesTheFocusedOneRunning() {
+        focusedSession()
+        val pane = column(streaming = true)
+        sent.clear()
+
+        SidePaneModel(model, pane).stopTurn()
+
+        assertEquals(
+            listOf(CancelTurn("convo-pane")), sent.filterIsInstance<CancelTurn>(),
+            "the column's ■ must interrupt its OWN conversation — delegation cancelled convo-focused",
+        )
+        assertTrue(repo.streaming.value, "the focused turn is untouched")
+    }
+
+    @Test
+    fun stopInAnIdleColumnSendsNothing() {
+        focusedSession()
+        val pane = column(streaming = false)
+        sent.clear()
+
+        SidePaneModel(model, pane).stopTurn()
+
+        assertTrue(sent.isEmpty(), "no turn to interrupt here, and certainly not the focused one")
+    }
+
+    @Test
+    fun alwaysAllowInAColumnKeepsItsRemember() {
+        focusedSession()
+        val pane = column()
+        repo.receiveForTest(ask("convo-pane", "ask-pane", "Edit"))
+        sent.clear()
+
+        SidePaneModel(model, pane).resolve(allow = true, remember = true)
+
+        val v = verdicts().single()
+        assertEquals("convo-pane", v.convoId)
+        assertEquals("ask-pane", v.askId)
+        assertEquals(Decision.ALLOW, v.decision)
+        // the first cut dropped the flag on the floor: 始终允许 became a silent allow-once, and the very
+        // next matching action asked again with nothing to explain why
+        assertTrue(v.remember, "『始终允许』must reach the daemon as remember=true")
+        assertNull(pane.pendingAsk.value)
+    }
+
+    @Test
+    fun aColumnsVerdictGoesOutEvenWhenTheInboxHasNoRowForIt() {
+        focusedSession()
+        val pane = column()
+        repo.receiveForTest(ask("convo-pane", "ask-pane", "Edit"))
+        // A `PendingApprovals` reply clears and refills the inbox wholesale (a reconnect, or a snapshot
+        // that raced this ask). The card is still on screen; the row backing it is not. The old
+        // row-keyed path returned here and destroyed the card with NO verdict on the wire — the CLI then
+        // waited out its whole timeout on a decision the user had already made.
+        repo.receiveForTest(PendingApprovals(emptyList()))
+        sent.clear()
+
+        SidePaneModel(model, pane).resolve(allow = false, remember = false)
+
+        val v = verdicts().single()
+        assertEquals("convo-pane", v.convoId)
+        assertEquals("ask-pane", v.askId)
+        assertEquals(Decision.DENY, v.decision)
+    }
+
+    @Test
+    fun taskGrantInAColumnDecidesThatColumnsAskNotTheFocusedOne() {
+        val focused = focusedSession()
+        val pane = column()
+        repo.receiveForTest(ask("convo-pane", "ask-pane", "Edit"))
+        sent.clear()
+
+        SidePaneModel(model, pane).resolveTaskGrant()
+
+        val v = verdicts().single()
+        assertEquals("convo-pane", v.convoId, "『允许本任务』granted the FOCUSED session's tool before this")
+        assertEquals("ask-pane", v.askId)
+        assertEquals(Decision.ALLOW, v.decision)
+        assertEquals("task", v.grantScope)
+        assertEquals(focused, repo.pendingAsk.value, "the focused card is still waiting for its own answer")
+    }
+
+    @Test
+    fun retrySaferInAColumnDeniesThatColumnsAskUnderItsConstraints() {
+        val focused = focusedSession()
+        val pane = column()
+        repo.receiveForTest(ask("convo-pane", "ask-pane", "Bash"))
+        sent.clear()
+
+        SidePaneModel(model, pane).retrySafer(listOf("no network"))
+
+        val v = verdicts().single()
+        assertEquals("convo-pane", v.convoId)
+        assertEquals("ask-pane", v.askId)
+        assertEquals(Decision.DENY, v.decision)
+        assertTrue(v.retrySafer)
+        assertEquals(listOf("no network"), v.constraints)
+        assertEquals(focused, repo.pendingAsk.value)
+    }
+}

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/SidePaneVerbScopeTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/SidePaneVerbScopeTest.kt
@@ -4,6 +4,10 @@ import dev.ccpocket.app.data.PocketRepository
 import dev.ccpocket.app.data.SidePane
 import dev.ccpocket.app.pairing.PairedDaemon
 import dev.ccpocket.protocol.AgentKind
+import dev.ccpocket.protocol.AskOption
+import dev.ccpocket.protocol.AskQuestion
+import dev.ccpocket.protocol.AskWithdrawn
+import dev.ccpocket.protocol.AskWithdrawnReason
 import dev.ccpocket.protocol.CancelTurn
 import dev.ccpocket.protocol.Decision
 import dev.ccpocket.protocol.Frame
@@ -17,6 +21,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -68,6 +73,14 @@ class SidePaneVerbScopeTest {
 
     private fun ask(convoId: String, askId: String, tool: String) =
         PermissionAsk(convoId = convoId, askId = askId, tool = tool, inputPreview = "…", rule = tool)
+
+    /** An AskUserQuestion for [convoId]: same frame, `questions` non-null. */
+    private fun question(convoId: String, askId: String) = PermissionAsk(
+        convoId = convoId, askId = askId, tool = "AskUserQuestion", inputPreview = "…",
+        questions = listOf(
+            AskQuestion("Which parser?", options = listOf(AskOption("recursive descent"), AskOption("PEG"))),
+        ),
+    )
 
     private fun verdicts() = sent.filterIsInstance<PermissionVerdict>()
 
@@ -169,5 +182,87 @@ class SidePaneVerbScopeTest {
         assertTrue(v.retrySafer)
         assertEquals(listOf("no network"), v.constraints)
         assertEquals(focused, repo.pendingAsk.value)
+    }
+
+    // ── AskUserQuestion in a column (W3) ─────────────────────────────────────────────────────────────
+
+    /**
+     * The answer must be shaped EXACTLY like the focused path's, because that shape is a wire contract:
+     * the daemon merges `answers` into claude's `updatedInput.answers`, keyed by the verbatim question
+     * text, and a bare ALLOW without it reads to the CLI as "the user did not answer" (#57). So this
+     * answers a column's question and the focused session's question with the same picks, and compares
+     * the two verdicts field by field — only the address may differ.
+     */
+    @Test
+    fun answeringInAColumnSendsTheFocusedPathsVerdictAddressedToTheColumnsAsk() {
+        repo.openSession("/w/proj", resumeId = "sid-focused")
+        repo.receiveForTest(SessionLive("convo-focused", "/w/proj", "sid-focused", executing = true))
+        repo.receiveForTest(question("convo-focused", "q-focused"))
+        val pane = column()
+        repo.receiveForTest(question("convo-pane", "q-pane"))
+        val picks = mapOf("Which parser?" to "recursive descent")
+        sent.clear()
+
+        SidePaneModel(model, pane).answerQuestions(picks, null)
+        model.answerQuestions(picks, null) // the focused card, same picks — the reference shape
+
+        val (column, focused) = verdicts().let { it[0] to it[1] }
+        assertEquals("convo-pane", column.convoId, "the column answered the FOCUSED question before this")
+        assertEquals("q-pane", column.askId)
+        assertEquals(picks, column.answers, "the answers map IS the contract — a bare ALLOW means 'unanswered'")
+        assertEquals(
+            focused.copy(convoId = column.convoId, askId = column.askId), column,
+            "a column's answer must be the focused path's verdict, addressed differently — nothing else",
+        )
+        assertNull(pane.pendingAsk.value, "the answered card is retired")
+        // the answer reads back where it was given: the agent quotes nothing back, so without the note the
+        // column shows a question and then, apparently, nothing
+        assertEquals(
+            listOf(listOf("Which parser?" to "recursive descent")),
+            pane.messages.filterIsInstance<dev.ccpocket.app.data.ChatItem.QuestionsAnswered>().map { it.items },
+        )
+    }
+
+    @Test
+    fun skippingInAColumnDeniesThatColumnsQuestionWithTheNote() {
+        val focused = focusedSession()
+        val pane = column()
+        repo.receiveForTest(question("convo-pane", "q-pane"))
+        sent.clear()
+
+        SidePaneModel(model, pane).skipQuestions("User skipped the questions")
+
+        val v = verdicts().single()
+        assertEquals("convo-pane", v.convoId)
+        assertEquals("q-pane", v.askId)
+        assertEquals(Decision.DENY, v.decision)
+        // the note is why the skip is a DENY and not a dropped card: claude learns the user opted out
+        // instead of waiting out the whole timeout (#57)
+        assertEquals("User skipped the questions", v.message)
+        assertEquals(focused, repo.pendingAsk.value)
+    }
+
+    /** The queue and the issue-#100 terminal state are read off the COLUMN, not the repository — the
+     *  delegated answers described the focused conversation's burst and the focused ask's timeout. */
+    @Test
+    fun theColumnsCardReportsItsOwnQueueAndItsOwnTimeout() {
+        focusedSession()
+        val pane = column()
+        val m = SidePaneModel(model, pane)
+        repo.receiveForTest(ask("convo-pane", "ask-1", "Edit"))
+        assertNull(m.askQueuePosition, "one card, no chip — exactly the old single-ask card")
+
+        repo.receiveForTest(ask("convo-pane", "ask-2", "Write"))
+        assertEquals(1 to 2, m.askQueuePosition)
+        assertFalse(m.askTimedOut)
+
+        repo.receiveForTest(AskWithdrawn("convo-pane", "ask-1", AskWithdrawnReason.TIMED_OUT))
+        assertTrue(m.askTimedOut, "the card flips to its terminal state instead of vanishing")
+        sent.clear()
+
+        m.dismissAsk()
+        assertTrue(sent.isEmpty(), "the daemon already auto-denied — a verdict now decides nothing")
+        assertEquals("ask-2", m.ask?.askId, "and the queued card comes up")
+        assertFalse(m.askTimedOut, "a stale timeout cannot grey out the next ask")
     }
 }

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/SplitPaneUiTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/SplitPaneUiTest.kt
@@ -11,6 +11,7 @@ import dev.ccpocket.app.data.ChatItem
 import dev.ccpocket.app.data.SidePane
 import dev.ccpocket.app.present
 import dev.ccpocket.app.resources.Res
+import dev.ccpocket.app.resources.split_pane_close
 import dev.ccpocket.app.resources.split_pane_focus
 import dev.ccpocket.app.resources.split_session_ended
 import dev.ccpocket.app.str
@@ -109,5 +110,19 @@ class SplitPaneUiTest {
         waitForIdle()
         assertPresent(str(Res.string.split_session_ended))
         assertTrue(!present("CI is green")) // the dead stream is not left on screen looking live
+    }
+
+    /** The ended column's one verb has to WORK — it is now drawn by the focused chat's shared notice
+     *  ([ChatNotice]) rather than a look-alike built in the split view, so this pins the wiring that the
+     *  reuse could have quietly dropped. (Its `tightCenter` alignment is a visual claim no unit test can
+     *  make; that stays a device check.) */
+    @Test
+    fun theEndedColumnsCloseActuallyClosesThatColumn() = runComposeUiTest {
+        val p = pane(1, "Tidy CI workflow", "CI is green").apply { gone.value = true }
+        val model = SplitSeed(listOf(p))
+        setContent { PocketTheme { DesktopApp(model) } }
+        waitForIdle()
+        onAllNodes(hasText(str(Res.string.split_pane_close))).onFirst().performClick()
+        assertEquals(1L, model.closed)
     }
 }


### PR DESCRIPTION
## 背景

PR #327 落地了 #311 的桌面分屏主线。合并后的深度审查（8 个查找角度＋对抗验证轮）确认了一批「pane 与焦点路径平权」缺口，本 PR 按四个工作包逐一修复。审查中唯一后置的回合机 watchdog 已单独录为 #329。

Closes #311

## 四个 commit 对应四个工作包

**W1　会话认领与生命周期（dfac0af1）**
- 不变量确立：一个会话绝不同时出现在焦点区与分屏列。`openSession` 咽喉点先把同会话的列摘除（`releaseToFocus`），任何入口（侧栏点击／pin／推送／deep-link）聚焦已分屏会话都统一为「提升」语义——修掉「点击侧栏行 → SessionLive 被列抢走 → 主区永卡 Opening／open failed」。
- `reopenAll` 重置列回 opening 态再重开：daemon 重启后新 convoId 可正常重绑（原先列会永久冻结、主区为空时还会被 catch-all 劫持），顺带消掉「opening 与 openFailed 同真」矛盾态。
- 在途 open 被关闭的孤儿回收：`disowned` 记账，迟到的 SessionLive 回以 CloseSession，不再不请自来地开进空主区。
- `demoteToSatellite` 补 `sidePanes.clear()`：fleet 热切换不再把列的会话漏在卫星链路上被幽灵重开。

**W2　委托穿透封堵（aa9b81d1）**
- `SidePaneModel` 补齐定界：`stopTurn` 按列的 convoId 发 CancelTurn（原先 ■ 按钮打断的是焦点会话）；附件全家桶、rewind／handoff 横幅、ask 心跳、会话身份字段等 20 个成员显式 PANE_INERT（原先焦点会话上传中会禁用所有列的发送按钮）。
- 裁决直达 wire：新增 `resolveAskDirect`——verdict 无条件发送（原先收件箱行缺失时点 Allow 无声无息什么都不发）、`remember` 如实转发（原先「始终允许」被静默降级为一次性放行）、task-grant／retry-safer 按列的 ask 定址（原先卡显示列的 ask、按钮裁决焦点的 ask）。
- 防复发守卫：`SidePaneModelDelegationGuardTest` 反射枚举 `DesktopModel` 全部 338 个成员，强制归类 PANE_SCOPED／PANE_INERT／WINDOW_DELEGATED——未来新增成员不显式分类即红。

**W3　AskUserQuestion 承接（c32964b9）**
- 列会话发起的提问原先在任何界面都不渲染（v1.9.5 刚修完的丢 ask 类别一列之隔重现），现在与审批一样进列的卡槽，ChatPane 零改动即可作答。
- ask 生命周期对齐焦点路径：M1 排队（第二个 ask 不再顶掉未决卡、reattach resurface 原位刷新）、#100 超时终态（卡保留「已超时」而非无声消失）、question 撤回留注记、SessionGone 清仓。
- 答题动词 `answerQuestionsDirect`／`skipQuestionsDirect` 与焦点路径共用一份 wire 构造（updatedInput.answers map 形状逐字段一致，有测试比对钉死）。

**W4　机器下沉与收尾（626573b2）**
- `bind()` 补 `finishThinking`：reattach 报 idle 时盖章未完的 Thinking 块（原先永远转「Thinking…」，下一回合还会盖上荒谬时长）。
- 回合／历史机器收归一份：`ChatTranscript.endTurn`／`mergeHistory` 下沉，焦点与列共用（原先逐句复制、已开始漂移）；`reset()` 接上会话边界；open 超时常量两路共享。
- `EndedPane` 复用泛化后的 `ChatNotice`，动作胶囊补 `tightCenter` 铁律并拿回 hoverFill。
- 删除死状态 `SidePane.composer`；`finishThinking` 折进 `onToolEvent` 让配对约定变成结构。

## 验证

- 全量 `scripts/check-all.sh` 四套件全绿；`:mobile:composeApp:desktopTest` 147 类 1197 条（较基线净增 28 条，含枚举守卫、wire 逐字段比对、竞态钉死用例）。
- 每包均做过「撤销修复 → 测试变红」的非空洞性验证。
- 待真机目验（无法单测断言）：分屏三主链路（点击聚焦、daemon 重启重绑、列内答题）与 `ChatNotice` 胶囊的视觉对齐。

🤖 Generated with [Claude Code](https://claude.com/claude-code)