### PR TITLE
桌面端顶部 chrome v2：拆标题栏＋侧栏直通窗顶＋会话导航历史＋右键菜单重设计

### DIFF
--- a/docs/design/claude-design-handoff/desktop-chrome-redesign/Context Menu v1.dc.html
+++ b/docs/design/claude-design-handoff/desktop-chrome-redesign/Context Menu v1.dc.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<meta name="design_doc_mode" content="canvas" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="crossorigin" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+  body { margin: 0; background: #08090A; }
+  a { color: #D97757; text-decoration: none; }
+  a:hover { color: #E89072; }
+</style>
+</helmet>
+
+<section style="padding:40px 44px 72px;font-family:'Inter',system-ui,sans-serif;color:#F3F3F4">
+  <div style="display:flex;align-items:baseline;gap:12px">
+    <span style="min-width:30px;height:22px;padding:0 8px;border-radius:6px;background:#D97757;color:#160C07;font:600 12px/22px 'JetBrains Mono',monospace;text-align:center">3a</span>
+    <span style="font:600 19px/1.2 'Inter',sans-serif;letter-spacing:-.015em">Context menu — surface, item states, separator metrics</span>
+  </div>
+  <p style="margin:10px 0 0;max-width:840px;font:400 13.5px/1.6 'Inter',sans-serif;color:#8C8D95;text-wrap:pretty">One generic surface: a vertical list of labelled rows with optional boundary marks, so the same component serves session rows and text-field cut/copy/paste. The removal verb stays #E6E6E9 at rest and only turns #E5604D under a tinted hover, so nothing pulls the eye to the bottom of the menu before the pointer gets there.</p>
+
+  <div data-screen-label="Context menu · spec" style="width:900px;height:620px;margin-top:28px;border-radius:11px;overflow:hidden;border:1px solid #2A2E33;background:#0E0F11;display:flex;box-shadow:0 40px 90px -40px rgba(0,0,0,.8)">
+
+    <div style="width:260px;flex:none;background:#16181B;border-right:1px solid #2A2E33;display:flex;flex-direction:column;position:relative">
+      <div style="padding:14px 12px 4px;font:600 9px/1 'JetBrains Mono',monospace;letter-spacing:.15em;color:#6E6E76">PINNED</div>
+      <sc-for list="{{ pinned }}" as="s" hint-placeholder-count="2">
+        <div style="flex:none;height:29px;display:flex;align-items:center;gap:8px;padding:0 12px">
+          <span aria-hidden="true" style="flex:none;width:4px;height:4px;border-radius:1px;background:#4A4E55;transform:rotate(45deg)"></span>
+          <span style="flex:1;min-width:0;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ s.t }}</span>
+          <span style="flex:none;font:400 9.5px/1 'JetBrains Mono',monospace;color:#6E6E76">{{ s.m }}</span>
+        </div>
+      </sc-for>
+
+      <div style="padding:12px 12px 4px;font:600 9px/1 'JetBrains Mono',monospace;letter-spacing:.15em;color:#6E6E76">RECENT</div>
+      <div style="flex:none;height:29px;display:flex;align-items:center;gap:8px;padding:0 12px">
+        <span style="flex:1;min-width:0;font:400 12.5px/1 'Inter',sans-serif;color:#B4B5BC;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">rate limiter backoff</span>
+        <span style="flex:none;font:400 9.5px/1 'JetBrains Mono',monospace;color:#6E6E76">2h</span>
+      </div>
+      <div style="flex:none;height:29px;display:flex;align-items:center;gap:8px;padding:0 12px;background:#1E2125;box-shadow:inset 0 0 0 1px #3A3F46;border-radius:0">
+        <span style="flex:1;min-width:0;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">fix webpack chunk split</span>
+        <span style="flex:none;font:400 9.5px/1 'JetBrains Mono',monospace;color:#8C8D95">5h</span>
+      </div>
+      <sc-for list="{{ recent }}" as="s" hint-placeholder-count="6">
+        <div style="flex:none;height:29px;display:flex;align-items:center;gap:8px;padding:0 12px">
+          <span style="flex:1;min-width:0;font:400 12.5px/1 'Inter',sans-serif;color:#B4B5BC;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ s.t }}</span>
+          <span style="flex:none;font:400 9.5px/1 'JetBrains Mono',monospace;color:#6E6E76">{{ s.m }}</span>
+        </div>
+      </sc-for>
+      <div style="flex:1"></div>
+    </div>
+
+    <div style="flex:1;min-width:0;position:relative;display:flex;flex-direction:column">
+
+      <div style="position:absolute;left:-42px;top:172px;width:216px;background:#1E2125;border:1px solid #2A2E33;border-radius:10px;padding:5px 0;box-shadow:0 8px 24px -8px #000;z-index:3">
+        <div style="height:28px;display:flex;align-items:center;padding:0 10px;margin:0 4px;border-radius:6px;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9;cursor:default" style-hover="background:#2A2E33">Open in split</div>
+        <div style="height:1px;background:#2A2E33;margin:4px 8px"></div>
+        <div style="height:28px;display:flex;align-items:center;padding:0 10px;margin:0 4px;border-radius:6px;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9;cursor:default" style-hover="background:#2A2E33">Rename session</div>
+        <div style="height:1px;background:#2A2E33;margin:4px 8px"></div>
+        <div style="height:28px;display:flex;align-items:center;gap:4px;padding:0 10px;margin:0 4px;border-radius:6px;font:400 12.5px/1 'Inter',sans-serif;cursor:default;background:#2A2E33">
+          <span style="flex:none;color:#9BA1A6">Move to group ·</span>
+          <span style="flex:1;min-width:0;color:#E6E6E9;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">Infra</span>
+        </div>
+        <div style="height:28px;display:flex;align-items:center;gap:4px;padding:0 10px;margin:0 4px;border-radius:6px;font:400 12.5px/1 'Inter',sans-serif;cursor:default" style-hover="background:#2A2E33">
+          <span style="flex:none;color:#9BA1A6">Move to group ·</span>
+          <span style="flex:1;min-width:0;color:#E6E6E9;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">Billing platform</span>
+        </div>
+        <div style="height:28px;display:flex;align-items:center;padding:0 10px;margin:0 4px;border-radius:6px;font:400 12.5px/1 'Inter',sans-serif;color:#6B7177;cursor:default">Remove from group</div>
+        <div style="height:1px;background:#2A2E33;margin:4px 8px"></div>
+        <div style="height:28px;display:flex;align-items:center;padding:0 10px;margin:0 4px;border-radius:6px;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9;cursor:default" style-hover="background:#2A2E33">Archive session</div>
+        <div style="height:28px;display:flex;align-items:center;padding:0 10px;margin:0 4px;border-radius:6px;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9;cursor:default" style-hover="background:rgba(229,96,77,.12);color:#E5604D">Remove from recents</div>
+      </div>
+
+      <div style="flex:1;min-height:0;padding:22px 24px 22px 214px;display:flex;flex-direction:column;gap:0">
+        <div style="font:600 9px/1 'JetBrains Mono',monospace;letter-spacing:.15em;color:#6E6E76">STATES</div>
+
+        <div style="margin-top:14px;display:flex;flex-direction:column;gap:11px">
+          <div style="display:flex;align-items:center;gap:12px">
+            <div style="width:216px;flex:none;background:#1E2125;border:1px solid #2A2E33;border-radius:10px;padding:5px 0">
+              <div style="height:28px;display:flex;align-items:center;padding:0 10px;margin:0 4px;border-radius:6px;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9">Rename session</div>
+            </div>
+            <div style="flex:1;min-width:0">
+              <div style="font:500 11.5px/1.4 'Inter',sans-serif;color:#E6E6E9">Rest</div>
+              <div style="font:400 10.5px/1.5 'JetBrains Mono',monospace;color:#6E6E76">h 28 · pad 10 · Inter 12.5 · #E6E6E9</div>
+            </div>
+          </div>
+
+          <div style="display:flex;align-items:center;gap:12px">
+            <div style="width:216px;flex:none;background:#1E2125;border:1px solid #2A2E33;border-radius:10px;padding:5px 0">
+              <div style="height:28px;display:flex;align-items:center;padding:0 10px;margin:0 4px;border-radius:6px;background:#2A2E33;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9">Rename session</div>
+            </div>
+            <div style="flex:1;min-width:0">
+              <div style="font:500 11.5px/1.4 'Inter',sans-serif;color:#E6E6E9">Hover — inner pill</div>
+              <div style="font:400 10.5px/1.5 'JetBrains Mono',monospace;color:#6E6E76">fill #2A2E33 · r6 · inset 4 · pressed #33383E</div>
+            </div>
+          </div>
+
+          <div style="display:flex;align-items:center;gap:12px">
+            <div style="width:216px;flex:none;background:#1E2125;border:1px solid #2A2E33;border-radius:10px;padding:5px 0">
+              <div style="height:28px;display:flex;align-items:center;padding:0 10px;margin:0 4px;border-radius:6px;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9">Remove from recents</div>
+            </div>
+            <div style="flex:1;min-width:0">
+              <div style="font:500 11.5px/1.4 'Inter',sans-serif;color:#E6E6E9">Removal verb — rest</div>
+              <div style="font:400 10.5px/1.5 'JetBrains Mono',monospace;color:#6E6E76">#E6E6E9 · no red until hover</div>
+            </div>
+          </div>
+
+          <div style="display:flex;align-items:center;gap:12px">
+            <div style="width:216px;flex:none;background:#1E2125;border:1px solid #2A2E33;border-radius:10px;padding:5px 0">
+              <div style="height:28px;display:flex;align-items:center;padding:0 10px;margin:0 4px;border-radius:6px;background:rgba(229,96,77,.12);font:400 12.5px/1 'Inter',sans-serif;color:#E5604D">Remove from recents</div>
+            </div>
+            <div style="flex:1;min-width:0">
+              <div style="font:500 11.5px/1.4 'Inter',sans-serif;color:#E5604D">Removal verb — hover</div>
+              <div style="font:400 10.5px/1.5 'JetBrains Mono',monospace;color:#6E6E76">fill rgba(229,96,77,.12) · text #E5604D</div>
+            </div>
+          </div>
+
+          <div style="display:flex;align-items:center;gap:12px">
+            <div style="width:216px;flex:none;background:#1E2125;border:1px solid #2A2E33;border-radius:10px;padding:5px 0">
+              <div style="height:28px;display:flex;align-items:center;padding:0 10px;margin:0 4px;border-radius:6px;font:400 12.5px/1 'Inter',sans-serif;color:#6B7177">Remove from group</div>
+            </div>
+            <div style="flex:1;min-width:0">
+              <div style="font:500 11.5px/1.4 'Inter',sans-serif;color:#8C8D95">Disabled</div>
+              <div style="font:400 10.5px/1.5 'JetBrains Mono',monospace;color:#6E6E76">#6B7177 · no hover, no press</div>
+            </div>
+          </div>
+
+          <div style="display:flex;align-items:center;gap:12px">
+            <div style="width:216px;flex:none;background:#1E2125;border:1px solid #2A2E33;border-radius:10px;padding:5px 0">
+              <div style="height:28px;display:flex;align-items:center;padding:0 10px;margin:0 4px;border-radius:6px;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9">Rename session</div>
+              <div style="height:1px;background:#2A2E33;margin:4px 8px"></div>
+              <div style="height:28px;display:flex;align-items:center;padding:0 10px;margin:0 4px;border-radius:6px;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9">Archive session</div>
+            </div>
+            <div style="flex:1;min-width:0">
+              <div style="font:500 11.5px/1.4 'Inter',sans-serif;color:#E6E6E9">Separator</div>
+              <div style="font:400 10.5px/1.5 'JetBrains Mono',monospace;color:#6E6E76">1px #2A2E33 · inset 8 · margin 4 / 4</div>
+            </div>
+          </div>
+        </div>
+
+        <div style="flex:1"></div>
+        <div style="font:400 11.5px/1.6 'Inter',sans-serif;color:#8C8D95;text-wrap:pretty;max-width:400px">Surface: #1E2125 on 1px #2A2E33, r10, pad 5 / 0, shadow 0 8px 24px -8px #000, min 180 / max 260 with the group name ellipsizing.</div>
+      </div>
+    </div>
+  </div>
+</section>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1000,&quot;height&quot;:760}}">
+class Component extends DCLogic {
+  renderVals() {
+    return {
+      pinned: [
+        { t: "api-gateway · main", m: "" },
+        { t: "design-system audit", m: "1h" }
+      ],
+      recent: [
+        { t: "add pairing QR fallback", m: "Yd" },
+        { t: "prune stale sessions job", m: "Yd" },
+        { t: "voice input latency", m: "2d" },
+        { t: "relay reconnect storm", m: "3d" },
+        { t: "sqlite wal checkpointing", m: "4d" },
+        { t: "telemetry opt-out copy", m: "5d" }
+      ]
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/claude-design-handoff/desktop-chrome-redesign/Desktop Chrome Redesign v1.dc.html
+++ b/docs/design/claude-design-handoff/desktop-chrome-redesign/Desktop Chrome Redesign v1.dc.html
@@ -1,0 +1,393 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<meta name="design_doc_mode" content="canvas" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="crossorigin" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+  body { margin: 0; background: #08090A; }
+  a { color: #D97757; text-decoration: none; }
+  a:hover { color: #E8907288; }
+</style>
+</helmet>
+
+<section style="padding:40px 44px 72px;font-family:'Inter',system-ui,sans-serif;color:#F3F3F4">
+  <div style="display:flex;align-items:baseline;gap:12px">
+    <span style="min-width:30px;height:22px;padding:0 8px;border-radius:6px;background:#D97757;color:#160C07;font:600 12px/22px 'JetBrains Mono',monospace;text-align:center">1a</span>
+    <span style="font:600 19px/1.2 'Inter',sans-serif;letter-spacing:-.015em">Desktop chrome — title bar navigation + sidebar top</span>
+  </div>
+  <p style="margin:10px 0 0;max-width:820px;font:400 13.5px/1.6 'Inter',sans-serif;color:#8C8D95;text-wrap:pretty">Wordmark removed; the title bar carries only window controls, the sidebar toggle, and session history navigation. Search moves into the sidebar as the first element, the device switcher shrinks to a one-line strip beneath it, and the session list starts at 184px from the window top instead of 232px.</p>
+
+  <div style="display:flex;flex-direction:column;gap:44px;margin-top:32px">
+
+    <div>
+      <div style="font:500 10.5px/1 'JetBrains Mono',monospace;letter-spacing:.16em;text-transform:uppercase;color:#6E6E76;margin-bottom:12px">1 · Default — sidebar expanded, back enabled / forward disabled</div>
+      <div data-screen-label="Desktop · default" style="width:1280px;height:800px;border-radius:11px;overflow:hidden;border:1px solid #2A2E33;background:#0E0F11;display:flex;flex-direction:column;box-shadow:0 40px 90px -40px rgba(0,0,0,.8)">
+
+        <div style="height:38px;flex:none;display:flex;align-items:center;gap:2px;padding:0 12px;border-bottom:1px solid #2A2E33;background:#0E0F11">
+          <span style="display:flex;gap:8px;align-items:center;flex:none;margin-right:12px">
+            <span style="width:12px;height:12px;border-radius:50%;background:#FF5F57"></span>
+            <span style="width:12px;height:12px;border-radius:50%;background:#FEBC2E"></span>
+            <span style="width:12px;height:12px;border-radius:50%;background:#28C840"></span>
+          </span>
+          <button type="button" aria-label="Toggle sidebar" style="appearance:none;border:0;background:none;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none" style-hover="background:#1E2125">
+            <span aria-hidden="true" style="position:relative;width:15px;height:13px;display:block">
+              <span style="position:absolute;inset:0;border:1.5px solid #B4B5BC;border-radius:2.5px;box-sizing:border-box"></span>
+              <span style="position:absolute;left:5px;top:0;bottom:0;width:1.5px;background:#B4B5BC"></span>
+            </span>
+          </button>
+          <button type="button" aria-label="Previous session" style="appearance:none;border:0;background:none;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none" style-hover="background:#1E2125">
+            <span aria-hidden="true" style="width:6px;height:6px;border-left:1.5px solid #B4B5BC;border-bottom:1.5px solid #B4B5BC;transform:rotate(45deg) translate(1px,-1px)"></span>
+          </button>
+          <button type="button" aria-label="Next session" disabled="disabled" style="appearance:none;border:0;background:none;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:default;flex:none">
+            <span aria-hidden="true" style="width:6px;height:6px;border-right:1.5px solid #4A4E55;border-top:1.5px solid #4A4E55;transform:rotate(45deg) translate(-1px,1px)"></span>
+          </button>
+          <span style="flex:1"></span>
+          <button type="button" aria-label="Connection status" style="appearance:none;border:0;background:none;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none" style-hover="background:#1E2125">
+            <span style="width:7px;height:7px;border-radius:50%;background:#7ECBA0;box-shadow:0 0 0 3px rgba(126,203,160,.14)"></span>
+          </button>
+        </div>
+
+        <div style="flex:1;min-height:0;display:flex">
+
+          <div style="width:260px;flex:none;display:flex;flex-direction:column;background:#16181B;border-right:1px solid #2A2E33">
+
+            <div style="flex:none;padding:8px 10px 7px">
+              <div style="height:30px;border:1px solid #2A2E33;border-radius:8px;background:#0E0F11;display:flex;align-items:center;gap:7px;padding:0 9px;cursor:text" style-hover="border-color:#3A3F46">
+                <span aria-hidden="true" style="position:relative;width:12px;height:12px;flex:none;display:block">
+                  <span style="position:absolute;left:0;top:0;width:9px;height:9px;border:1.5px solid #8C8D95;border-radius:50%;box-sizing:border-box"></span>
+                  <span style="position:absolute;left:7.5px;top:8px;width:5px;height:1.5px;background:#8C8D95;border-radius:1px;transform:rotate(45deg);transform-origin:left center"></span>
+                </span>
+                <span style="flex:1;font:400 12.5px/1 'Inter',sans-serif;color:#6E6E76">Search</span>
+                <span style="flex:none;font:500 10px/1 'JetBrains Mono',monospace;color:#6E6E76;letter-spacing:.02em">⌘K</span>
+              </div>
+            </div>
+
+            <button type="button" aria-haspopup="menu" style="appearance:none;border:0;background:none;flex:none;height:26px;display:flex;align-items:center;gap:7px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:#1E2125">
+              <span style="flex:none;width:5px;height:5px;border-radius:50%;background:#7ECBA0"></span>
+              <span style="min-width:0;font:500 11px/1 'JetBrains Mono',monospace;color:#B4B5BC;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">mbp-m3</span>
+              <span aria-hidden="true" style="flex:none;width:4.5px;height:4.5px;border-right:1.4px solid #6E6E76;border-bottom:1.4px solid #6E6E76;transform:rotate(45deg) translateY(-1.5px)"></span>
+              <span style="flex:1"></span>
+              <span aria-label="Attention" style="position:relative;width:12px;height:12px;flex:none;color:#8C8D95;display:block">
+                <span style="position:absolute;left:2px;top:1px;width:8px;height:7px;border:1.4px solid currentColor;border-bottom:0;border-radius:4.5px 4.5px 0 0;box-sizing:border-box"></span>
+                <span style="position:absolute;left:0;top:8px;width:12px;height:1.4px;background:currentColor;border-radius:1px"></span>
+                <span style="position:absolute;left:5px;top:10px;width:2px;height:1.5px;background:currentColor;border-radius:0 0 2px 2px"></span>
+              </span>
+            </button>
+
+            <div style="height:1px;flex:none;background:#2A2E33;margin:5px 0 4px"></div>
+
+            <button type="button" style="appearance:none;border:0;background:none;flex:none;height:28px;display:flex;align-items:center;gap:8px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:rgba(217,119,87,.09)">
+              <span aria-hidden="true" style="position:relative;width:12px;height:12px;flex:none;display:block">
+                <span style="position:absolute;left:0;top:5.25px;width:12px;height:1.5px;background:#D97757;border-radius:1px"></span>
+                <span style="position:absolute;top:0;left:5.25px;height:12px;width:1.5px;background:#D97757;border-radius:1px"></span>
+              </span>
+              <span style="font:500 12.5px/1 'Inter',sans-serif;color:#D97757">New session</span>
+              <span style="flex:1"></span>
+              <span style="font:500 10px/1 'JetBrains Mono',monospace;color:#6E6E76">⌘N</span>
+            </button>
+            <button type="button" style="appearance:none;border:0;background:none;flex:none;height:28px;display:flex;align-items:center;gap:8px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:#1E2125">
+              <span aria-hidden="true" style="position:relative;width:12px;height:11px;flex:none;display:block">
+                <span style="position:absolute;left:0;top:2.5px;width:12px;height:8px;border:1.5px solid #8C8D95;border-radius:2px;box-sizing:border-box"></span>
+                <span style="position:absolute;left:1px;top:.5px;width:5px;height:3px;border:1.5px solid #8C8D95;border-bottom:0;border-radius:2px 2px 0 0;box-sizing:border-box"></span>
+              </span>
+              <span style="font:400 12.5px/1 'Inter',sans-serif;color:#B4B5BC">Open folder…</span>
+            </button>
+
+            <div style="height:1px;flex:none;background:#2A2E33;margin:4px 0 0"></div>
+
+            <div style="flex:1;min-height:0;overflow:hidden;display:flex;flex-direction:column">
+              <div style="padding:10px 12px 4px;font:600 9px/1 'JetBrains Mono',monospace;letter-spacing:.15em;color:#6E6E76">PINNED</div>
+              <sc-for list="{{ pinned }}" as="s" hint-placeholder-count="2">
+                <button type="button" style="appearance:none;border:0;background:none;flex:none;height:29px;display:flex;align-items:center;gap:8px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:#1E2125">
+                  <span aria-hidden="true" style="flex:none;width:4px;height:4px;border-radius:1px;background:#4A4E55;transform:rotate(45deg)"></span>
+                  <span style="flex:1;min-width:0;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ s.t }}</span>
+                  <span style="flex:none;font:400 9.5px/1 'JetBrains Mono',monospace;color:#6E6E76">{{ s.m }}</span>
+                </button>
+              </sc-for>
+
+              <div style="padding:12px 12px 4px;font:600 9px/1 'JetBrains Mono',monospace;letter-spacing:.15em;color:#6E6E76">RUNNING</div>
+              <button type="button" style="appearance:none;border:0;flex:none;height:29px;display:flex;align-items:center;gap:8px;padding:0 12px 0 10px;cursor:pointer;text-align:left;background:#1E2125;box-shadow:inset 2px 0 0 #D97757">
+                <span style="flex:none;width:5px;height:5px;border-radius:50%;background:#7ECBA0;box-shadow:0 0 0 2.5px rgba(126,203,160,.14)"></span>
+                <span style="flex:1;min-width:0;font:500 12.5px/1 'Inter',sans-serif;color:#F3F3F4;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">fix flaky auth test</span>
+                <span style="flex:none;font:400 9.5px/1 'JetBrains Mono',monospace;color:#8C8D95">2m</span>
+              </button>
+              <sc-for list="{{ running }}" as="s" hint-placeholder-count="2">
+                <button type="button" style="appearance:none;border:0;background:none;flex:none;height:29px;display:flex;align-items:center;gap:8px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:#1E2125">
+                  <span style="flex:none;width:5px;height:5px;border-radius:50%;background:#7ECBA0;box-shadow:0 0 0 2.5px rgba(126,203,160,.14)"></span>
+                  <span style="flex:1;min-width:0;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ s.t }}</span>
+                  <span style="flex:none;font:400 9.5px/1 'JetBrains Mono',monospace;color:#6E6E76">{{ s.m }}</span>
+                </button>
+              </sc-for>
+
+              <div style="padding:12px 12px 4px;font:600 9px/1 'JetBrains Mono',monospace;letter-spacing:.15em;color:#6E6E76">RECENT</div>
+              <sc-for list="{{ recent }}" as="s" hint-placeholder-count="7">
+                <button type="button" style="appearance:none;border:0;background:none;flex:none;height:29px;display:flex;align-items:center;gap:8px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:#1E2125">
+                  <span style="flex:1;min-width:0;font:400 12.5px/1 'Inter',sans-serif;color:#B4B5BC;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ s.t }}</span>
+                  <span style="flex:none;font:400 9.5px/1 'JetBrains Mono',monospace;color:#6E6E76">{{ s.m }}</span>
+                </button>
+              </sc-for>
+              <div style="flex:1"></div>
+            </div>
+
+            <div style="height:1px;flex:none;background:#2A2E33"></div>
+            <div style="flex:none;height:30px;display:flex;align-items:center;gap:8px;padding:0 12px">
+              <span style="font:400 11.5px/1 'Inter',sans-serif;color:#8C8D95">Help &amp; support</span>
+              <span style="flex:1"></span>
+              <span style="font:400 10px/1 'JetBrains Mono',monospace;color:#6E6E76">v1.9.1</span>
+              <span aria-label="Settings" style="font:400 12px/1 'Inter',sans-serif;color:#8C8D95">⚙︎</span>
+            </div>
+          </div>
+
+          <div style="flex:1;min-width:0;display:flex;flex-direction:column;background:#0E0F11">
+            <div style="height:42px;flex:none;display:flex;align-items:center;gap:10px;padding:0 16px;border-bottom:1px solid #2A2E33">
+              <span style="font:600 13px/1 'Inter',sans-serif;letter-spacing:-.005em;color:#F3F3F4">fix flaky auth test</span>
+              <span style="flex:none;display:flex;align-items:center;height:20px;padding:0 7px;border-radius:5px;border:1px solid #2A2E33;background:#16181B;font:500 10px/1 'JetBrains Mono',monospace;color:#B4B5BC">⎇ fix/auth-retry</span>
+              <span style="flex:none;font:400 11px/1 'JetBrains Mono',monospace;color:#6E6E76">~/dev/api-gateway</span>
+              <span style="flex:1"></span>
+              <span style="flex:none;font:400 11px/1 'JetBrains Mono',monospace;color:#6E6E76">claude-sonnet-4.5</span>
+            </div>
+
+            <div style="flex:1;min-height:0;overflow:hidden;padding:22px 28px;display:flex;flex-direction:column;gap:18px">
+              <div style="display:flex;gap:11px">
+                <span style="flex:none;width:22px;height:22px;border-radius:6px;border:1px solid #2A2E33;background:#16181B;display:flex;align-items:center;justify-content:center;font:500 10px/1 'JetBrains Mono',monospace;color:#8C8D95">R</span>
+                <div style="flex:1;min-width:0;font:400 13px/1.6 'Inter',sans-serif;color:#E6E6E9;max-width:640px;text-wrap:pretty">The auth test fails about one run in six on CI. Can you find the race and fix it without adding sleeps?</div>
+              </div>
+              <div style="display:flex;gap:11px">
+                <span style="flex:none;width:22px;height:22px;border-radius:6px;background:#D97757;display:flex;align-items:center;justify-content:center;font:600 10px/1 'JetBrains Mono',monospace;color:#160C07">C</span>
+                <div style="flex:1;min-width:0;max-width:700px;display:flex;flex-direction:column;gap:12px">
+                  <div style="font:400 13px/1.6 'Inter',sans-serif;color:#E6E6E9;text-wrap:pretty">The token refresh in <span style="font:400 12px/1 'JetBrains Mono',monospace;color:#D9A57C">setupAuth()</span> is not awaited, so the first request can go out with the stale token. Reading the two call sites now.</div>
+                  <div style="border:1px solid #2A2E33;border-radius:8px;background:#16181B;overflow:hidden">
+                    <div style="height:28px;display:flex;align-items:center;gap:8px;padding:0 11px;border-bottom:1px solid #2A2E33">
+                      <span style="width:5px;height:5px;border-radius:50%;background:#7ECBA0"></span>
+                      <span style="font:500 10.5px/1 'JetBrains Mono',monospace;color:#B4B5BC">Read</span>
+                      <span style="font:400 10.5px/1 'JetBrains Mono',monospace;color:#6E6E76">tests/auth/setup.ts</span>
+                      <span style="flex:1"></span>
+                      <span style="font:400 10px/1 'JetBrains Mono',monospace;color:#6E6E76">142 lines</span>
+                    </div>
+                    <div style="padding:10px 11px;font:400 11.5px/1.7 'JetBrains Mono',monospace;color:#8C8D95;white-space:pre">  38  const t = refreshToken(ctx)
+  39  client.use(bearer(t))
+  40  return client</div>
+                  </div>
+                  <div style="font:400 13px/1.6 'Inter',sans-serif;color:#E6E6E9;text-wrap:pretty">Line 38 returns a promise that is dropped. I will await it and thread the token through explicitly.</div>
+                </div>
+              </div>
+              <div style="flex:1"></div>
+              <div style="flex:none;border:1px solid #2A2E33;border-radius:10px;background:#16181B;padding:11px 13px;display:flex;align-items:center;gap:10px">
+                <span style="flex:1;font:400 13px/1 'Inter',sans-serif;color:#6E6E76">Reply to Claude…</span>
+                <span style="flex:none;font:500 10px/1 'JetBrains Mono',monospace;color:#6E6E76">⏎</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div style="font:500 10.5px/1 'JetBrains Mono',monospace;letter-spacing:.16em;text-transform:uppercase;color:#6E6E76;margin-bottom:12px">2 · Sidebar collapsed — chat takes full width, ⌘K still opens the palette</div>
+      <div data-screen-label="Desktop · sidebar collapsed" style="width:1280px;height:800px;border-radius:11px;overflow:hidden;border:1px solid #2A2E33;background:#0E0F11;display:flex;flex-direction:column;box-shadow:0 40px 90px -40px rgba(0,0,0,.8)">
+
+        <div style="height:38px;flex:none;display:flex;align-items:center;gap:2px;padding:0 12px;border-bottom:1px solid #2A2E33;background:#0E0F11">
+          <span style="display:flex;gap:8px;align-items:center;flex:none;margin-right:12px">
+            <span style="width:12px;height:12px;border-radius:50%;background:#FF5F57"></span>
+            <span style="width:12px;height:12px;border-radius:50%;background:#FEBC2E"></span>
+            <span style="width:12px;height:12px;border-radius:50%;background:#28C840"></span>
+          </span>
+          <button type="button" aria-label="Toggle sidebar" style="appearance:none;border:0;background:#1E2125;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none">
+            <span aria-hidden="true" style="position:relative;width:15px;height:13px;display:block">
+              <span style="position:absolute;inset:0;border:1.5px solid #E6E6E9;border-radius:2.5px;box-sizing:border-box"></span>
+              <span style="position:absolute;left:5px;top:0;bottom:0;width:1.5px;background:#E6E6E9"></span>
+              <span style="position:absolute;left:0;top:0;bottom:0;width:5px;background:rgba(230,230,233,.22)"></span>
+            </span>
+          </button>
+          <button type="button" aria-label="Previous session" style="appearance:none;border:0;background:none;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none" style-hover="background:#1E2125">
+            <span aria-hidden="true" style="width:6px;height:6px;border-left:1.5px solid #B4B5BC;border-bottom:1.5px solid #B4B5BC;transform:rotate(45deg) translate(1px,-1px)"></span>
+          </button>
+          <button type="button" aria-label="Next session" style="appearance:none;border:0;background:none;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none" style-hover="background:#1E2125">
+            <span aria-hidden="true" style="width:6px;height:6px;border-right:1.5px solid #B4B5BC;border-top:1.5px solid #B4B5BC;transform:rotate(45deg) translate(-1px,1px)"></span>
+          </button>
+          <span style="flex:1"></span>
+          <button type="button" aria-label="Connection status" style="appearance:none;border:0;background:none;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none" style-hover="background:#1E2125">
+            <span style="width:7px;height:7px;border-radius:50%;background:#7ECBA0;box-shadow:0 0 0 3px rgba(126,203,160,.14)"></span>
+          </button>
+        </div>
+
+        <div style="flex:1;min-height:0;display:flex;flex-direction:column;background:#0E0F11">
+          <div style="height:42px;flex:none;display:flex;align-items:center;gap:10px;padding:0 16px;border-bottom:1px solid #2A2E33">
+            <span style="font:600 13px/1 'Inter',sans-serif;letter-spacing:-.005em;color:#F3F3F4">fix flaky auth test</span>
+            <span style="flex:none;display:flex;align-items:center;height:20px;padding:0 7px;border-radius:5px;border:1px solid #2A2E33;background:#16181B;font:500 10px/1 'JetBrains Mono',monospace;color:#B4B5BC">⎇ fix/auth-retry</span>
+            <span style="flex:none;font:400 11px/1 'JetBrains Mono',monospace;color:#6E6E76">~/dev/api-gateway</span>
+            <span style="flex:1"></span>
+            <span style="flex:none;font:400 11px/1 'JetBrains Mono',monospace;color:#6E6E76">claude-sonnet-4.5</span>
+          </div>
+
+          <div style="flex:1;min-height:0;overflow:hidden;padding:26px 0;display:flex;flex-direction:column;align-items:center">
+            <div style="width:780px;display:flex;flex-direction:column;gap:18px;flex:1;min-height:0">
+              <div style="display:flex;gap:11px">
+                <span style="flex:none;width:22px;height:22px;border-radius:6px;border:1px solid #2A2E33;background:#16181B;display:flex;align-items:center;justify-content:center;font:500 10px/1 'JetBrains Mono',monospace;color:#8C8D95">R</span>
+                <div style="flex:1;min-width:0;font:400 13px/1.6 'Inter',sans-serif;color:#E6E6E9;text-wrap:pretty">The auth test fails about one run in six on CI. Can you find the race and fix it without adding sleeps?</div>
+              </div>
+              <div style="display:flex;gap:11px">
+                <span style="flex:none;width:22px;height:22px;border-radius:6px;background:#D97757;display:flex;align-items:center;justify-content:center;font:600 10px/1 'JetBrains Mono',monospace;color:#160C07">C</span>
+                <div style="flex:1;min-width:0;display:flex;flex-direction:column;gap:12px">
+                  <div style="font:400 13px/1.6 'Inter',sans-serif;color:#E6E6E9;text-wrap:pretty">The token refresh in <span style="font:400 12px/1 'JetBrains Mono',monospace;color:#D9A57C">setupAuth()</span> is not awaited, so the first request can go out with the stale token. Reading the two call sites now.</div>
+                  <div style="border:1px solid #2A2E33;border-radius:8px;background:#16181B;overflow:hidden">
+                    <div style="height:28px;display:flex;align-items:center;gap:8px;padding:0 11px;border-bottom:1px solid #2A2E33">
+                      <span style="width:5px;height:5px;border-radius:50%;background:#7ECBA0"></span>
+                      <span style="font:500 10.5px/1 'JetBrains Mono',monospace;color:#B4B5BC">Read</span>
+                      <span style="font:400 10.5px/1 'JetBrains Mono',monospace;color:#6E6E76">tests/auth/setup.ts</span>
+                      <span style="flex:1"></span>
+                      <span style="font:400 10px/1 'JetBrains Mono',monospace;color:#6E6E76">142 lines</span>
+                    </div>
+                    <div style="padding:10px 11px;font:400 11.5px/1.7 'JetBrains Mono',monospace;color:#8C8D95;white-space:pre">  38  const t = refreshToken(ctx)
+  39  client.use(bearer(t))
+  40  return client</div>
+                  </div>
+                </div>
+              </div>
+              <div style="flex:1"></div>
+              <div style="flex:none;border:1px solid #2A2E33;border-radius:10px;background:#16181B;padding:11px 13px;display:flex;align-items:center;gap:10px">
+                <span style="flex:1;font:400 13px/1 'Inter',sans-serif;color:#6E6E76">Reply to Claude…</span>
+                <span style="flex:none;font:500 10px/1 'JetBrains Mono',monospace;color:#6E6E76">⏎</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div style="width:1280px;font:400 12.5px/1.6 'Inter',sans-serif;color:#8C8D95;margin-top:12px;text-wrap:pretty">Collapsed state adds no chrome: the toggle sits filled to read as active, and search stays reachable through ⌘K. Sessions are reached with ⌘[ / ⌘] or by expanding.</div>
+    </div>
+
+    <div>
+      <div style="font:500 10.5px/1 'JetBrains Mono',monospace;letter-spacing:.16em;text-transform:uppercase;color:#6E6E76;margin-bottom:12px">3 · Detail — hover, tooltips, disabled forward (2× scale)</div>
+      <div data-screen-label="Desktop · chrome detail" style="width:1280px;border-radius:11px;border:1px solid #2A2E33;background:#0E0F11;padding:34px 0 44px;overflow:hidden">
+        <div style="width:1280px;height:476px;overflow:hidden">
+        <div style="transform:scale(2);transform-origin:top left;width:640px;height:238px">
+          <div style="width:640px;background:#0E0F11">
+            <div style="height:38px;display:flex;align-items:center;gap:2px;padding:0 12px;border-bottom:1px solid #2A2E33;position:relative">
+              <span style="display:flex;gap:8px;align-items:center;flex:none;margin-right:12px">
+                <span style="width:12px;height:12px;border-radius:50%;background:#FF5F57"></span>
+                <span style="width:12px;height:12px;border-radius:50%;background:#FEBC2E"></span>
+                <span style="width:12px;height:12px;border-radius:50%;background:#28C840"></span>
+              </span>
+              <span style="width:28px;height:28px;border-radius:6px;background:#1E2125;display:flex;align-items:center;justify-content:center;flex:none">
+                <span aria-hidden="true" style="position:relative;width:15px;height:13px;display:block">
+                  <span style="position:absolute;inset:0;border:1.5px solid #E6E6E9;border-radius:2.5px;box-sizing:border-box"></span>
+                  <span style="position:absolute;left:5px;top:0;bottom:0;width:1.5px;background:#E6E6E9"></span>
+                </span>
+              </span>
+              <span style="width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;flex:none">
+                <span aria-hidden="true" style="width:6px;height:6px;border-left:1.5px solid #B4B5BC;border-bottom:1.5px solid #B4B5BC;transform:rotate(45deg) translate(1px,-1px)"></span>
+              </span>
+              <span style="width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;flex:none">
+                <span aria-hidden="true" style="width:6px;height:6px;border-right:1.5px solid #4A4E55;border-top:1.5px solid #4A4E55;transform:rotate(45deg) translate(-1px,1px)"></span>
+              </span>
+              <span style="flex:1"></span>
+              <span style="width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;flex:none">
+                <span style="width:7px;height:7px;border-radius:50%;background:#7ECBA0;box-shadow:0 0 0 3px rgba(126,203,160,.14)"></span>
+              </span>
+              <span style="position:absolute;left:52px;top:44px;display:flex;align-items:center;gap:6px;height:21px;padding:0 7px;border-radius:5px;border:1px solid #2A2E33;background:#1E2125;box-shadow:0 6px 16px -6px rgba(0,0,0,.7);white-space:nowrap">
+                <span style="font:400 10.5px/1 'Inter',sans-serif;color:#E6E6E9">Toggle sidebar</span>
+                <span style="font:500 10px/1 'JetBrains Mono',monospace;color:#8C8D95">⌘\</span>
+              </span>
+              <span style="position:absolute;left:186px;top:44px;display:flex;align-items:center;gap:6px;height:21px;padding:0 7px;border-radius:5px;border:1px solid #2A2E33;background:#1E2125;box-shadow:0 6px 16px -6px rgba(0,0,0,.7);white-space:nowrap;opacity:.45">
+                <span style="font:400 10.5px/1 'Inter',sans-serif;color:#E6E6E9">Next session</span>
+                <span style="font:500 10px/1 'JetBrains Mono',monospace;color:#8C8D95">⌘]</span>
+              </span>
+            </div>
+
+            <div style="height:30px;background:#0E0F11"></div>
+            <div style="display:flex">
+              <div style="width:260px;flex:none;background:#16181B;border-right:1px solid #2A2E33;height:162px;display:flex;flex-direction:column">
+                <div style="flex:none;padding:8px 10px 7px">
+                  <div style="height:30px;border:1px solid #2A2E33;border-radius:8px;background:#0E0F11;display:flex;align-items:center;gap:7px;padding:0 9px">
+                    <span aria-hidden="true" style="position:relative;width:12px;height:12px;flex:none;display:block">
+                      <span style="position:absolute;left:0;top:0;width:9px;height:9px;border:1.5px solid #8C8D95;border-radius:50%;box-sizing:border-box"></span>
+                      <span style="position:absolute;left:7.5px;top:8px;width:5px;height:1.5px;background:#8C8D95;border-radius:1px;transform:rotate(45deg);transform-origin:left center"></span>
+                    </span>
+                    <span style="flex:1;font:400 12.5px/1 'Inter',sans-serif;color:#6E6E76">Search</span>
+                    <span style="flex:none;font:500 10px/1 'JetBrains Mono',monospace;color:#6E6E76">⌘K</span>
+                  </div>
+                </div>
+                <div style="flex:none;height:26px;display:flex;align-items:center;gap:7px;padding:0 12px">
+                  <span style="flex:none;width:5px;height:5px;border-radius:50%;background:#7ECBA0"></span>
+                  <span style="font:500 11px/1 'JetBrains Mono',monospace;color:#B4B5BC">mbp-m3</span>
+                  <span aria-hidden="true" style="flex:none;width:4.5px;height:4.5px;border-right:1.4px solid #6E6E76;border-bottom:1.4px solid #6E6E76;transform:rotate(45deg) translateY(-1.5px)"></span>
+                  <span style="flex:1"></span>
+                  <span style="position:relative;width:12px;height:12px;flex:none;color:#8C8D95;display:block">
+                    <span style="position:absolute;left:2px;top:1px;width:8px;height:7px;border:1.4px solid currentColor;border-bottom:0;border-radius:4.5px 4.5px 0 0;box-sizing:border-box"></span>
+                    <span style="position:absolute;left:0;top:8px;width:12px;height:1.4px;background:currentColor;border-radius:1px"></span>
+                    <span style="position:absolute;left:5px;top:10px;width:2px;height:1.5px;background:currentColor;border-radius:0 0 2px 2px"></span>
+                  </span>
+                </div>
+                <div style="height:1px;flex:none;background:#2A2E33;margin:5px 0 4px"></div>
+                <div style="flex:none;height:28px;display:flex;align-items:center;gap:8px;padding:0 12px;background:rgba(217,119,87,.09)">
+                  <span aria-hidden="true" style="position:relative;width:12px;height:12px;flex:none;display:block">
+                    <span style="position:absolute;left:0;top:5.25px;width:12px;height:1.5px;background:#D97757;border-radius:1px"></span>
+                    <span style="position:absolute;top:0;left:5.25px;height:12px;width:1.5px;background:#D97757;border-radius:1px"></span>
+                  </span>
+                  <span style="font:500 12.5px/1 'Inter',sans-serif;color:#D97757">New session</span>
+                  <span style="flex:1"></span>
+                  <span style="font:500 10px/1 'JetBrains Mono',monospace;color:#6E6E76">⌘N</span>
+                </div>
+                <div style="flex:none;height:28px;display:flex;align-items:center;gap:8px;padding:0 12px">
+                  <span aria-hidden="true" style="position:relative;width:12px;height:11px;flex:none;display:block">
+                    <span style="position:absolute;left:0;top:2.5px;width:12px;height:8px;border:1.5px solid #8C8D95;border-radius:2px;box-sizing:border-box"></span>
+                    <span style="position:absolute;left:1px;top:.5px;width:5px;height:3px;border:1.5px solid #8C8D95;border-bottom:0;border-radius:2px 2px 0 0;box-sizing:border-box"></span>
+                  </span>
+                  <span style="font:400 12.5px/1 'Inter',sans-serif;color:#B4B5BC">Open folder…</span>
+                </div>
+                <div style="height:1px;flex:none;background:#2A2E33;margin:4px 0 0"></div>
+                <div style="padding:10px 12px 4px;font:600 9px/1 'JetBrains Mono',monospace;letter-spacing:.15em;color:#6E6E76">PINNED</div>
+              </div>
+              <div style="flex:1;height:162px;background:#0E0F11;border-bottom:1px solid #2A2E33">
+                <div style="height:42px;display:flex;align-items:center;gap:10px;padding:0 16px;border-bottom:1px solid #2A2E33">
+                  <span style="font:600 13px/1 'Inter',sans-serif;color:#F3F3F4">fix flaky auth test</span>
+                  <span style="flex:none;display:flex;align-items:center;height:20px;padding:0 7px;border-radius:5px;border:1px solid #2A2E33;background:#16181B;font:500 10px/1 'JetBrains Mono',monospace;color:#B4B5BC">⎇ fix/auth-retry</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        </div>
+      </div>
+      <div style="width:1280px;font:400 12.5px/1.6 'Inter',sans-serif;color:#8C8D95;margin-top:12px;text-wrap:pretty">Hover raises a rounded-6 #1E2125 plate under the 28px hit target; the disabled forward chevron drops to #4A4E55 and takes no hover or tooltip (shown faded here only to place it). The gap under the title bar exists only in this detail frame, to clear the tooltips.</div>
+    </div>
+
+  </div>
+</section>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1400,&quot;height&quot;:1100}}">
+class Component extends DCLogic {
+  renderVals() {
+    return {
+      pinned: [
+        { t: "api-gateway · main", m: "" },
+        { t: "design-system audit", m: "1h" }
+      ],
+      running: [
+        { t: "migrate billing schema", m: "14m" },
+        { t: "docs: rewrite quickstart", m: "31m" }
+      ],
+      recent: [
+        { t: "rate limiter backoff", m: "2h" },
+        { t: "fix webpack chunk split", m: "5h" },
+        { t: "add pairing QR fallback", m: "Yd" },
+        { t: "prune stale sessions job", m: "Yd" },
+        { t: "voice input latency", m: "2d" },
+        { t: "relay reconnect storm", m: "3d" },
+        { t: "sqlite wal checkpointing", m: "4d" }
+      ]
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/claude-design-handoff/desktop-chrome-redesign/Desktop Chrome Redesign v2.dc.html
+++ b/docs/design/claude-design-handoff/desktop-chrome-redesign/Desktop Chrome Redesign v2.dc.html
@@ -1,0 +1,616 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<meta name="design_doc_mode" content="canvas" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="crossorigin" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+  body { margin: 0; background: #08090A; }
+  a { color: #D97757; text-decoration: none; }
+  a:hover { color: #E89072; }
+</style>
+</helmet>
+
+<section style="padding:40px 44px 72px;font-family:'Inter',system-ui,sans-serif;color:#F3F3F4">
+  <div style="display:flex;align-items:baseline;gap:12px">
+    <span style="min-width:30px;height:22px;padding:0 8px;border-radius:6px;background:#D97757;color:#160C07;font:600 12px/22px 'JetBrains Mono',monospace;text-align:center">2a</span>
+    <span style="font:600 19px/1.2 'Inter',sans-serif;letter-spacing:-.015em">Desktop chrome v2 — no title bar, columns run to the window top</span>
+  </div>
+  <p style="margin:10px 0 0;max-width:840px;font:400 13.5px/1.6 'Inter',sans-serif;color:#8C8D95;text-wrap:pretty">Nothing spans the window width. The sidebar owns its own 38px control row (traffic lights, toggle, back/forward, search) and the chat sub-header is the chat column's first element, doubling as drag area and carrying the connection dot. Search collapses into that same control row, taking the width left over beside the four buttons, so the session list begins at 136px, down from 232px in the shipping build.</p>
+
+  <div style="display:flex;flex-direction:column;gap:44px;margin-top:32px">
+
+    <div>
+      <div style="font:500 10.5px/1 'JetBrains Mono',monospace;letter-spacing:.16em;text-transform:uppercase;color:#6E6E76;margin-bottom:12px">1 · Default — sidebar expanded, back enabled / forward disabled</div>
+      <div data-screen-label="Desktop v2 · default" style="width:1280px;height:800px;border-radius:11px;overflow:hidden;border:1px solid #2A2E33;background:#0E0F11;display:flex;box-shadow:0 40px 90px -40px rgba(0,0,0,.8)">
+
+        <div style="width:260px;flex:none;display:flex;flex-direction:column;background:#16181B;border-right:1px solid #2A2E33">
+
+          <div style="height:38px;flex:none;display:flex;align-items:center;gap:2px;padding:0 10px 0 12px">
+            <span style="display:flex;gap:8px;align-items:center;flex:none;margin-right:10px">
+              <span style="width:12px;height:12px;border-radius:50%;background:#FF5F57"></span>
+              <span style="width:12px;height:12px;border-radius:50%;background:#FEBC2E"></span>
+              <span style="width:12px;height:12px;border-radius:50%;background:#28C840"></span>
+            </span>
+            <button type="button" aria-label="Toggle sidebar" style="appearance:none;border:0;background:none;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none" style-hover="background:#1E2125">
+              <span aria-hidden="true" style="position:relative;width:15px;height:13px;display:block">
+                <span style="position:absolute;inset:0;border:1.5px solid #B4B5BC;border-radius:2.5px;box-sizing:border-box"></span>
+                <span style="position:absolute;left:5px;top:0;bottom:0;width:1.5px;background:#B4B5BC"></span>
+              </span>
+            </button>
+            <button type="button" aria-label="Previous session" style="appearance:none;border:0;background:none;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none" style-hover="background:#1E2125">
+              <span aria-hidden="true" style="width:6px;height:6px;border-left:1.5px solid #B4B5BC;border-bottom:1.5px solid #B4B5BC;transform:rotate(45deg) translate(1px,-1px)"></span>
+            </button>
+            <button type="button" aria-label="Next session" disabled="disabled" style="appearance:none;border:0;background:none;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:default;flex:none">
+              <span aria-hidden="true" style="width:6px;height:6px;border-right:1.5px solid #4A4E55;border-top:1.5px solid #4A4E55;transform:rotate(45deg) translate(-1px,1px)"></span>
+            </button>
+            <div style="flex:1;min-width:0;margin-left:6px;height:26px;border:1px solid #2A2E33;border-radius:7px;background:#0E0F11;display:flex;align-items:center;gap:6px;padding:0 8px;cursor:text" style-hover="border-color:#3A3F46">
+              <span aria-hidden="true" style="position:relative;width:12px;height:12px;flex:none;display:block">
+                <span style="position:absolute;left:0;top:0;width:9px;height:9px;border:1.5px solid #8C8D95;border-radius:50%;box-sizing:border-box"></span>
+                <span style="position:absolute;left:7.5px;top:8px;width:5px;height:1.5px;background:#8C8D95;border-radius:1px;transform:rotate(45deg);transform-origin:left center"></span>
+              </span>
+              <span style="flex:1;min-width:0;font:400 12px/1 'Inter',sans-serif;color:#6E6E76;white-space:nowrap;overflow:hidden">Search</span>
+            </div>
+          </div>
+
+          <button type="button" aria-haspopup="menu" style="appearance:none;border:0;background:none;flex:none;height:26px;display:flex;align-items:center;gap:7px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:#1E2125">
+            <span style="flex:none;width:5px;height:5px;border-radius:50%;background:#7ECBA0"></span>
+            <span style="min-width:0;font:500 11px/1 'JetBrains Mono',monospace;color:#B4B5BC;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">mbp-m3</span>
+            <span aria-hidden="true" style="flex:none;width:4.5px;height:4.5px;border-right:1.4px solid #6E6E76;border-bottom:1.4px solid #6E6E76;transform:rotate(45deg) translateY(-1.5px)"></span>
+            <span style="flex:1"></span>
+            <span aria-label="Attention" style="position:relative;width:12px;height:12px;flex:none;color:#8C8D95;display:block">
+              <span style="position:absolute;left:2px;top:1px;width:8px;height:7px;border:1.4px solid currentColor;border-bottom:0;border-radius:4.5px 4.5px 0 0;box-sizing:border-box"></span>
+              <span style="position:absolute;left:0;top:8px;width:12px;height:1.4px;background:currentColor;border-radius:1px"></span>
+              <span style="position:absolute;left:5px;top:10px;width:2px;height:1.5px;background:currentColor;border-radius:0 0 2px 2px"></span>
+            </span>
+          </button>
+
+          <div style="height:1px;flex:none;background:#2A2E33;margin:5px 0 4px"></div>
+
+          <button type="button" style="appearance:none;border:0;background:none;flex:none;height:28px;display:flex;align-items:center;gap:8px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:rgba(217,119,87,.09)">
+            <span aria-hidden="true" style="position:relative;width:12px;height:12px;flex:none;display:block">
+              <span style="position:absolute;left:0;top:5.25px;width:12px;height:1.5px;background:#D97757;border-radius:1px"></span>
+              <span style="position:absolute;top:0;left:5.25px;height:12px;width:1.5px;background:#D97757;border-radius:1px"></span>
+            </span>
+            <span style="font:500 12.5px/1 'Inter',sans-serif;color:#D97757">New session</span>
+            <span style="flex:1"></span>
+            <span style="font:500 10px/1 'JetBrains Mono',monospace;color:#6E6E76">⌘N</span>
+          </button>
+          <button type="button" style="appearance:none;border:0;background:none;flex:none;height:28px;display:flex;align-items:center;gap:8px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:#1E2125">
+            <span aria-hidden="true" style="position:relative;width:12px;height:11px;flex:none;display:block">
+              <span style="position:absolute;left:0;top:2.5px;width:12px;height:8px;border:1.5px solid #8C8D95;border-radius:2px;box-sizing:border-box"></span>
+              <span style="position:absolute;left:1px;top:.5px;width:5px;height:3px;border:1.5px solid #8C8D95;border-bottom:0;border-radius:2px 2px 0 0;box-sizing:border-box"></span>
+            </span>
+            <span style="font:400 12.5px/1 'Inter',sans-serif;color:#B4B5BC">Open folder…</span>
+          </button>
+
+          <div style="height:1px;flex:none;background:#2A2E33;margin:4px 0 0"></div>
+
+          <div style="flex:1;min-height:0;overflow:hidden;display:flex;flex-direction:column">
+            <div style="padding:10px 12px 4px;font:600 9px/1 'JetBrains Mono',monospace;letter-spacing:.15em;color:#6E6E76">PINNED</div>
+            <sc-for list="{{ pinned }}" as="s" hint-placeholder-count="2">
+              <button type="button" style="appearance:none;border:0;background:none;flex:none;height:29px;display:flex;align-items:center;gap:8px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:#1E2125">
+                <span aria-hidden="true" style="flex:none;width:4px;height:4px;border-radius:1px;background:#4A4E55;transform:rotate(45deg)"></span>
+                <span style="flex:1;min-width:0;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ s.t }}</span>
+                <span style="flex:none;font:400 9.5px/1 'JetBrains Mono',monospace;color:#6E6E76">{{ s.m }}</span>
+              </button>
+            </sc-for>
+
+            <div style="padding:12px 12px 4px;font:600 9px/1 'JetBrains Mono',monospace;letter-spacing:.15em;color:#6E6E76">RUNNING</div>
+            <button type="button" style="appearance:none;border:0;flex:none;height:29px;display:flex;align-items:center;gap:8px;padding:0 12px 0 10px;cursor:pointer;text-align:left;background:#1E2125;box-shadow:inset 2px 0 0 #D97757">
+              <span style="flex:none;width:5px;height:5px;border-radius:50%;background:#7ECBA0;box-shadow:0 0 0 2.5px rgba(126,203,160,.14)"></span>
+              <span style="flex:1;min-width:0;font:500 12.5px/1 'Inter',sans-serif;color:#F3F3F4;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">fix flaky auth test</span>
+              <span style="flex:none;font:400 9.5px/1 'JetBrains Mono',monospace;color:#8C8D95">2m</span>
+            </button>
+            <sc-for list="{{ running }}" as="s" hint-placeholder-count="2">
+              <button type="button" style="appearance:none;border:0;background:none;flex:none;height:29px;display:flex;align-items:center;gap:8px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:#1E2125">
+                <span style="flex:none;width:5px;height:5px;border-radius:50%;background:#7ECBA0;box-shadow:0 0 0 2.5px rgba(126,203,160,.14)"></span>
+                <span style="flex:1;min-width:0;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ s.t }}</span>
+                <span style="flex:none;font:400 9.5px/1 'JetBrains Mono',monospace;color:#6E6E76">{{ s.m }}</span>
+              </button>
+            </sc-for>
+
+            <div style="padding:12px 12px 4px;font:600 9px/1 'JetBrains Mono',monospace;letter-spacing:.15em;color:#6E6E76">RECENT</div>
+            <sc-for list="{{ recent }}" as="s" hint-placeholder-count="9">
+              <button type="button" style="appearance:none;border:0;background:none;flex:none;height:29px;display:flex;align-items:center;gap:8px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:#1E2125">
+                <span style="flex:1;min-width:0;font:400 12.5px/1 'Inter',sans-serif;color:#B4B5BC;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ s.t }}</span>
+                <span style="flex:none;font:400 9.5px/1 'JetBrains Mono',monospace;color:#6E6E76">{{ s.m }}</span>
+              </button>
+            </sc-for>
+            <div style="flex:1"></div>
+          </div>
+
+          <div style="height:1px;flex:none;background:#2A2E33"></div>
+          <div style="flex:none;height:30px;display:flex;align-items:center;gap:8px;padding:0 12px">
+            <span style="font:400 11.5px/1 'Inter',sans-serif;color:#8C8D95">Help &amp; support</span>
+            <span style="flex:1"></span>
+            <span style="font:400 10px/1 'JetBrains Mono',monospace;color:#6E6E76">v1.9.1</span>
+            <span aria-label="Settings" style="font:400 12px/1 'Inter',sans-serif;color:#8C8D95">⚙︎</span>
+          </div>
+        </div>
+
+        <div style="flex:1;min-width:0;display:flex;flex-direction:column;background:#0E0F11">
+          <div style="height:38px;flex:none;display:flex;align-items:center;gap:10px;padding:0 12px 0 16px;border-bottom:1px solid #2A2E33">
+            <span style="font:600 13px/1 'Inter',sans-serif;letter-spacing:-.005em;color:#F3F3F4">fix flaky auth test</span>
+            <span style="flex:none;display:flex;align-items:center;height:20px;padding:0 7px;border-radius:5px;border:1px solid #2A2E33;background:#16181B;font:500 10px/1 'JetBrains Mono',monospace;color:#B4B5BC">⎇ fix/auth-retry</span>
+            <span style="flex:none;font:400 11px/1 'JetBrains Mono',monospace;color:#6E6E76">~/dev/api-gateway</span>
+            <span style="flex:1"></span>
+            <span style="flex:none;font:400 11px/1 'JetBrains Mono',monospace;color:#6E6E76">claude-sonnet-4.5</span>
+            <button type="button" aria-label="Connection status" style="appearance:none;border:0;background:none;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none" style-hover="background:#1E2125">
+              <span style="width:7px;height:7px;border-radius:50%;background:#7ECBA0;box-shadow:0 0 0 3px rgba(126,203,160,.14)"></span>
+            </button>
+          </div>
+
+          <div style="flex:1;min-height:0;overflow:hidden;padding:22px 28px;display:flex;flex-direction:column;gap:18px">
+            <div style="display:flex;gap:11px">
+              <span style="flex:none;width:22px;height:22px;border-radius:6px;border:1px solid #2A2E33;background:#16181B;display:flex;align-items:center;justify-content:center;font:500 10px/1 'JetBrains Mono',monospace;color:#8C8D95">R</span>
+              <div style="flex:1;min-width:0;font:400 13px/1.6 'Inter',sans-serif;color:#E6E6E9;max-width:640px;text-wrap:pretty">The auth test fails about one run in six on CI. Can you find the race and fix it without adding sleeps?</div>
+            </div>
+            <div style="display:flex;gap:11px">
+              <span style="flex:none;width:22px;height:22px;border-radius:6px;background:#D97757;display:flex;align-items:center;justify-content:center;font:600 10px/1 'JetBrains Mono',monospace;color:#160C07">C</span>
+              <div style="flex:1;min-width:0;max-width:700px;display:flex;flex-direction:column;gap:12px">
+                <div style="font:400 13px/1.6 'Inter',sans-serif;color:#E6E6E9;text-wrap:pretty">The token refresh in <span style="font:400 12px/1 'JetBrains Mono',monospace;color:#D9A57C">setupAuth()</span> is not awaited, so the first request can go out with the stale token. Reading the two call sites now.</div>
+                <div style="border:1px solid #2A2E33;border-radius:8px;background:#16181B;overflow:hidden">
+                  <div style="height:28px;display:flex;align-items:center;gap:8px;padding:0 11px;border-bottom:1px solid #2A2E33">
+                    <span style="width:5px;height:5px;border-radius:50%;background:#7ECBA0"></span>
+                    <span style="font:500 10.5px/1 'JetBrains Mono',monospace;color:#B4B5BC">Read</span>
+                    <span style="font:400 10.5px/1 'JetBrains Mono',monospace;color:#6E6E76">tests/auth/setup.ts</span>
+                    <span style="flex:1"></span>
+                    <span style="font:400 10px/1 'JetBrains Mono',monospace;color:#6E6E76">142 lines</span>
+                  </div>
+                  <div style="padding:10px 11px;font:400 11.5px/1.7 'JetBrains Mono',monospace;color:#8C8D95;white-space:pre">  38  const t = refreshToken(ctx)
+  39  client.use(bearer(t))
+  40  return client</div>
+                </div>
+                <div style="font:400 13px/1.6 'Inter',sans-serif;color:#E6E6E9;text-wrap:pretty">Line 38 returns a promise that is dropped. I will await it and thread the token through explicitly.</div>
+              </div>
+            </div>
+            <div style="flex:1"></div>
+            <div style="flex:none;border:1px solid #2A2E33;border-radius:10px;background:#16181B;padding:11px 13px;display:flex;align-items:center;gap:10px">
+              <span style="flex:1;font:400 13px/1 'Inter',sans-serif;color:#6E6E76">Reply to Claude…</span>
+              <span style="flex:none;font:500 10px/1 'JetBrains Mono',monospace;color:#6E6E76">⏎</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div style="font:500 10.5px/1 'JetBrains Mono',monospace;letter-spacing:.16em;text-transform:uppercase;color:#6E6E76;margin-bottom:12px">2 · Sidebar collapsed — controls move into the chat sub-header, single row</div>
+      <div data-screen-label="Desktop v2 · sidebar collapsed" style="width:1280px;height:800px;border-radius:11px;overflow:hidden;border:1px solid #2A2E33;background:#0E0F11;display:flex;flex-direction:column;box-shadow:0 40px 90px -40px rgba(0,0,0,.8)">
+
+        <div style="height:38px;flex:none;display:flex;align-items:center;gap:10px;padding:0 12px;border-bottom:1px solid #2A2E33">
+          <span style="display:flex;gap:8px;align-items:center;flex:none;margin-right:2px">
+            <span style="width:12px;height:12px;border-radius:50%;background:#FF5F57"></span>
+            <span style="width:12px;height:12px;border-radius:50%;background:#FEBC2E"></span>
+            <span style="width:12px;height:12px;border-radius:50%;background:#28C840"></span>
+          </span>
+          <span style="display:flex;align-items:center;gap:2px;flex:none">
+            <button type="button" aria-label="Toggle sidebar" style="appearance:none;border:0;background:#1E2125;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none">
+              <span aria-hidden="true" style="position:relative;width:15px;height:13px;display:block">
+                <span style="position:absolute;inset:0;border:1.5px solid #E6E6E9;border-radius:2.5px;box-sizing:border-box"></span>
+                <span style="position:absolute;left:5px;top:0;bottom:0;width:1.5px;background:#E6E6E9"></span>
+                <span style="position:absolute;left:0;top:0;bottom:0;width:5px;background:rgba(230,230,233,.22)"></span>
+              </span>
+            </button>
+            <button type="button" aria-label="Previous session" style="appearance:none;border:0;background:none;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none" style-hover="background:#1E2125">
+              <span aria-hidden="true" style="width:6px;height:6px;border-left:1.5px solid #B4B5BC;border-bottom:1.5px solid #B4B5BC;transform:rotate(45deg) translate(1px,-1px)"></span>
+            </button>
+            <button type="button" aria-label="Next session" style="appearance:none;border:0;background:none;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none" style-hover="background:#1E2125">
+              <span aria-hidden="true" style="width:6px;height:6px;border-right:1.5px solid #B4B5BC;border-top:1.5px solid #B4B5BC;transform:rotate(45deg) translate(-1px,1px)"></span>
+            </button>
+          </span>
+          <span style="flex:none;width:1px;height:16px;background:#2A2E33;margin:0 2px"></span>
+          <span style="font:600 13px/1 'Inter',sans-serif;letter-spacing:-.005em;color:#F3F3F4">fix flaky auth test</span>
+          <span style="flex:none;display:flex;align-items:center;height:20px;padding:0 7px;border-radius:5px;border:1px solid #2A2E33;background:#16181B;font:500 10px/1 'JetBrains Mono',monospace;color:#B4B5BC">⎇ fix/auth-retry</span>
+          <span style="flex:none;font:400 11px/1 'JetBrains Mono',monospace;color:#6E6E76">~/dev/api-gateway</span>
+          <span style="flex:1"></span>
+          <span style="flex:none;font:400 11px/1 'JetBrains Mono',monospace;color:#6E6E76">claude-sonnet-4.5</span>
+          <button type="button" aria-label="Connection status" style="appearance:none;border:0;background:none;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none" style-hover="background:#1E2125">
+            <span style="width:7px;height:7px;border-radius:50%;background:#7ECBA0;box-shadow:0 0 0 3px rgba(126,203,160,.14)"></span>
+          </button>
+        </div>
+
+        <div style="flex:1;min-height:0;overflow:hidden;padding:26px 0;display:flex;flex-direction:column;align-items:center">
+          <div style="width:780px;display:flex;flex-direction:column;gap:18px;flex:1;min-height:0">
+            <div style="display:flex;gap:11px">
+              <span style="flex:none;width:22px;height:22px;border-radius:6px;border:1px solid #2A2E33;background:#16181B;display:flex;align-items:center;justify-content:center;font:500 10px/1 'JetBrains Mono',monospace;color:#8C8D95">R</span>
+              <div style="flex:1;min-width:0;font:400 13px/1.6 'Inter',sans-serif;color:#E6E6E9;text-wrap:pretty">The auth test fails about one run in six on CI. Can you find the race and fix it without adding sleeps?</div>
+            </div>
+            <div style="display:flex;gap:11px">
+              <span style="flex:none;width:22px;height:22px;border-radius:6px;background:#D97757;display:flex;align-items:center;justify-content:center;font:600 10px/1 'JetBrains Mono',monospace;color:#160C07">C</span>
+              <div style="flex:1;min-width:0;display:flex;flex-direction:column;gap:12px">
+                <div style="font:400 13px/1.6 'Inter',sans-serif;color:#E6E6E9;text-wrap:pretty">The token refresh in <span style="font:400 12px/1 'JetBrains Mono',monospace;color:#D9A57C">setupAuth()</span> is not awaited, so the first request can go out with the stale token. Reading the two call sites now.</div>
+                <div style="border:1px solid #2A2E33;border-radius:8px;background:#16181B;overflow:hidden">
+                  <div style="height:28px;display:flex;align-items:center;gap:8px;padding:0 11px;border-bottom:1px solid #2A2E33">
+                    <span style="width:5px;height:5px;border-radius:50%;background:#7ECBA0"></span>
+                    <span style="font:500 10.5px/1 'JetBrains Mono',monospace;color:#B4B5BC">Read</span>
+                    <span style="font:400 10.5px/1 'JetBrains Mono',monospace;color:#6E6E76">tests/auth/setup.ts</span>
+                    <span style="flex:1"></span>
+                    <span style="font:400 10px/1 'JetBrains Mono',monospace;color:#6E6E76">142 lines</span>
+                  </div>
+                  <div style="padding:10px 11px;font:400 11.5px/1.7 'JetBrains Mono',monospace;color:#8C8D95;white-space:pre">  38  const t = refreshToken(ctx)
+  39  client.use(bearer(t))
+  40  return client</div>
+                </div>
+              </div>
+            </div>
+            <div style="flex:1"></div>
+            <div style="flex:none;border:1px solid #2A2E33;border-radius:10px;background:#16181B;padding:11px 13px;display:flex;align-items:center;gap:10px">
+              <span style="flex:1;font:400 13px/1 'Inter',sans-serif;color:#6E6E76">Reply to Claude…</span>
+              <span style="flex:none;font:500 10px/1 'JetBrains Mono',monospace;color:#6E6E76">⏎</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div style="width:1280px;font:400 12.5px/1.6 'Inter',sans-serif;color:#8C8D95;margin-top:12px;text-wrap:pretty">The leading cluster (lights, toggle, ‹ ›) is separated from the session title by a 16px hairline rule, so the sub-header still reads title-first. No band is added: the row stays 38px.</div>
+    </div>
+
+    <div>
+      <div style="font:500 10.5px/1 'JetBrains Mono',monospace;letter-spacing:.16em;text-transform:uppercase;color:#6E6E76;margin-bottom:12px">3 · Detail — hover, tooltips, disabled forward (2× scale)</div>
+      <div data-screen-label="Desktop v2 · chrome detail" style="width:1280px;border-radius:11px;border:1px solid #2A2E33;background:#0E0F11;padding:34px 0 44px;overflow:hidden">
+        <div style="width:1280px;height:500px;overflow:hidden">
+          <div style="transform:scale(2);transform-origin:top left;width:640px;height:250px">
+            <div style="width:640px;background:#0E0F11;display:flex">
+
+              <div style="width:260px;flex:none;background:#16181B;border-right:1px solid #2A2E33;height:250px;display:flex;flex-direction:column;position:relative">
+                <div style="height:38px;flex:none;display:flex;align-items:center;gap:2px;padding:0 10px 0 12px">
+                  <span style="display:flex;gap:8px;align-items:center;flex:none;margin-right:10px">
+                    <span style="width:12px;height:12px;border-radius:50%;background:#FF5F57"></span>
+                    <span style="width:12px;height:12px;border-radius:50%;background:#FEBC2E"></span>
+                    <span style="width:12px;height:12px;border-radius:50%;background:#28C840"></span>
+                  </span>
+                  <span style="width:28px;height:28px;border-radius:6px;background:#1E2125;display:flex;align-items:center;justify-content:center;flex:none">
+                    <span aria-hidden="true" style="position:relative;width:15px;height:13px;display:block">
+                      <span style="position:absolute;inset:0;border:1.5px solid #E6E6E9;border-radius:2.5px;box-sizing:border-box"></span>
+                      <span style="position:absolute;left:5px;top:0;bottom:0;width:1.5px;background:#E6E6E9"></span>
+                    </span>
+                  </span>
+                  <span style="width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;flex:none">
+                    <span aria-hidden="true" style="width:6px;height:6px;border-left:1.5px solid #B4B5BC;border-bottom:1.5px solid #B4B5BC;transform:rotate(45deg) translate(1px,-1px)"></span>
+                  </span>
+                  <span style="width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;flex:none">
+                    <span aria-hidden="true" style="width:6px;height:6px;border-right:1.5px solid #4A4E55;border-top:1.5px solid #4A4E55;transform:rotate(45deg) translate(-1px,1px)"></span>
+                  </span>
+                  <div style="flex:1;min-width:0;margin-left:6px;height:26px;border:1px solid #2A2E33;border-radius:7px;background:#0E0F11;display:flex;align-items:center;gap:6px;padding:0 8px">
+                    <span aria-hidden="true" style="position:relative;width:12px;height:12px;flex:none;display:block">
+                      <span style="position:absolute;left:0;top:0;width:9px;height:9px;border:1.5px solid #8C8D95;border-radius:50%;box-sizing:border-box"></span>
+                      <span style="position:absolute;left:7.5px;top:8px;width:5px;height:1.5px;background:#8C8D95;border-radius:1px;transform:rotate(45deg);transform-origin:left center"></span>
+                    </span>
+                    <span style="flex:1;min-width:0;font:400 12px/1 'Inter',sans-serif;color:#6E6E76;white-space:nowrap;overflow:hidden">Search</span>
+                  </div>
+                </div>
+
+                <div style="height:56px;flex:none"></div>
+
+                <div style="flex:none;height:26px;display:flex;align-items:center;gap:7px;padding:0 12px">
+                  <span style="flex:none;width:5px;height:5px;border-radius:50%;background:#7ECBA0"></span>
+                  <span style="font:500 11px/1 'JetBrains Mono',monospace;color:#B4B5BC">mbp-m3</span>
+                  <span aria-hidden="true" style="flex:none;width:4.5px;height:4.5px;border-right:1.4px solid #6E6E76;border-bottom:1.4px solid #6E6E76;transform:rotate(45deg) translateY(-1.5px)"></span>
+                  <span style="flex:1"></span>
+                  <span style="position:relative;width:12px;height:12px;flex:none;color:#8C8D95;display:block">
+                    <span style="position:absolute;left:2px;top:1px;width:8px;height:7px;border:1.4px solid currentColor;border-bottom:0;border-radius:4.5px 4.5px 0 0;box-sizing:border-box"></span>
+                    <span style="position:absolute;left:0;top:8px;width:12px;height:1.4px;background:currentColor;border-radius:1px"></span>
+                    <span style="position:absolute;left:5px;top:10px;width:2px;height:1.5px;background:currentColor;border-radius:0 0 2px 2px"></span>
+                  </span>
+                </div>
+                <div style="height:1px;flex:none;background:#2A2E33;margin:5px 0 4px"></div>
+                <div style="flex:none;height:28px;display:flex;align-items:center;gap:8px;padding:0 12px;background:rgba(217,119,87,.09)">
+                  <span aria-hidden="true" style="position:relative;width:12px;height:12px;flex:none;display:block">
+                    <span style="position:absolute;left:0;top:5.25px;width:12px;height:1.5px;background:#D97757;border-radius:1px"></span>
+                    <span style="position:absolute;top:0;left:5.25px;height:12px;width:1.5px;background:#D97757;border-radius:1px"></span>
+                  </span>
+                  <span style="font:500 12.5px/1 'Inter',sans-serif;color:#D97757">New session</span>
+                  <span style="flex:1"></span>
+                  <span style="font:500 10px/1 'JetBrains Mono',monospace;color:#6E6E76">⌘N</span>
+                </div>
+                <div style="flex:none;height:28px;display:flex;align-items:center;gap:8px;padding:0 12px">
+                  <span aria-hidden="true" style="position:relative;width:12px;height:11px;flex:none;display:block">
+                    <span style="position:absolute;left:0;top:2.5px;width:12px;height:8px;border:1.5px solid #8C8D95;border-radius:2px;box-sizing:border-box"></span>
+                    <span style="position:absolute;left:1px;top:.5px;width:5px;height:3px;border:1.5px solid #8C8D95;border-bottom:0;border-radius:2px 2px 0 0;box-sizing:border-box"></span>
+                  </span>
+                  <span style="font:400 12.5px/1 'Inter',sans-serif;color:#B4B5BC">Open folder…</span>
+                </div>
+
+                <span style="position:absolute;left:52px;top:42px;display:flex;align-items:center;gap:6px;height:21px;padding:0 7px;border-radius:5px;border:1px solid #2A2E33;background:#1E2125;box-shadow:0 6px 16px -6px rgba(0,0,0,.7);white-space:nowrap">
+                  <span style="font:400 10.5px/1 'Inter',sans-serif;color:#E6E6E9">Toggle sidebar</span>
+                  <span style="font:500 10px/1 'JetBrains Mono',monospace;color:#8C8D95">⌘\</span>
+                </span>
+                <span style="position:absolute;left:132px;top:68px;display:flex;align-items:center;gap:6px;height:21px;padding:0 7px;border-radius:5px;border:1px solid #2A2E33;background:#1E2125;box-shadow:0 6px 16px -6px rgba(0,0,0,.7);white-space:nowrap;opacity:.45">
+                  <span style="font:400 10.5px/1 'Inter',sans-serif;color:#E6E6E9">Next session</span>
+                  <span style="font:500 10px/1 'JetBrains Mono',monospace;color:#8C8D95">⌘]</span>
+                </span>
+              </div>
+
+              <div style="flex:1;height:250px;background:#0E0F11">
+                <div style="height:38px;display:flex;align-items:center;gap:10px;padding:0 12px 0 16px;border-bottom:1px solid #2A2E33">
+                  <span style="font:600 13px/1 'Inter',sans-serif;color:#F3F3F4">fix flaky auth test</span>
+                  <span style="flex:none;display:flex;align-items:center;height:20px;padding:0 7px;border-radius:5px;border:1px solid #2A2E33;background:#16181B;font:500 10px/1 'JetBrains Mono',monospace;color:#B4B5BC">⎇ fix/auth-retry</span>
+                  <span style="flex:1"></span>
+                  <span style="width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;flex:none">
+                    <span style="width:7px;height:7px;border-radius:50%;background:#7ECBA0;box-shadow:0 0 0 3px rgba(126,203,160,.14)"></span>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div style="width:1280px;font:400 12.5px/1.6 'Inter',sans-serif;color:#8C8D95;margin-top:12px;text-wrap:pretty">Hover raises a rounded-6 #1E2125 plate under the 28px hit target; the disabled forward chevron drops to #4A4E55 and takes no hover or tooltip (faded here only to place it). At 260px the row leaves 78px for the search field, which fits the magnifier and placeholder but not the ⌘K hint — the hint is dropped rather than the field shrunk. The 56px gap under the control row exists only in this detail frame, to clear the tooltips.</div>
+    </div>
+
+    <div>
+      <div style="font:500 10.5px/1 'JetBrains Mono',monospace;letter-spacing:.16em;text-transform:uppercase;color:#6E6E76;margin-bottom:12px">4 · Split panes — two conversation columns, left focused</div>
+      <div data-screen-label="Desktop v2 · split panes" style="width:1280px;height:800px;border-radius:11px;overflow:hidden;border:1px solid #2A2E33;background:#0E0F11;display:flex;box-shadow:0 40px 90px -40px rgba(0,0,0,.8)">
+
+        <div style="width:260px;flex:none;display:flex;flex-direction:column;background:#16181B;border-right:1px solid #2A2E33">
+          <div style="height:38px;flex:none;display:flex;align-items:center;gap:2px;padding:0 10px 0 12px">
+            <span style="display:flex;gap:8px;align-items:center;flex:none;margin-right:10px">
+              <span style="width:12px;height:12px;border-radius:50%;background:#FF5F57"></span>
+              <span style="width:12px;height:12px;border-radius:50%;background:#FEBC2E"></span>
+              <span style="width:12px;height:12px;border-radius:50%;background:#28C840"></span>
+            </span>
+            <button type="button" aria-label="Toggle sidebar" style="appearance:none;border:0;background:none;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none" style-hover="background:#1E2125">
+              <span aria-hidden="true" style="position:relative;width:15px;height:13px;display:block">
+                <span style="position:absolute;inset:0;border:1.5px solid #B4B5BC;border-radius:2.5px;box-sizing:border-box"></span>
+                <span style="position:absolute;left:5px;top:0;bottom:0;width:1.5px;background:#B4B5BC"></span>
+              </span>
+            </button>
+            <button type="button" aria-label="Previous session" style="appearance:none;border:0;background:none;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none" style-hover="background:#1E2125">
+              <span aria-hidden="true" style="width:6px;height:6px;border-left:1.5px solid #B4B5BC;border-bottom:1.5px solid #B4B5BC;transform:rotate(45deg) translate(1px,-1px)"></span>
+            </button>
+            <button type="button" aria-label="Next session" disabled="disabled" style="appearance:none;border:0;background:none;width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:default;flex:none">
+              <span aria-hidden="true" style="width:6px;height:6px;border-right:1.5px solid #4A4E55;border-top:1.5px solid #4A4E55;transform:rotate(45deg) translate(-1px,1px)"></span>
+            </button>
+            <div style="flex:1;min-width:0;margin-left:6px;height:26px;border:1px solid #2A2E33;border-radius:7px;background:#0E0F11;display:flex;align-items:center;gap:6px;padding:0 8px;cursor:text" style-hover="border-color:#3A3F46">
+              <span aria-hidden="true" style="position:relative;width:12px;height:12px;flex:none;display:block">
+                <span style="position:absolute;left:0;top:0;width:9px;height:9px;border:1.5px solid #8C8D95;border-radius:50%;box-sizing:border-box"></span>
+                <span style="position:absolute;left:7.5px;top:8px;width:5px;height:1.5px;background:#8C8D95;border-radius:1px;transform:rotate(45deg);transform-origin:left center"></span>
+              </span>
+              <span style="flex:1;min-width:0;font:400 12px/1 'Inter',sans-serif;color:#6E6E76;white-space:nowrap;overflow:hidden">Search</span>
+            </div>
+          </div>
+
+          <button type="button" aria-haspopup="menu" style="appearance:none;border:0;background:none;flex:none;height:26px;display:flex;align-items:center;gap:7px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:#1E2125">
+            <span style="flex:none;width:5px;height:5px;border-radius:50%;background:#7ECBA0"></span>
+            <span style="min-width:0;font:500 11px/1 'JetBrains Mono',monospace;color:#B4B5BC;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">mbp-m3</span>
+            <span aria-hidden="true" style="flex:none;width:4.5px;height:4.5px;border-right:1.4px solid #6E6E76;border-bottom:1.4px solid #6E6E76;transform:rotate(45deg) translateY(-1.5px)"></span>
+            <span style="flex:1"></span>
+            <span aria-label="Attention" style="position:relative;width:12px;height:12px;flex:none;color:#8C8D95;display:block">
+              <span style="position:absolute;left:2px;top:1px;width:8px;height:7px;border:1.4px solid currentColor;border-bottom:0;border-radius:4.5px 4.5px 0 0;box-sizing:border-box"></span>
+              <span style="position:absolute;left:0;top:8px;width:12px;height:1.4px;background:currentColor;border-radius:1px"></span>
+              <span style="position:absolute;left:5px;top:10px;width:2px;height:1.5px;background:currentColor;border-radius:0 0 2px 2px"></span>
+            </span>
+          </button>
+
+          <div style="height:1px;flex:none;background:#2A2E33;margin:5px 0 4px"></div>
+
+          <button type="button" style="appearance:none;border:0;background:none;flex:none;height:28px;display:flex;align-items:center;gap:8px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:rgba(217,119,87,.09)">
+            <span aria-hidden="true" style="position:relative;width:12px;height:12px;flex:none;display:block">
+              <span style="position:absolute;left:0;top:5.25px;width:12px;height:1.5px;background:#D97757;border-radius:1px"></span>
+              <span style="position:absolute;top:0;left:5.25px;height:12px;width:1.5px;background:#D97757;border-radius:1px"></span>
+            </span>
+            <span style="font:500 12.5px/1 'Inter',sans-serif;color:#D97757">New session</span>
+            <span style="flex:1"></span>
+            <span style="font:500 10px/1 'JetBrains Mono',monospace;color:#6E6E76">⌘N</span>
+          </button>
+          <button type="button" style="appearance:none;border:0;background:none;flex:none;height:28px;display:flex;align-items:center;gap:8px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:#1E2125">
+            <span aria-hidden="true" style="position:relative;width:12px;height:11px;flex:none;display:block">
+              <span style="position:absolute;left:0;top:2.5px;width:12px;height:8px;border:1.5px solid #8C8D95;border-radius:2px;box-sizing:border-box"></span>
+              <span style="position:absolute;left:1px;top:.5px;width:5px;height:3px;border:1.5px solid #8C8D95;border-bottom:0;border-radius:2px 2px 0 0;box-sizing:border-box"></span>
+            </span>
+            <span style="font:400 12.5px/1 'Inter',sans-serif;color:#B4B5BC">Open folder…</span>
+          </button>
+
+          <div style="height:1px;flex:none;background:#2A2E33;margin:4px 0 0"></div>
+
+          <div style="flex:1;min-height:0;overflow:hidden;display:flex;flex-direction:column">
+            <div style="padding:10px 12px 4px;font:600 9px/1 'JetBrains Mono',monospace;letter-spacing:.15em;color:#6E6E76">PINNED</div>
+            <sc-for list="{{ pinned }}" as="s" hint-placeholder-count="2">
+              <button type="button" style="appearance:none;border:0;background:none;flex:none;height:29px;display:flex;align-items:center;gap:8px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:#1E2125">
+                <span aria-hidden="true" style="flex:none;width:4px;height:4px;border-radius:1px;background:#4A4E55;transform:rotate(45deg)"></span>
+                <span style="flex:1;min-width:0;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ s.t }}</span>
+                <span style="flex:none;font:400 9.5px/1 'JetBrains Mono',monospace;color:#6E6E76">{{ s.m }}</span>
+              </button>
+            </sc-for>
+
+            <div style="padding:12px 12px 4px;font:600 9px/1 'JetBrains Mono',monospace;letter-spacing:.15em;color:#6E6E76">RUNNING</div>
+            <button type="button" style="appearance:none;border:0;flex:none;height:29px;display:flex;align-items:center;gap:8px;padding:0 12px 0 10px;cursor:pointer;text-align:left;background:#1E2125;box-shadow:inset 2px 0 0 #D97757">
+              <span style="flex:none;width:5px;height:5px;border-radius:50%;background:#7ECBA0;box-shadow:0 0 0 2.5px rgba(126,203,160,.14)"></span>
+              <span style="flex:1;min-width:0;font:500 12.5px/1 'Inter',sans-serif;color:#F3F3F4;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">fix flaky auth test</span>
+              <span style="flex:none;font:400 9.5px/1 'JetBrains Mono',monospace;color:#8C8D95">2m</span>
+            </button>
+            <button type="button" style="appearance:none;border:0;flex:none;height:29px;display:flex;align-items:center;gap:8px;padding:0 12px 0 10px;cursor:pointer;text-align:left;background:#1A1C20;box-shadow:inset 2px 0 0 #4A4E55">
+              <span style="flex:none;width:5px;height:5px;border-radius:50%;background:#7ECBA0;box-shadow:0 0 0 2.5px rgba(126,203,160,.14)"></span>
+              <span style="flex:1;min-width:0;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">migrate billing schema</span>
+              <span style="flex:none;font:400 9.5px/1 'JetBrains Mono',monospace;color:#6E6E76">14m</span>
+            </button>
+            <button type="button" style="appearance:none;border:0;background:none;flex:none;height:29px;display:flex;align-items:center;gap:8px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:#1E2125">
+              <span style="flex:none;width:5px;height:5px;border-radius:50%;background:#7ECBA0;box-shadow:0 0 0 2.5px rgba(126,203,160,.14)"></span>
+              <span style="flex:1;min-width:0;font:400 12.5px/1 'Inter',sans-serif;color:#E6E6E9;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">docs: rewrite quickstart</span>
+              <span style="flex:none;font:400 9.5px/1 'JetBrains Mono',monospace;color:#6E6E76">31m</span>
+            </button>
+
+            <div style="padding:12px 12px 4px;font:600 9px/1 'JetBrains Mono',monospace;letter-spacing:.15em;color:#6E6E76">RECENT</div>
+            <sc-for list="{{ recent }}" as="s" hint-placeholder-count="9">
+              <button type="button" style="appearance:none;border:0;background:none;flex:none;height:29px;display:flex;align-items:center;gap:8px;padding:0 12px;cursor:pointer;text-align:left" style-hover="background:#1E2125">
+                <span style="flex:1;min-width:0;font:400 12.5px/1 'Inter',sans-serif;color:#B4B5BC;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ s.t }}</span>
+                <span style="flex:none;font:400 9.5px/1 'JetBrains Mono',monospace;color:#6E6E76">{{ s.m }}</span>
+              </button>
+            </sc-for>
+            <div style="flex:1"></div>
+          </div>
+
+          <div style="height:1px;flex:none;background:#2A2E33"></div>
+          <div style="flex:none;height:30px;display:flex;align-items:center;gap:8px;padding:0 12px">
+            <span style="font:400 11.5px/1 'Inter',sans-serif;color:#8C8D95">Help &amp; support</span>
+            <span style="flex:1"></span>
+            <span style="font:400 10px/1 'JetBrains Mono',monospace;color:#6E6E76">v1.9.1</span>
+            <span aria-label="Settings" style="font:400 12px/1 'Inter',sans-serif;color:#8C8D95">⚙︎</span>
+          </div>
+        </div>
+
+        <div style="flex:1;min-width:0;display:flex;flex-direction:column;background:#0E0F11;border-right:1px solid #2A2E33">
+          <div style="height:38px;flex:none;display:flex;align-items:center;gap:9px;padding:0 12px 0 14px;border-bottom:1px solid #2A2E33;box-shadow:inset 0 2px 0 #D97757">
+            <span style="font:600 13px/1 'Inter',sans-serif;letter-spacing:-.005em;color:#F3F3F4;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">fix flaky auth test</span>
+            <span style="flex:none;display:flex;align-items:center;height:20px;padding:0 7px;border-radius:5px;border:1px solid #2A2E33;background:#16181B;font:500 10px/1 'JetBrains Mono',monospace;color:#B4B5BC">⎇ fix/auth-retry</span>
+            <span style="flex:1;min-width:0;font:400 11px/1 'JetBrains Mono',monospace;color:#6E6E76;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">~/dev/api-gateway</span>
+            <button type="button" aria-label="Close pane" style="appearance:none;border:0;background:none;width:22px;height:22px;border-radius:5px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none;font:400 12px/1 'Inter',sans-serif;color:#8C8D95" style-hover="background:#1E2125">✕</button>
+          </div>
+          <div style="flex:1;min-height:0;overflow:hidden;padding:20px 18px;display:flex;flex-direction:column;gap:16px">
+            <div style="display:flex;gap:10px">
+              <span style="flex:none;width:20px;height:20px;border-radius:6px;border:1px solid #2A2E33;background:#16181B;display:flex;align-items:center;justify-content:center;font:500 9.5px/1 'JetBrains Mono',monospace;color:#8C8D95">R</span>
+              <div style="flex:1;min-width:0;font:400 12.5px/1.6 'Inter',sans-serif;color:#E6E6E9;text-wrap:pretty">The auth test fails about one run in six on CI. Can you find the race and fix it without adding sleeps?</div>
+            </div>
+            <div style="display:flex;gap:10px">
+              <span style="flex:none;width:20px;height:20px;border-radius:6px;background:#D97757;display:flex;align-items:center;justify-content:center;font:600 9.5px/1 'JetBrains Mono',monospace;color:#160C07">C</span>
+              <div style="flex:1;min-width:0;display:flex;flex-direction:column;gap:11px">
+                <div style="font:400 12.5px/1.6 'Inter',sans-serif;color:#E6E6E9;text-wrap:pretty">The token refresh in <span style="font:400 11.5px/1 'JetBrains Mono',monospace;color:#D9A57C">setupAuth()</span> is not awaited, so the first request can go out with the stale token.</div>
+                <div style="border:1px solid #2A2E33;border-radius:8px;background:#16181B;overflow:hidden">
+                  <div style="height:26px;display:flex;align-items:center;gap:7px;padding:0 10px;border-bottom:1px solid #2A2E33">
+                    <span style="width:5px;height:5px;border-radius:50%;background:#7ECBA0"></span>
+                    <span style="font:500 10px/1 'JetBrains Mono',monospace;color:#B4B5BC">Read</span>
+                    <span style="flex:1;min-width:0;font:400 10px/1 'JetBrains Mono',monospace;color:#6E6E76;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">tests/auth/setup.ts</span>
+                  </div>
+                  <div style="padding:9px 10px;font:400 11px/1.7 'JetBrains Mono',monospace;color:#8C8D95;white-space:pre">  38  const t = refreshToken(ctx)
+  39  client.use(bearer(t))</div>
+                </div>
+              </div>
+            </div>
+            <div style="flex:1"></div>
+            <div style="flex:none;border:1px solid #3A3F46;border-radius:10px;background:#16181B;padding:10px 12px;display:flex;align-items:center;gap:10px">
+              <span style="flex:1;font:400 12.5px/1 'Inter',sans-serif;color:#6E6E76">Reply to Claude…</span>
+              <span style="flex:none;font:500 10px/1 'JetBrains Mono',monospace;color:#6E6E76">⏎</span>
+            </div>
+          </div>
+        </div>
+
+        <div style="flex:1;min-width:0;display:flex;flex-direction:column;background:#0E0F11">
+          <div style="height:38px;flex:none;display:flex;align-items:center;gap:9px;padding:0 12px 0 14px;border-bottom:1px solid #2A2E33">
+            <span style="font:600 13px/1 'Inter',sans-serif;letter-spacing:-.005em;color:#B4B5BC;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">migrate billing schema</span>
+            <span style="flex:none;display:flex;align-items:center;height:20px;padding:0 7px;border-radius:5px;border:1px solid #2A2E33;background:#16181B;font:500 10px/1 'JetBrains Mono',monospace;color:#6E6E76">⎇ db/billing-v2</span>
+            <span style="flex:1;min-width:0;font:400 11px/1 'JetBrains Mono',monospace;color:#4A4E55;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">~/dev/ledger</span>
+            <button type="button" aria-label="Close pane" style="appearance:none;border:0;background:none;width:22px;height:22px;border-radius:5px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none;font:400 12px/1 'Inter',sans-serif;color:#4A4E55" style-hover="background:#1E2125">✕</button>
+            <button type="button" aria-label="Connection status" style="appearance:none;border:0;background:none;width:24px;height:24px;border-radius:6px;display:flex;align-items:center;justify-content:center;cursor:pointer;flex:none" style-hover="background:#1E2125">
+              <span style="width:7px;height:7px;border-radius:50%;background:#7ECBA0;box-shadow:0 0 0 3px rgba(126,203,160,.14)"></span>
+            </button>
+          </div>
+          <div style="flex:1;min-height:0;overflow:hidden;padding:20px 18px;display:flex;flex-direction:column;gap:16px">
+            <div style="display:flex;gap:10px">
+              <span style="flex:none;width:20px;height:20px;border-radius:6px;border:1px solid #2A2E33;background:#16181B;display:flex;align-items:center;justify-content:center;font:500 9.5px/1 'JetBrains Mono',monospace;color:#8C8D95">R</span>
+              <div style="flex:1;min-width:0;font:400 12.5px/1.6 'Inter',sans-serif;color:#B4B5BC;text-wrap:pretty">Write the migration for the new invoice_lines table and backfill from the legacy column.</div>
+            </div>
+            <div style="display:flex;gap:10px">
+              <span style="flex:none;width:20px;height:20px;border-radius:6px;background:rgba(217,119,87,.35);display:flex;align-items:center;justify-content:center;font:600 9.5px/1 'JetBrains Mono',monospace;color:#160C07">C</span>
+              <div style="flex:1;min-width:0;display:flex;flex-direction:column;gap:11px">
+                <div style="font:400 12.5px/1.6 'Inter',sans-serif;color:#B4B5BC;text-wrap:pretty">Backfill runs in batches of 5,000 so the table is never locked for more than a second. Writing the up and down steps now.</div>
+                <div style="border:1px solid #2A2E33;border-radius:8px;background:#16181B;overflow:hidden">
+                  <div style="height:26px;display:flex;align-items:center;gap:7px;padding:0 10px;border-bottom:1px solid #2A2E33">
+                    <span style="width:5px;height:5px;border-radius:50%;background:#7ECBA0"></span>
+                    <span style="font:500 10px/1 'JetBrains Mono',monospace;color:#8C8D95">Write</span>
+                    <span style="flex:1;min-width:0;font:400 10px/1 'JetBrains Mono',monospace;color:#6E6E76;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">migrations/0042_invoice_lines.sql</span>
+                  </div>
+                  <div style="padding:9px 10px;font:400 11px/1.7 'JetBrains Mono',monospace;color:#6E6E76;white-space:pre">  create table invoice_lines (
+    id bigserial primary key,</div>
+                </div>
+              </div>
+            </div>
+            <div style="flex:1"></div>
+            <div style="flex:none;border:1px solid #2A2E33;border-radius:10px;background:#141619;padding:10px 12px;display:flex;align-items:center;gap:10px">
+              <span style="flex:1;font:400 12.5px/1 'Inter',sans-serif;color:#4A4E55">Reply to Claude…</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div style="width:1280px;margin-top:16px">
+        <div style="font:500 10.5px/1 'JetBrains Mono',monospace;letter-spacing:.16em;text-transform:uppercase;color:#6E6E76;margin-bottom:10px">4b · Split + sidebar collapsed — top edge only</div>
+        <div style="width:1280px;border-radius:10px;border:1px solid #2A2E33;background:#0E0F11;overflow:hidden;display:flex">
+          <div style="flex:1;min-width:0;border-right:1px solid #2A2E33">
+            <div style="height:38px;display:flex;align-items:center;gap:9px;padding:0 12px;border-bottom:1px solid #2A2E33;box-shadow:inset 0 2px 0 #D97757">
+              <span style="display:flex;gap:8px;align-items:center;flex:none;margin-right:2px">
+                <span style="width:12px;height:12px;border-radius:50%;background:#FF5F57"></span>
+                <span style="width:12px;height:12px;border-radius:50%;background:#FEBC2E"></span>
+                <span style="width:12px;height:12px;border-radius:50%;background:#28C840"></span>
+              </span>
+              <span style="display:flex;align-items:center;gap:2px;flex:none">
+                <span style="width:28px;height:28px;border-radius:6px;background:#1E2125;display:flex;align-items:center;justify-content:center">
+                  <span aria-hidden="true" style="position:relative;width:15px;height:13px;display:block">
+                    <span style="position:absolute;inset:0;border:1.5px solid #E6E6E9;border-radius:2.5px;box-sizing:border-box"></span>
+                    <span style="position:absolute;left:5px;top:0;bottom:0;width:1.5px;background:#E6E6E9"></span>
+                    <span style="position:absolute;left:0;top:0;bottom:0;width:5px;background:rgba(230,230,233,.22)"></span>
+                  </span>
+                </span>
+                <span style="width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center">
+                  <span aria-hidden="true" style="width:6px;height:6px;border-left:1.5px solid #B4B5BC;border-bottom:1.5px solid #B4B5BC;transform:rotate(45deg) translate(1px,-1px)"></span>
+                </span>
+                <span style="width:28px;height:28px;border-radius:6px;display:flex;align-items:center;justify-content:center">
+                  <span aria-hidden="true" style="width:6px;height:6px;border-right:1.5px solid #4A4E55;border-top:1.5px solid #4A4E55;transform:rotate(45deg) translate(-1px,1px)"></span>
+                </span>
+              </span>
+              <span style="flex:none;width:1px;height:16px;background:#2A2E33;margin:0 1px"></span>
+              <span style="font:600 13px/1 'Inter',sans-serif;color:#F3F3F4;white-space:nowrap">fix flaky auth test</span>
+              <span style="flex:none;display:flex;align-items:center;height:20px;padding:0 7px;border-radius:5px;border:1px solid #2A2E33;background:#16181B;font:500 10px/1 'JetBrains Mono',monospace;color:#B4B5BC">⎇ fix/auth-retry</span>
+              <span style="flex:1;min-width:0"></span>
+              <span style="width:22px;height:22px;display:flex;align-items:center;justify-content:center;flex:none;font:400 12px/1 'Inter',sans-serif;color:#8C8D95">✕</span>
+            </div>
+            <div style="height:52px;background:#0E0F11"></div>
+          </div>
+          <div style="flex:1;min-width:0">
+            <div style="height:38px;display:flex;align-items:center;gap:9px;padding:0 12px 0 14px;border-bottom:1px solid #2A2E33">
+              <span style="font:600 13px/1 'Inter',sans-serif;color:#B4B5BC;white-space:nowrap">migrate billing schema</span>
+              <span style="flex:none;display:flex;align-items:center;height:20px;padding:0 7px;border-radius:5px;border:1px solid #2A2E33;background:#16181B;font:500 10px/1 'JetBrains Mono',monospace;color:#6E6E76">⎇ db/billing-v2</span>
+              <span style="flex:1;min-width:0"></span>
+              <span style="width:22px;height:22px;display:flex;align-items:center;justify-content:center;flex:none;font:400 12px/1 'Inter',sans-serif;color:#4A4E55">✕</span>
+              <span style="width:24px;height:24px;display:flex;align-items:center;justify-content:center;flex:none">
+                <span style="width:7px;height:7px;border-radius:50%;background:#7ECBA0;box-shadow:0 0 0 3px rgba(126,203,160,.14)"></span>
+              </span>
+            </div>
+            <div style="height:52px;background:#0E0F11"></div>
+          </div>
+        </div>
+      </div>
+
+      <div style="width:1280px;font:400 12.5px/1.6 'Inter',sans-serif;color:#8C8D95;margin-top:12px;text-wrap:pretty">Focus is carried by a 2px terracotta inset on the focused sub-header plus full-strength title, path and composer border; the unfocused column mutes its title to #B4B5BC, its path to #4A4E55 and drops its composer to a flat #141619. The connection dot appears once, at the right end of the rightmost sub-header, so it always reads as a window-level fact rather than a per-pane one. Collapsed, the window controls join the leftmost sub-header behind the same hairline rule used in frame 2.</div>
+    </div>
+
+  </div>
+</section>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1400,&quot;height&quot;:1100}}">
+class Component extends DCLogic {
+  renderVals() {
+    return {
+      pinned: [
+        { t: "api-gateway · main", m: "" },
+        { t: "design-system audit", m: "1h" }
+      ],
+      running: [
+        { t: "migrate billing schema", m: "14m" },
+        { t: "docs: rewrite quickstart", m: "31m" }
+      ],
+      recent: [
+        { t: "rate limiter backoff", m: "2h" },
+        { t: "fix webpack chunk split", m: "5h" },
+        { t: "add pairing QR fallback", m: "Yd" },
+        { t: "prune stale sessions job", m: "Yd" },
+        { t: "voice input latency", m: "2d" },
+        { t: "relay reconnect storm", m: "3d" },
+        { t: "sqlite wal checkpointing", m: "4d" },
+        { t: "telemetry opt-out copy", m: "5d" },
+        { t: "menu bar icon states", m: "6d" }
+      ]
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/claude-design-handoff/desktop-chrome-redesign/README.md
+++ b/docs/design/claude-design-handoff/desktop-chrome-redesign/README.md
@@ -1,0 +1,93 @@
+# Desktop Chrome Redesign——顶栏拆除＋侧栏直通窗顶（2026-09-02）
+
+- 在线设计板：`https://claude.ai/design/p/eb401868-d618-47f7-b8d4-4641117d566d?file=Desktop+Chrome+Redesign+v2.dc.html`
+- 像素规格：本目录 `Desktop Chrome Redesign v2.dc.html`（定稿，四帧：默认／侧栏收起／2× 细节／分屏＋4b 收起分屏条）。`v1` 仅历史留档（保留全宽标题栏的旧方案，已被否）。
+- 需求来源：机主参考 Codex 桌面端顶栏的五点调整＋补充（顶行四操作、分屏状态）。
+
+## 设计要点（v2 定稿）
+
+1. **没有任何横贯窗宽的标题栏**。侧栏整列直通窗口顶；聊天列的子头部是该列第一个元素，顶到窗口上沿。
+2. **侧栏顶行（38px，侧栏底色）恰好四个操作**：红绿灯（mac）→ 收起侧栏 → 后退 ‹ → 前进 › → 搜索框（占余宽、齐侧栏右缘收边，260px 下不放 ⌘K 提示）。
+3. **设备行降为一行细条**（26px：状态点＋mono 机器名＋小箭头＋铃铛），会话列表从 136px 高度即开始（原 232px）。
+4. **聊天子头部**承接原标题栏职责：拖窗区＋双击 zoom＋右端连接状态点；侧栏收起时左端出现「红绿灯＋收起＋‹ ›」簇＋16px 竖分隔线。
+5. **分屏**：聚焦列子头部带 2px terracotta 顶端 inset；非聚焦列标题降 #B4B5BC。状态点只出现一次＝最右列右端。收起＋分屏时控件簇在最左列子头部。
+
+## 实现方案（fable 定稿，opus5 执行）
+
+> **范围铁律（机主原话）：这次主要调整顶部结构，不要根据设计稿改其他不相关的区域。**
+> 设计稿里对消息流、composer、会话行、底部 footer 的简化是 mock 噪声，一概**不实现**。
+> `ChatSubHeader` 保留现有两行结构与全部功能（AgentBadge、终端 chip、ChangesPill/GitPill/⋯、mono 元信息行、LineageBanner），只做「承接标题栏职责」的增量。
+
+### 已完成（本会话已落）
+
+- `DesktopModel` 新增 `canGoBack/canGoForward/goBack/goForward`（惰性默认）；`RepoDesktopModel` 历史栈（sessionKey×workdir 快照流记录、浏览器语义、跨机复用 openPin 路径）；`Main.kt` ⌘[/⌘]；`RepoDesktopModelNavHistoryTest` 两条已绿。
+
+### 待实现（编码工单）
+
+**A. 收起状态提升到 model**
+- `DesktopModel`：加 `val sidebarCollapsed: Boolean get() = false`、`fun setSidebarCollapsed(v: Boolean) {}`（惰性默认，seed/preview 不动）。
+- `RepoDesktopModel`：实现＋经自己的 `store` 持久化，**沿用原 key `"desktop_sidebar_collapsed"`**（值 "1"/"0"，与 DesktopApp 现状兼容）。
+- `DesktopApp.kt`：删本地 `collapsed`/`setCollapsed`，改读写 model；`sidebarW` 仍留本地。`SidebarRevealStrip` 移除（收起态零 chrome，回来的路＝子头部簇的 toggle／⌘\；拖拽把手逻辑不变）。
+- `SidePaneModel`（`desktop/SidePaneModel.kt`）：**必须把 `sidebarCollapsed/setSidebarCollapsed/canGoBack/canGoForward/goBack/goForward` 显式委托给 base**——分屏列的簇/箭头才不会拿到接口惰性默认。先看该文件现有委托风格照做。
+- `Main.kt`：`onPreviewKeyEvent` 加 ⌘\（`Key.Backslash`）→ `model.setSidebarCollapsed(!model.sidebarCollapsed)`。
+
+**B. 窗口 chrome 钩子下放**
+- `Main.kt` 删除 `DkTitleBar(...)` 调用（`if (!fullscreen)` 分支整个去掉；`else if (!mac) FullscreenExitStrip` 保留，非 mac 全屏行为不变）。
+- 新建 `DesktopWindowChrome`（放 `WindowChrome.kt`）：`mac: Boolean`、`fullscreen: Boolean`、`onClose/onMinimize/onToggleMax/onToggleFullscreen`、`dragAndZoomModifier: Modifier`（把现 `DkTitleBar` 里那两段 pointerInput——AWT 全局鼠标锚定拖窗＋双击 zoom——原样搬进去，注释一并保留）。以 `CompositionLocal`（默认 = 惰性实例，`Modifier` 空）在 `Main.kt` 提供，包住 `DesktopApp`。
+- `DkTitleBar` 本体删除；`TrafficLights`/`WinControls`/`FullscreenExitStrip` 保留复用。
+
+**C. 侧栏顶行（`Sidebar.kt`）**
+- `SwitcherHeader` 前插入新 `SidebarControlRow`（38dp，无自底 hairline，间距 2dp，水平 padding 左 12 右 10）：
+  1. mac 且非全屏 → `TrafficLights`（右 margin 10dp）；
+  2. 收起侧栏按钮：28dp 方形热区、hover `Tok.raised` 圆角 6；图标＝自绘 panel-left（15×13 圆角 2.5 边框＋x=5 竖线，1.5dp 描边，色 `Tok.tx2`）——新建小 Composable（Canvas 或 Box 线段拼装，参照 v2.dc.html:44-47）；
+  3. ‹ ›：28dp 热区，chevron 1.5dp 描边（自绘或 `Icons.Rounded` 里合适的 KeyboardArrowLeft/Right 缩到 16dp——以视觉贴近 mock 为准）；disabled（`!canGoBack`/`!canGoForward`）时色 #4A4E55 系（用 `Tok` 里最接近的 muted 降档）、无 hover 无 tooltip；
+  4. 搜索框：`weight(1f)`、高 26、圆角 7、hairline 边框、`Tok.base` 底、放大镜 12dp＋`Res.string.search` 12sp muted（**tightCenter**）、hover 边框提亮；点击 → `model.palette = PaletteScope.ALL`。不渲染 ⌘K 提示（260px 放不下，设计定稿如此）。
+- tooltip：用 `androidx.compose.foundation.TooltipArea`（compose desktop 自带），内容＝raised 底圆角 5 小胶囊「文案＋快捷键」（参照 mock:323-330；胶囊内文字 tightCenter）。新增字符串资源（values＋values-zh）：`tooltip_toggle_sidebar`（⌘\）、`tooltip_prev_session`（⌘[）、`tooltip_next_session`（⌘]）。
+- `SwitcherHeader` 瘦身为 26dp 一行：保留 osIcon（14→12dp 可调）＋机器名（mono 11sp，tightCenter）＋在线状态点／reconnecting 文案＋下拉小箭头＋右端铃铛（含 AttentionBadge）；**删去 `Key("⌘0")` 键帽视觉**（快捷键本身不动）。点击行为全部保留。行下 hairline 保留。
+- 侧栏其余分区（NewSessionRow 起）一律不动。
+
+**D. 聊天子头部承接（`ChatPane.kt` 的 `ChatSubHeader`，约 :1066 起）**
+- 槽位感知：`DesktopApp.kt` 的列循环里为每列 `CompositionLocalProvider(LocalPaneEdge provides PaneEdge(leftmost, rightmost))`（新 data class，默认值 `PaneEdge(true, true)`——单列与既有测试零感知）。watch 分支：ChatPane=（true,true），`WatchPane` 不动。docked workflow 面板忽略。
+- 第一行增量（保持现有内容与顺序不变）：
+  1. **左端**：`model.sidebarCollapsed && leftmost` 时插入簇——mac 非全屏 → TrafficLights；然后 toggle＋‹ ›（同 C 的组件，直接复用）；随后 1×16dp hairline 竖线、间距参照 mock:190-211；
+  2. **右端**：`rightmost` 时在行尾加连接状态点（28dp 热区＋`PulseDot(Tok.ok, 7.dp)`，点击 `model.showTray = !model.showTray`）；非 mac 再接 `WinControls`（关/最小化/最大化从 chrome 钩子取）；
+  3. **拖窗**：第一行中部的弹性空白区（现有 `Spacer(weight)`/等价区域）套 `chrome.dragAndZoomModifier`——**只挂在空白弹性区，不挂整行**（子控件点击优先，DkTitleBar 的既有教训）；
+  4. **聚焦 accent**：`focused && model.sidePanes.isNotEmpty()` 时子头部顶端画 2dp `Tok.accent` inset 线（mock:462 的 `inset 0 2px 0 #D97757`）。
+- 第二行（mono 元信息）与其余一概不动。
+
+**E. 截图测试同步**
+- `desktopTest/.../DesktopScreenshotTest.kt` 的 `WindowFrame`（:79 起）是顶栏静态复刻——按新结构重写（去标题栏、侧栏顶行四操作），保测试绿。
+
+**F. 验收**
+- `JAVA_HOME=/opt/homebrew/opt/openjdk@17 ./gradlew :mobile:composeApp:desktopTest` 全绿；
+- 迭代期可 `--tests` 定向（check-all 三档惯例）；
+- **禁止**：跑 `:daemon:run`、动 daemon/relay、`bash scripts/update-local-daemon.sh`。
+
+### 平台差异备忘
+
+| 平台 | 红绿灯 | 窗控 | 全屏 |
+|---|---|---|---|
+| macOS | 侧栏顶行（展开）／最左列子头部（收起）；全屏隐藏 | — | 系统菜单栏自现，无额外 chrome |
+| Windows/Linux | 无 | `WinControls` 移到最右列子头部行尾 | `FullscreenExitStrip` 不变 |
+
+## 追加交付（同批，均已实现）
+
+- **右键菜单重设计**（`Context Menu v1.dc.html`）：`PocketContextMenu.kt` 自绘 `ContextMenuRepresentation`＋`LocalContextMenuRepresentation` 全局挂载（含文本框剪切/复制菜单）；`PocketMenuItem`（removal hover 转红/双色前缀）＋`joinMenuFamilies` 族分隔；侧栏两处菜单已迁移。
+- **收起态左缘悬停窥视**：4dp 热区滑入覆盖层侧栏（不回流）、离开 250ms 宽限收回；切换器/铃铛/新会话浮层/右键菜单（`anyMenuOpen`）/拖拽分屏进行中按住不收。
+
+## 落地状态
+
+- [x] 会话导航历史（model＋⌘[/⌘]＋单测）
+- [x] A–E 编码（opus5 工单）
+- [x] `desktopTest` 全绿（1224 tests / 0 failures）
+- [ ] 真机目验（macOS＋Windows）——发版前必补
+
+### 编码期的两处方案外增补（已实现，需复核）
+
+-1. **切换抖动修复＋过渡动画**（真机目验＋录屏抽帧两轮定位）。三个抖动源与修法：
+   - **主犯＝侧栏内容随动画宽度回流**：`Box(width=animW)` 的父约束会钳制 `Sidebar(width=260)`（Compose 约束覆盖 preferred width，录屏 f003 帧＝40px 宽时整列图标竖排、文字全掉）。修法＝子加 `wrapContentWidth(Start, unbounded=true)`——按全宽测量一次、边缘纯 wipe，配 `animateFloatAsState`（200ms FastOutSlowIn）＋`clipToBounds`。
+   - **header 高度动画＝标题/元信息行整体弹跳**：padV 10→5 的做法废弃，行高恒定；簇 y 差 5dp 用 `offset(y=-5.dp)`（draw-time，不动布局）对齐侧栏行 y=19 中线。
+   - **簇延迟展开＝标题先左移后右飞**：改为「空间与滑动同步 expand/shrink（同 `SIDEBAR_ANIM_MS` 时钟）＋控件晚 120ms 淡入/立即淡出」——标题单段连续运动，交接读作同一簇换了主人。padStart 18→12 仍动画。
+0. **无会话的聊天列同样需要 chrome**（`EmptyChatChromeRow`，真机目验抓出）。`ChatPane` 的 `!hasChat` 分支（空状态/打开中/打开失败）跳过 `ChatSubHeader` 直接 return——拆掉标题栏后这条路径整窗无拖拽面，且侧栏收起时连展开按钮都没有。补 38dp 行：收起簇（leftmost）＋全宽拖窗区＋状态点/WinControls（rightmost）。
+1. **配对前的连接页需要自己的 chrome**（`ConnectChromeRow`）。方案 B 删掉 `DkTitleBar` 后，`ConnectPanel` 这条分支既没有侧栏也没有子头部，undecorated 窗口在配对完成前将**无法拖动 / 缩放 / 关闭**。补了一条只有红绿灯＋拖窗区＋`WinControls` 的 38dp 裸条（无标题、无搜索、无状态点——此时既没有会话也没有链路可报）。
+2. **侧栏锚定的三个浮层上移 16dp**：顶行 38＋设备行 26＋hairline＝65dp（原 header 49dp）。`switcherOpen` / `showAttention` 52→68，`showNewSession` 84→100。不改会与新的侧栏顶部几何错位。

--- a/mobile/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -1280,6 +1280,10 @@
     <!-- 窗口边框及杂项 -->
     <string name="exit_fullscreen">退出全屏</string>
     <string name="show_sidebar">显示侧栏</string>
+    <!-- desktop chrome v2: the sidebar control row's tooltips -->
+    <string name="tooltip_toggle_sidebar">显示/隐藏侧栏</string>
+    <string name="tooltip_prev_session">上一个会话</string>
+    <string name="tooltip_next_session">下一个会话</string>
     <!-- split panes (issue #311) -->
     <string name="split_pane_focus">聚焦</string>
     <string name="split_pane_close">关闭此栏</string>

--- a/mobile/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -68,7 +68,6 @@
     <string name="dir_current_project">当前项目</string>
     <string name="pin_project">置顶</string>
     <string name="unpin_project">取消置顶</string>
-    <string name="unpin_session">取消置顶</string>
     <string name="new_session_here">在此新建会话</string>
     <string name="running">运行中</string>
     <string name="idle">空闲</string>
@@ -1280,7 +1279,6 @@
 
     <!-- 窗口边框及杂项 -->
     <string name="exit_fullscreen">退出全屏</string>
-    <string name="show_sidebar">显示侧栏</string>
     <!-- desktop chrome v2: the sidebar control row's tooltips -->
     <string name="tooltip_toggle_sidebar">显示/隐藏侧栏</string>
     <string name="tooltip_prev_session">上一个会话</string>

--- a/mobile/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -68,6 +68,7 @@
     <string name="dir_current_project">当前项目</string>
     <string name="pin_project">置顶</string>
     <string name="unpin_project">取消置顶</string>
+    <string name="unpin_session">取消置顶</string>
     <string name="new_session_here">在此新建会话</string>
     <string name="running">运行中</string>
     <string name="idle">空闲</string>

--- a/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="dir_current_project">Current project</string>
     <string name="pin_project">Pin to top</string>
     <string name="unpin_project">Unpin</string>
+    <string name="unpin_session">Unpin</string>
     <string name="new_session_here">New session here</string>
     <string name="running">running</string>
     <string name="idle">idle</string>

--- a/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1283,6 +1283,10 @@
     <!-- window chrome & misc -->
     <string name="exit_fullscreen">Exit Full Screen</string>
     <string name="show_sidebar">Show sidebar</string>
+    <!-- desktop chrome v2: the sidebar control row's tooltips -->
+    <string name="tooltip_toggle_sidebar">Toggle sidebar</string>
+    <string name="tooltip_prev_session">Previous session</string>
+    <string name="tooltip_next_session">Next session</string>
     <!-- split panes (issue #311) -->
     <string name="split_pane_focus">Focus</string>
     <string name="split_pane_close">Close column</string>

--- a/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -68,7 +68,6 @@
     <string name="dir_current_project">Current project</string>
     <string name="pin_project">Pin to top</string>
     <string name="unpin_project">Unpin</string>
-    <string name="unpin_session">Unpin</string>
     <string name="new_session_here">New session here</string>
     <string name="running">running</string>
     <string name="idle">idle</string>
@@ -1283,7 +1282,6 @@
 
     <!-- window chrome & misc -->
     <string name="exit_fullscreen">Exit Full Screen</string>
-    <string name="show_sidebar">Show sidebar</string>
     <!-- desktop chrome v2: the sidebar control row's tooltips -->
     <string name="tooltip_toggle_sidebar">Toggle sidebar</string>
     <string name="tooltip_prev_session">Previous session</string>

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
@@ -3157,6 +3157,18 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
                 migrateDraft(f.sessionId) // before re-keying: composerKey() still reads the old chain
                 convoId.value = f.convoId; workdir.value = f.workdir; observing.value = f.observing; currentSessionId = f.sessionId
                 f.sessionId?.let { sessionKey.value = it }
+                // The LISTED project follows the conversation: whatever path opened this session — a row
+                // click, a pin, ⌘[ history, a push tap, a launch restore — its project becomes the listed
+                // one, so everything scoped to "the current project" (the sidebar's right-click verbs, ⌘N)
+                // means the project the user is demonstrably in. This is the one seam every open funnels
+                // through; per-path repoints (switchToSession's, the desktop's) remain as optimistic
+                // fast-paths and converge here. Skips: an already-matching dir (the common case — also
+                // keeps browse-another-project-while-chatting intact, since browsing lists AFTER the open),
+                // and observe views (watching a session must not hijack what the sidebar lists).
+                if (!f.observing && sessionsDir.value?.let { sameDirPath(it, f.workdir) } != true) {
+                    sessionsDir.value = f.workdir
+                    listSessions(f.workdir)
+                }
                 // The opener's title is only an optimistic seed: push/deep-link routes know no title at
                 // all, and a project row can be stale while Codex renames its thread. A new daemon sends
                 // transcript/index truth here; null from an older daemon deliberately keeps the seed.

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
@@ -3157,18 +3157,6 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
                 migrateDraft(f.sessionId) // before re-keying: composerKey() still reads the old chain
                 convoId.value = f.convoId; workdir.value = f.workdir; observing.value = f.observing; currentSessionId = f.sessionId
                 f.sessionId?.let { sessionKey.value = it }
-                // The LISTED project follows the conversation: whatever path opened this session — a row
-                // click, a pin, ⌘[ history, a push tap, a launch restore — its project becomes the listed
-                // one, so everything scoped to "the current project" (the sidebar's right-click verbs, ⌘N)
-                // means the project the user is demonstrably in. This is the one seam every open funnels
-                // through; per-path repoints (switchToSession's, the desktop's) remain as optimistic
-                // fast-paths and converge here. Skips: an already-matching dir (the common case — also
-                // keeps browse-another-project-while-chatting intact, since browsing lists AFTER the open),
-                // and observe views (watching a session must not hijack what the sidebar lists).
-                if (!f.observing && sessionsDir.value?.let { sameDirPath(it, f.workdir) } != true) {
-                    sessionsDir.value = f.workdir
-                    listSessions(f.workdir)
-                }
                 // The opener's title is only an optimistic seed: push/deep-link routes know no title at
                 // all, and a project row can be stale while Codex renames its thread. A new daemon sends
                 // transcript/index truth here; null from an older daemon deliberately keeps the seed.

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/SplitPanes.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/SplitPanes.kt
@@ -20,6 +20,7 @@ import dev.ccpocket.protocol.SessionGone
 import dev.ccpocket.protocol.SessionLive
 import dev.ccpocket.protocol.ToolEvent
 import dev.ccpocket.protocol.TurnDone
+import dev.ccpocket.protocol.isModelCompatibleWithAgent
 import dev.ccpocket.protocol.isQuestion
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -62,6 +63,9 @@ class SidePane(
     /** Filled by this pane's own SessionLive. Null while the open is still in flight. */
     val convoId = mutableStateOf<String?>(null)
     val title = mutableStateOf(initialTitle)
+    /** The daemon's actual model for THIS pane's session (its own SessionLive), the focused path's
+     *  `repo.model` one column over — what the column's composer chip shows and switches. */
+    val model = mutableStateOf<String?>(null)
     val transcript = ChatTranscript()
     val messages get() = transcript.messages
     val streaming get() = transcript.streaming
@@ -499,6 +503,21 @@ class SidePanes(
         scope.launch { send(CancelTurn(convo)) }
     }
 
+    /**
+     * Switch [pane]'s OWN model — the focused path's `switchModel`, one column over: the same `/model`
+     * command interception, the same agent-compatibility gate, the same optimistic set (this pane's next
+     * `SessionLive` corrects it to the resolved id — see [bind]). What it deliberately does NOT mirror is
+     * the effort/service-tier follow-up: a column tracks neither, so there is nothing stale to clear.
+     */
+    fun switchModel(pane: SidePane, name: String) {
+        val convo = pane.convoId.value ?: return
+        val target = name.trim()
+        if (target.isEmpty() || target == pane.model.value) return
+        if (!isModelCompatibleWithAgent(pane.agent, target)) return
+        pane.model.value = target
+        scope.launch { send(SendPrompt(convo, "/model $target")) }
+    }
+
     private fun byConvo(convoId: String): SidePane? = panes.firstOrNull { it.convoId.value == convoId }
 
     private fun bind(f: SessionLive) {
@@ -519,6 +538,7 @@ class SidePanes(
         pane.opening.value = false
         pane.openFailed.value = false
         pane.gone.value = false
+        f.model?.let { pane.model.value = it } // daemon truth corrects the optimistic switchModel guess too
         // daemon truth beats the local guess, exactly as the focused path takes it — the stamp included:
         // a turn killed MID-THINKING has no TurnDone coming to close its block, so a reattach that reports
         // idle is the only chance to stamp it. Without this the column keeps an eternal "Thinking…" row

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/Main.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/Main.kt
@@ -484,6 +484,7 @@ private fun ApplicationScope.PocketShell() {
                 onToggleMax = toggleZoom,
                 onToggleFullscreen = toggleFullscreen,
                 dragAndZoomModifier = windowDragAndZoom(window, toggleZoom),
+                window = window,
             )
         }
         PocketTheme(mode = repo.themeMode.value, accent = repo.accentTheme.value) {
@@ -519,6 +520,10 @@ private fun ApplicationScope.PocketShell() {
                     }
                     // "Add computer" pairs a new daemon in a modal over the live shell (no disconnect)
                     if (model.showAddComputer) AddComputerModal(repo) { model.showAddComputer = false }
+                    // With an overlay up, the in-content chrome sits UNDER its scrim — the old title bar
+                    // sat above the overlays by construction, so restore that: a transparent drag band
+                    // (plus Win/Linux window buttons) over everything while any overlay is open.
+                    if (connected && model.anyOverlayOpen) dev.ccpocket.app.desktop.OverlayChromeStrip()
                 }
             }
             }

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/Main.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/Main.kt
@@ -281,6 +281,15 @@ private fun ApplicationScope.PocketShell() {
                 // the one it has. While the SHELL owns the keyboard AWT keeps the keystroke — the
                 // engine's own dispatcher forwards it, so the toggle works from either side.
                 e.type == KeyEventType.KeyDown && mod && e.key == Key.J && connected -> { model.toggleEmbeddedTerminal(); true }
+                // ⌘[ / ⌘] step the session history — the control row's ‹ › (browser back/forward semantics)
+                e.type == KeyEventType.KeyDown && mod && e.key == Key.LeftBracket && connected -> { model.goBack(); true }
+                e.type == KeyEventType.KeyDown && mod && e.key == Key.RightBracket && connected -> { model.goForward(); true }
+                // ⌘\ hides/shows the sidebar. With the title bar gone (desktop chrome v2) the collapsed
+                // sidebar leaves NO chrome behind — this and the sub-header's own toggle are the way back,
+                // so the shortcut is deliberately not gated on `connected`: the ConnectPanel has no toggle.
+                e.type == KeyEventType.KeyDown && mod && e.key == Key.Backslash -> {
+                    model.setSidebarCollapsed(!model.sidebarCollapsed); true
+                }
                 // ⌘⇧R (the Review Center) must be tested BEFORE plain ⌘R: the refresh branch below
                 // matches Key.R whatever the modifiers, so the shifted case has to claim it first.
                 e.type == KeyEventType.KeyDown && mod && e.isShiftPressed && e.key == Key.R && connected -> {

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/Main.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/Main.kt
@@ -36,13 +36,16 @@ import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import dev.ccpocket.app.data.PocketRepository
 import dev.ccpocket.app.desktop.AddComputerModal
+import dev.ccpocket.app.desktop.ConnectChromeRow
 import dev.ccpocket.app.desktop.ConnectPanel
 import dev.ccpocket.app.desktop.DesktopApp
 import dev.ccpocket.app.desktop.DesktopCrashGuard
 import dev.ccpocket.app.desktop.openFolderAction
 import dev.ccpocket.app.desktop.DesktopNotify
-import dev.ccpocket.app.desktop.DkTitleBar
+import dev.ccpocket.app.desktop.DesktopWindowChrome
 import dev.ccpocket.app.desktop.FullscreenExitStrip
+import dev.ccpocket.app.desktop.LocalWindowChrome
+import dev.ccpocket.app.desktop.windowDragAndZoom
 import dev.ccpocket.app.desktop.JediTermEngine
 import dev.ccpocket.app.desktop.MacWindow
 import dev.ccpocket.app.desktop.PaletteScope
@@ -322,6 +325,16 @@ private fun ApplicationScope.PocketShell() {
         // undecorated windows on macOS. Non-null == currently zoomed, holding the bounds to restore.
         // (The green traffic light no longer zooms — it toggles native fullscreen, issue #94.)
         var zoomRestore by remember { mutableStateOf<Rectangle?>(null) }
+        val toggleZoom: () -> Unit = {
+            val restore = zoomRestore
+            if (restore != null) {
+                window.bounds = restore
+                zoomRestore = null
+            } else {
+                zoomRestore = window.bounds
+                window.bounds = usableScreenBounds(window)
+            }
+        }
         LaunchedEffect(Unit) {
             // record the window bounds (debounced) so the next launch reopens exactly here. While zoomed,
             // persist the PRE-zoom bounds plus a zoomed flag: the next launch re-zooms itself (below) and
@@ -453,41 +466,57 @@ private fun ApplicationScope.PocketShell() {
         }
         // appearance (issue #63): PocketTheme resolves the persisted mode against the OS, so a SYSTEM pick
         // tracks a live OS light/dark flip and Settings' setThemeMode() re-themes the whole shell.
+        // Window chrome, handed to the surfaces that now own it (desktop chrome v2): the sidebar's control
+        // row while it is open, the leftmost/rightmost chat sub-header otherwise.
+        //
+        // REMEMBERED, keyed only on what can actually change it. LocalWindowChrome is a STATIC composition
+        // local, so a new instance recomposes the entire shell below — and this scope also holds
+        // `windowFocused` / `unseenDone`, which move on every focus flip and every finished turn. A fresh
+        // instance per composition would have turned each of those into a whole-window recomposition.
+        // Capturing one generation of the callbacks is safe: every one of them closes over a MutableState
+        // or the AWT window, never over a snapshot value read at construction time.
+        val chrome = remember(mac, fullscreen, window) {
+            DesktopWindowChrome(
+                mac = mac,
+                fullscreen = fullscreen,
+                onClose = closeMainWindow,
+                onMinimize = { windowState.isMinimized = true },
+                onToggleMax = toggleZoom,
+                onToggleFullscreen = toggleFullscreen,
+                dragAndZoomModifier = windowDragAndZoom(window, toggleZoom),
+            )
+        }
         PocketTheme(mode = repo.themeMode.value, accent = repo.accentTheme.value) {
             androidx.compose.runtime.CompositionLocalProvider(
                 dev.ccpocket.app.ui.LocalPathOpener provides dev.ccpocket.app.desktop.DesktopPathOpener(),
+                LocalWindowChrome provides chrome,
+                // one menu for the whole shell (design "Context Menu v1"): the sidebar's session menus and
+                // every text field's cut/copy/paste stop rendering the stock Swing-grey dropdown
+                androidx.compose.foundation.LocalContextMenuRepresentation provides dev.ccpocket.app.desktop.PocketContextMenuRepresentation,
             ) {
             Column(Modifier.fillMaxSize().background(Tok.base)) {
-                // In fullscreen the self-drawn title bar collapses (issue #94): macOS already provides its
-                // own auto-hiding menu on top-hover, so drawing our bar too would double up. Win/Linux
-                // borderless fullscreen has no such menu, so they get a slim hover-reveal exit strip instead.
-                if (!fullscreen) {
-                    DkTitleBar(
-                        mac = mac,
-                        onClose = closeMainWindow,
-                        onMinimize = { windowState.isMinimized = true },
-                        onToggleMax = {
-                            val restore = zoomRestore
-                            if (restore != null) {
-                                window.bounds = restore
-                                zoomRestore = null
-                            } else {
-                                zoomRestore = window.bounds
-                                window.bounds = usableScreenBounds(window)
-                            }
-                        },
-                        onToggleFullscreen = toggleFullscreen,
-                        onTray = { model.showTray = !model.showTray },
-                        onSearch = { model.palette = PaletteScope.ALL },
-                    )
-                } else if (!mac) {
+                // Nothing spans the window width any more (desktop chrome v2) — the columns below run to
+                // the window's top edge and carry the chrome themselves. What survives here is the
+                // Win/Linux fullscreen affordance (issue #94): macOS auto-reveals its own menu bar on
+                // top-hover, borderless Win/Linux fullscreen has nothing, so it keeps the hover strip.
+                if (fullscreen && !mac) {
                     FullscreenExitStrip(onExit = toggleFullscreen)
                 }
                 Box(Modifier.fillMaxWidth().weight(1f)) {
                     // the tray's "Open cc-pocket" / row-jump raise the window (issue #111): un-minimize, then
                     // bring the AWT window to front and focus it — a real menu-bar action once the tray leaves
                     // the title bar, and harmless (already-frontmost) while it lives there.
-                    if (connected) DesktopApp(model, onActivateWindow = activateMainWindow) else ConnectPanel(repo)
+                    // The shell carries its own chrome (sidebar control row / chat sub-header). The connect
+                    // screen has neither, and this window is undecorated — so it keeps a bare bar of its
+                    // own, or a user who hasn't paired yet cannot move, zoom or close the app at all.
+                    if (connected) {
+                        DesktopApp(model, onActivateWindow = activateMainWindow)
+                    } else {
+                        Column(Modifier.fillMaxSize()) {
+                            if (!fullscreen) ConnectChromeRow()
+                            Box(Modifier.fillMaxWidth().weight(1f)) { ConnectPanel(repo) }
+                        }
+                    }
                     // "Add computer" pairs a new daemon in a modal over the live shell (no disconnect)
                     if (model.showAddComputer) AddComputerModal(repo) { model.showAddComputer = false }
                 }

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/ChatPane.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/ChatPane.kt
@@ -1,6 +1,12 @@
 package dev.ccpocket.app.desktop
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
@@ -23,6 +29,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.heightIn
@@ -267,6 +274,10 @@ fun ChatPane(model: DesktopModel, modifier: Modifier = Modifier, focused: Boolea
         // EmptyChat flash in between. And when the open never lands at all, say THAT (issue #235) instead
         // of falling back to the same empty state a user who clicked nothing would see.
         Column(modifier.fillMaxSize().background(Tok.base)) {
+            // These branches skip [ChatSubHeader] — and with the title bar gone, that used to leave the
+            // window with NO drag surface at all (and, sidebar collapsed, no way to bring it back). The
+            // sub-header's chrome duties therefore ride this slim row, minus its session content.
+            EmptyChatChromeRow(model)
             when {
                 model.opening -> OpeningChat(model.chatTitle)
                 // the open that never landed (issue #235) — named by the session the user actually asked for
@@ -1062,17 +1073,112 @@ internal fun ChatNotice(
     }
 }
 
+/**
+ * The window chrome for a chat column with NOTHING open ([DesktopModel.hasChat] false): the empty state,
+ * an open in flight, a failed open. [ChatSubHeader] isn't composed on those paths, so this row carries
+ * its chrome duties — the whole width drags (there are no session controls to protect), the collapsed
+ * sidebar's cluster keeps its home on the leftmost column, and the rightmost edge keeps the connection
+ * dot + the Windows/Linux window buttons. Without it, launching into "no session open" left the window
+ * undraggable — and, collapsed, with no way to reopen the sidebar.
+ */
+@Composable
+private fun EmptyChatChromeRow(model: DesktopModel) {
+    val chrome = LocalWindowChrome.current
+    val edge = LocalPaneEdge.current
+    Row(
+        Modifier.fillMaxWidth().height(38.dp).padding(horizontal = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        // same choreography as [ChatSubHeader]'s cluster — and this row already sits at the sidebar
+        // row's exact geometry (start 12, 38dp tall), so the late fade is a swap in place
+        AnimatedVisibility(
+            visible = model.sidebarCollapsed && edge.leftmost,
+            enter = expandHorizontally(tween(SIDEBAR_ANIM_MS)) +
+                fadeIn(tween(100, delayMillis = SIDEBAR_ANIM_MS - 80)),
+            exit = shrinkHorizontally(tween(SIDEBAR_ANIM_MS)) + fadeOut(tween(80)),
+        ) {
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp), verticalAlignment = Alignment.CenterVertically) {
+                if (chrome.mac && !chrome.fullscreen) TrafficLights(chrome.onClose, chrome.onMinimize, chrome.onToggleFullscreen)
+                Row(horizontalArrangement = Arrangement.spacedBy(2.dp), verticalAlignment = Alignment.CenterVertically) {
+                    SidebarToggleButton(model)
+                    SessionNavButtons(model)
+                }
+            }
+        }
+        Box(Modifier.weight(1f).height(38.dp).then(chrome.dragAndZoomModifier))
+        if (edge.rightmost) {
+            Box(
+                Modifier.size(28.dp).clip(RoundedCornerShape(6.dp)).hoverFill(RoundedCornerShape(6.dp))
+                    .clickable { model.showTray = !model.showTray },
+                contentAlignment = Alignment.Center,
+            ) { PulseDot(Tok.ok, 7.dp) }
+            if (!chrome.mac && !chrome.fullscreen) WinControls(chrome.onMinimize, chrome.onToggleMax, chrome.onClose)
+        }
+    }
+}
+
+/**
+ * The chat column's own header — and, since the desktop chrome v2 redesign, the window's top edge.
+ *
+ * With the title bar gone there is nothing above this row, so it takes over what the bar used to do:
+ * it is the drag handle (double-click zooms), the LEFTMOST column adopts the sidebar's control cluster
+ * whenever the sidebar is collapsed, and the RIGHTMOST one carries the connection dot plus the
+ * Windows/Linux window buttons. Everything that was already here — title, agent badge, terminal chip,
+ * Changes/Git/⋯, the mono meta line, the lineage banner — is untouched; the chrome is strictly added
+ * around it.
+ */
 @Composable
 private fun ChatSubHeader(model: DesktopModel, onTerminalMenu: () -> Unit = {}) {
+    val chrome = LocalWindowChrome.current
+    val edge = LocalPaneEdge.current
+    val clusterHere = model.sidebarCollapsed && edge.leftmost
+    // Start 12 while the cluster is home (the sidebar row's own inset) so the lights land at the same x
+    // they left. The row's HEIGHT deliberately never changes — an earlier cut animated the vertical
+    // padding too and the whole header (title, meta line and all) bounced 10dp on every toggle; the
+    // remaining 5dp y-difference is closed by drawing the cluster into the top padding instead (offset,
+    // a draw-time shift, so the layout stays put).
+    val padStart by animateDpAsState(if (clusterHere) 12.dp else 18.dp, tween(SIDEBAR_ANIM_MS), label = "subheader-pad-s")
     Column(Modifier.fillMaxWidth()) {
         Row(
-            Modifier.fillMaxWidth().padding(horizontal = 18.dp, vertical = 10.dp),
+            Modifier.fillMaxWidth().padding(start = padStart, end = 18.dp, top = 10.dp, bottom = 10.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {
+            // the collapsed sidebar's controls, re-homed (mock frames 2 / 4b). Leftmost column only: the
+            // cluster describes the window, and one window has one of it. The SPACE expands in step with
+            // the sidebar's slide (one continuous motion for the title — no reserve-then-push lurch);
+            // the CONTROLS fade in late, once the sidebar's own copy has been wiped past, so the
+            // hand-off reads as one cluster changing owners rather than two coexisting.
+            AnimatedVisibility(
+                visible = clusterHere,
+                enter = expandHorizontally(tween(SIDEBAR_ANIM_MS)) +
+                    fadeIn(tween(100, delayMillis = SIDEBAR_ANIM_MS - 80)),
+                exit = shrinkHorizontally(tween(SIDEBAR_ANIM_MS)) + fadeOut(tween(80)),
+            ) {
+                Row(
+                    // −5dp: center the 28dp controls at y19 — the sidebar control row's centerline
+                    // (38dp tall) — inside this row's 28+20dp geometry, without touching its height
+                    Modifier.offset(y = (-5).dp),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    if (chrome.mac && !chrome.fullscreen) TrafficLights(chrome.onClose, chrome.onMinimize, chrome.onToggleFullscreen)
+                    Row(horizontalArrangement = Arrangement.spacedBy(2.dp), verticalAlignment = Alignment.CenterVertically) {
+                        SidebarToggleButton(model)
+                        SessionNavButtons(model)
+                    }
+                    // the rule that keeps the sub-header reading title-first despite the cluster (mock:211)
+                    ChromeDivider()
+                }
+            }
             Text(
                 model.chatTitle, color = Tok.tx, fontFamily = Dk.ui, fontSize = 15.sp, fontWeight = FontWeight.SemiBold,
-                maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f),
+                maxLines = 1, overflow = TextOverflow.Ellipsis,
+                // the title region is the window's drag handle, exactly as the title bar's label region
+                // was — and for the same reason it is the ONLY thing wearing it: this row's own buttons
+                // must keep their clicks, so the gesture goes on the flexible, non-interactive middle.
+                modifier = Modifier.weight(1f).then(chrome.dragAndZoomModifier),
             )
             AgentBadge(model.chatAgent)
             // quick terminal at the session's cwd — only when that directory exists on THIS machine, so a
@@ -1114,6 +1220,18 @@ private fun ChatSubHeader(model: DesktopModel, onTerminalMenu: () -> Unit = {}) 
                     modifier = Modifier.size(26.dp).clip(RoundedCornerShape(999.dp))
                         .clickable { model.showQuickActions = true }.padding(4.dp),
                 )
+            }
+            // ONCE per window, at the right end of the RIGHTMOST column (design frame 4): the link is a
+            // window-level fact, and a dot per column would read as a per-conversation one. Opens the tray.
+            if (edge.rightmost) {
+                Box(
+                    Modifier.size(28.dp).clip(RoundedCornerShape(6.dp)).hoverFill(RoundedCornerShape(6.dp))
+                        .clickable { model.showTray = !model.showTray },
+                    contentAlignment = Alignment.Center,
+                ) { PulseDot(Tok.ok, 7.dp) }
+                // Windows/Linux min · max · close land here too — macOS keeps its traffic lights on the
+                // leading edge, and in fullscreen neither platform draws window buttons at all (#94).
+                if (!chrome.mac && !chrome.fullscreen) WinControls(chrome.onMinimize, chrome.onToggleMax, chrome.onClose)
             }
         }
         val branch = model.chatBranch?.let { "  ·  ⑂ $it" } ?: ""

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/ChatPane.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/ChatPane.kt
@@ -1082,7 +1082,7 @@ internal fun ChatNotice(
  * undraggable — and, collapsed, with no way to reopen the sidebar.
  */
 @Composable
-private fun EmptyChatChromeRow(model: DesktopModel) {
+internal fun EmptyChatChromeRow(model: DesktopModel) {
     val chrome = LocalWindowChrome.current
     val edge = LocalPaneEdge.current
     Row(
@@ -1092,30 +1092,54 @@ private fun EmptyChatChromeRow(model: DesktopModel) {
     ) {
         // same choreography as [ChatSubHeader]'s cluster — and this row already sits at the sidebar
         // row's exact geometry (start 12, 38dp tall), so the late fade is a swap in place
-        AnimatedVisibility(
-            visible = model.sidebarCollapsed && edge.leftmost,
-            enter = expandHorizontally(tween(SIDEBAR_ANIM_MS)) +
-                fadeIn(tween(100, delayMillis = SIDEBAR_ANIM_MS - 80)),
-            exit = shrinkHorizontally(tween(SIDEBAR_ANIM_MS)) + fadeOut(tween(80)),
-        ) {
-            Row(horizontalArrangement = Arrangement.spacedBy(10.dp), verticalAlignment = Alignment.CenterVertically) {
-                if (chrome.mac && !chrome.fullscreen) TrafficLights(chrome.onClose, chrome.onMinimize, chrome.onToggleFullscreen)
-                Row(horizontalArrangement = Arrangement.spacedBy(2.dp), verticalAlignment = Alignment.CenterVertically) {
-                    SidebarToggleButton(model)
-                    SessionNavButtons(model)
-                }
-            }
-        }
+        CollapsedChromeCluster(model, chrome, visible = model.sidebarCollapsed && edge.leftmost)
         Box(Modifier.weight(1f).height(38.dp).then(chrome.dragAndZoomModifier))
-        if (edge.rightmost) {
-            Box(
-                Modifier.size(28.dp).clip(RoundedCornerShape(6.dp)).hoverFill(RoundedCornerShape(6.dp))
-                    .clickable { model.showTray = !model.showTray },
-                contentAlignment = Alignment.Center,
-            ) { PulseDot(Tok.ok, 7.dp) }
-            if (!chrome.mac && !chrome.fullscreen) WinControls(chrome.onMinimize, chrome.onToggleMax, chrome.onClose)
+        if (edge.rightmost) TrailingWindowControls(model, chrome)
+    }
+}
+
+// The hand-off choreography, defined ONCE for both cluster hosts (the sub-header and the empty row):
+// the SPACE expands in step with the sidebar's slide — one continuous motion for whatever sits after
+// it — while the CONTROLS fade in late, after the sidebar's own copy has been wiped past, so the swap
+// reads as one cluster changing owners rather than two coexisting. Retuning is a one-place edit.
+private val CLUSTER_ENTER = expandHorizontally(tween(SIDEBAR_ANIM_MS)) +
+    fadeIn(tween(100, delayMillis = SIDEBAR_ANIM_MS - 80))
+private val CLUSTER_EXIT = shrinkHorizontally(tween(SIDEBAR_ANIM_MS)) + fadeOut(tween(80))
+
+/** The collapsed sidebar's controls, re-homed (mock frames 2 / 4b) — leftmost column only: the cluster
+ *  describes the window, and one window has one of it. One definition for both hosts, so they cannot
+ *  drift out of pixel alignment (the hand-off depends on it). */
+@Composable
+private fun CollapsedChromeCluster(
+    model: DesktopModel,
+    chrome: DesktopWindowChrome,
+    visible: Boolean,
+    divider: Boolean = false,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(visible = visible, enter = CLUSTER_ENTER, exit = CLUSTER_EXIT) {
+        Row(modifier, horizontalArrangement = Arrangement.spacedBy(10.dp), verticalAlignment = Alignment.CenterVertically) {
+            if (chrome.mac && !chrome.fullscreen) TrafficLights(chrome.onClose, chrome.onMinimize, chrome.onToggleFullscreen)
+            Row(horizontalArrangement = Arrangement.spacedBy(2.dp), verticalAlignment = Alignment.CenterVertically) {
+                SidebarToggleButton(model)
+                SessionNavButtons(model)
+            }
+            // the rule that keeps a sub-header reading title-first despite the cluster (mock:211)
+            if (divider) ChromeDivider()
         }
     }
+}
+
+/** The rightmost column's window-level tail: the connection dot (opens the tray) and, on Win/Linux,
+ *  min · max · close. One definition — the dot must read identical wherever it lands. */
+@Composable
+private fun TrailingWindowControls(model: DesktopModel, chrome: DesktopWindowChrome) {
+    Box(
+        Modifier.size(28.dp).clip(RoundedCornerShape(6.dp)).hoverFill(RoundedCornerShape(6.dp))
+            .clickable { model.showTray = !model.showTray },
+        contentAlignment = Alignment.Center,
+    ) { PulseDot(Tok.ok, 7.dp) }
+    if (!chrome.mac && !chrome.fullscreen) WinControls(chrome.onMinimize, chrome.onToggleMax, chrome.onClose)
 }
 
 /**
@@ -1145,35 +1169,15 @@ private fun ChatSubHeader(model: DesktopModel, onTerminalMenu: () -> Unit = {}) 
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {
-            // the collapsed sidebar's controls, re-homed (mock frames 2 / 4b). Leftmost column only: the
-            // cluster describes the window, and one window has one of it. The SPACE expands in step with
-            // the sidebar's slide (one continuous motion for the title — no reserve-then-push lurch);
-            // the CONTROLS fade in late, once the sidebar's own copy has been wiped past, so the
-            // hand-off reads as one cluster changing owners rather than two coexisting.
-            AnimatedVisibility(
-                visible = clusterHere,
-                enter = expandHorizontally(tween(SIDEBAR_ANIM_MS)) +
-                    fadeIn(tween(100, delayMillis = SIDEBAR_ANIM_MS - 80)),
-                exit = shrinkHorizontally(tween(SIDEBAR_ANIM_MS)) + fadeOut(tween(80)),
-            ) {
-                Row(
-                    // −5dp: center the 28dp controls at y19 — the sidebar control row's centerline
-                    // (38dp tall) — inside this row's 28+20dp geometry, without touching its height
-                    Modifier.offset(y = (-5).dp),
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    if (chrome.mac && !chrome.fullscreen) TrafficLights(chrome.onClose, chrome.onMinimize, chrome.onToggleFullscreen)
-                    Row(horizontalArrangement = Arrangement.spacedBy(2.dp), verticalAlignment = Alignment.CenterVertically) {
-                        SidebarToggleButton(model)
-                        SessionNavButtons(model)
-                    }
-                    // the rule that keeps the sub-header reading title-first despite the cluster (mock:211)
-                    ChromeDivider()
-                }
-            }
+            CollapsedChromeCluster(
+                model, chrome, visible = clusterHere, divider = true,
+                // −5dp: center the 28dp controls at y19 — the sidebar control row's centerline
+                // (38dp tall) — inside this row's 28+20dp geometry, without touching its height
+                modifier = Modifier.offset(y = (-5).dp),
+            )
             Text(
                 model.chatTitle, color = Tok.tx, fontFamily = Dk.ui, fontSize = 15.sp, fontWeight = FontWeight.SemiBold,
+                style = tightCenter(15.sp),
                 maxLines = 1, overflow = TextOverflow.Ellipsis,
                 // the title region is the window's drag handle, exactly as the title bar's label region
                 // was — and for the same reason it is the ONLY thing wearing it: this row's own buttons
@@ -1223,16 +1227,7 @@ private fun ChatSubHeader(model: DesktopModel, onTerminalMenu: () -> Unit = {}) 
             }
             // ONCE per window, at the right end of the RIGHTMOST column (design frame 4): the link is a
             // window-level fact, and a dot per column would read as a per-conversation one. Opens the tray.
-            if (edge.rightmost) {
-                Box(
-                    Modifier.size(28.dp).clip(RoundedCornerShape(6.dp)).hoverFill(RoundedCornerShape(6.dp))
-                        .clickable { model.showTray = !model.showTray },
-                    contentAlignment = Alignment.Center,
-                ) { PulseDot(Tok.ok, 7.dp) }
-                // Windows/Linux min · max · close land here too — macOS keeps its traffic lights on the
-                // leading edge, and in fullscreen neither platform draws window buttons at all (#94).
-                if (!chrome.mac && !chrome.fullscreen) WinControls(chrome.onMinimize, chrome.onToggleMax, chrome.onClose)
-            }
+            if (edge.rightmost) TrailingWindowControls(model, chrome)
         }
         val branch = model.chatBranch?.let { "  ·  ⑂ $it" } ?: ""
         // machine-first line: which computer this session lives on leads the mono meta (fleet language)

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopApp.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopApp.kt
@@ -129,27 +129,7 @@ fun DesktopApp(model: DesktopModel, onActivateWindow: () -> Unit = {}) {
             // with it the hairline that used to stand in for the missing sidebar. The way back is the
             // toggle in the leftmost sub-header's control cluster, or ⌘\ — both always available.
             //
-            // The hide/show SLIDES: the box's width animates while the sidebar inside keeps its full
-            // width and clips, so rows never reflow mid-flight and the control cluster stays put until
-            // the edge sweeps past it (an instant swap read as the top-left corner jumping). First
-            // composition starts at the target, so launching collapsed doesn't play the slide.
-            val animW by animateFloatAsState(
-                targetValue = if (collapsed) 0f else sidebarW,
-                animationSpec = tween(SIDEBAR_ANIM_MS, easing = FastOutSlowInEasing),
-                label = "sidebar-width",
-            )
-            if (animW > 0.5f) {
-                Box(Modifier.width(animW.dp).fillMaxHeight().clipToBounds()) {
-                    // unbounded + Start: the sidebar must MEASURE at its full width whatever the box
-                    // animates through — a plain width() child gets clamped by the box's constraints and
-                    // the whole column re-lays-out at every frame of the slide (rows wrapping to 40px was
-                    // the "severe jitter"). This way the layout is computed once and the edge just wipes.
-                    Sidebar(
-                        model, width = sidebarW.dp,
-                        modifier = Modifier.wrapContentWidth(align = Alignment.Start, unbounded = true),
-                    )
-                }
-            }
+            AnimatedSidebar(model, collapsed, sidebarW)
             if (!collapsed) {
                 SidebarResizeHandle(
                     onDrag = { dxPx ->
@@ -447,6 +427,32 @@ private fun SplitDropOverlay(drag: SplitDragState, model: DesktopModel) {
 // the sidebar hidden rather than stopping at the floor.
 /** Long enough that the launch-time check never competes with connect + first paint (issue #200). */
 private const val STARTUP_UPDATE_CHECK_DELAY_MS = 8_000L
+/**
+ * The sliding sidebar. The hide/show animates the BOX's width while the sidebar inside keeps its full
+ * width and clips — rows never reflow mid-flight (a plain width() child gets clamped by the box's
+ * constraints and re-lays-out at every frame: the "severe jitter"), and the control cluster stays put
+ * until the edge sweeps past it. First composition starts at the target, so launching collapsed plays
+ * no slide. Its own composable ON PURPOSE: the animated float is read here and nowhere else, so the
+ * ~12 frames of a toggle invalidate this box alone — read one scope up, they re-ran every sibling chat
+ * column's body per frame (DesktopModel is unstable, nothing in that row is skippable).
+ */
+@Composable
+private fun AnimatedSidebar(model: DesktopModel, collapsed: Boolean, sidebarW: Float) {
+    val animW by animateFloatAsState(
+        targetValue = if (collapsed) 0f else sidebarW,
+        animationSpec = tween(SIDEBAR_ANIM_MS, easing = FastOutSlowInEasing),
+        label = "sidebar-width",
+    )
+    if (animW > 0.5f) {
+        Box(Modifier.width(animW.dp).fillMaxHeight().clipToBounds()) {
+            Sidebar(
+                model, width = sidebarW.dp,
+                modifier = Modifier.wrapContentWidth(align = Alignment.Start, unbounded = true),
+            )
+        }
+    }
+}
+
 /** One clock for the sidebar slide and everything choreographed against it (the sub-header's cluster
  *  hand-off, its padding ease) — shared so the pieces cannot drift apart. */
 internal const val SIDEBAR_ANIM_MS = 200

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopApp.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopApp.kt
@@ -103,23 +103,23 @@ fun DesktopApp(model: DesktopModel, onActivateWindow: () -> Unit = {}) {
     // move without adding a node, so the band costs nothing and the pointer crossing x≤8dp on its way
     // to the edge is what triggers.
     var pointerAtLeftEdge by remember { mutableStateOf(false) }
-    val edgePx = with(density) { HOVER_REVEAL_EDGE.dp.toPx() }
+    val edgePx = remember(density) { with(density) { HOVER_REVEAL_EDGE.dp.toPx() } }
+    // The Move observer is on the whole window's hit path, so it only rides while the feature it feeds
+    // can do anything — expanded (the default state) pays nothing for it. An Exit through the LEFT
+    // border keeps the band armed (the pointer went into the AWT resize band, where Compose gets no
+    // events — clearing there made the peek retract the instant it reached the edge it was invited to
+    // rest on); the parked-outside-the-window case is what the reveal block's MouseInfo watchdog is for.
     @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
-    Box(
-        Modifier.fillMaxSize().background(Tok.base)
-            .onPointerEvent(androidx.compose.ui.input.pointer.PointerEventType.Move) { e ->
-                val near = (e.changes.lastOrNull()?.position?.x ?: Float.MAX_VALUE) <= edgePx
-                if (near != pointerAtLeftEdge) pointerAtLeftEdge = near // write only on change — this runs on every move
-            }
-            .onPointerEvent(androidx.compose.ui.input.pointer.PointerEventType.Exit) { e ->
-                // Leaving THROUGH the left border — into the AWT resize band, where Compose gets no
-                // events at all — still counts as hugging the edge: clearing unconditionally here made
-                // the peek retract the instant the pointer reached the very edge it was invited to rest
-                // on. Only an exit through any OTHER border ends the band.
-                val stillLeft = (e.changes.lastOrNull()?.position?.x ?: Float.MAX_VALUE) <= edgePx
-                if (pointerAtLeftEdge != stillLeft) pointerAtLeftEdge = stillLeft
-            },
-    ) {
+    val edgeWatch = if (!collapsed) Modifier else Modifier
+        .onPointerEvent(androidx.compose.ui.input.pointer.PointerEventType.Move) { e ->
+            val near = (e.changes.lastOrNull()?.position?.x ?: Float.MAX_VALUE) <= edgePx
+            if (near != pointerAtLeftEdge) pointerAtLeftEdge = near // write only on change — this runs on every move
+        }
+        .onPointerEvent(androidx.compose.ui.input.pointer.PointerEventType.Exit) { e ->
+            val stillLeft = (e.changes.lastOrNull()?.position?.x ?: Float.MAX_VALUE) <= edgePx
+            if (pointerAtLeftEdge != stillLeft) pointerAtLeftEdge = stillLeft
+        }
+    Box(Modifier.fillMaxSize().background(Tok.base).then(edgeWatch)) {
         // drag-to-split: the one gesture state shared between the sidebar (where a drag starts) and the
         // chat columns (where it lands). Provided here so every row below can reach the same instance.
         val drag = remember { SplitDragState() }
@@ -235,6 +235,23 @@ fun DesktopApp(model: DesktopModel, onActivateWindow: () -> Unit = {}) {
                 } else if (revealed) {
                     delay(HOVER_REVEAL_GRACE_MS)
                     revealed = false
+                }
+            }
+            // The parked-outside watchdog: an exit through the LEFT border keeps the band armed (see the
+            // Move/Exit observers), which is right for the resize band but wrong once the pointer leaves
+            // the window entirely — Compose then delivers nothing, and the peek would sit painted over
+            // the chat until the pointer happened to come back. AWT still knows where the pointer is, so
+            // while revealed (and not held by an open surface) poll it: gone from the window = disarm.
+            val chrome = LocalWindowChrome.current
+            LaunchedEffect(revealed, heldOpen) {
+                val win = chrome.window ?: return@LaunchedEffect
+                while (revealed && !heldOpen) {
+                    delay(HOVER_REVEAL_WATCHDOG_MS)
+                    val at = runCatching { java.awt.MouseInfo.getPointerInfo()?.location }.getOrNull() ?: continue
+                    if (!win.bounds.contains(at)) {
+                        pointerAtLeftEdge = false
+                        break // the reveal effect above owns the grace + hide from here
+                    }
                 }
             }
             androidx.compose.animation.AnimatedVisibility(
@@ -437,12 +454,12 @@ internal const val SIDEBAR_ANIM_MS = 200
 private const val HOVER_REVEAL_EDGE = 8 // dp — the left-edge band that peeks the hidden sidebar (must
 // clear AWT's undecorated-window resize border, whose outer pixels never reach Compose)
 private const val HOVER_REVEAL_GRACE_MS = 250L // pointer-out grace before the peek tucks away
+private const val HOVER_REVEAL_WATCHDOG_MS = 400L // parked-outside poll cadence while the peek is up
 
 private const val SIDEBAR_MIN = 220f
 private const val SIDEBAR_MAX = 460f
 private const val SIDEBAR_COLLAPSE_AT = 170f
 private const val K_SIDEBAR_WIDTH = "desktop_sidebar_width"
-private const val K_SIDEBAR_COLLAPSED = "desktop_sidebar_collapsed"
 
 private val resizeCursor = PointerIcon(java.awt.Cursor(java.awt.Cursor.E_RESIZE_CURSOR))
 

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopApp.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopApp.kt
@@ -1,32 +1,35 @@
 package dev.ccpocket.app.desktop
 
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.KeyboardArrowRight
-import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -43,6 +46,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -50,7 +54,6 @@ import kotlin.math.roundToInt
 import dev.ccpocket.app.resources.Res
 import dev.ccpocket.app.resources.dir_picker_choose_here
 import dev.ccpocket.app.resources.dir_picker_remote_title
-import dev.ccpocket.app.resources.show_sidebar
 import dev.ccpocket.app.resources.your_computer
 import dev.ccpocket.app.data.paneIndexForSlot
 import dev.ccpocket.protocol.AgentKind
@@ -66,9 +69,11 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun DesktopApp(model: DesktopModel, onActivateWindow: () -> Unit = {}) {
     // sidebar sizing (issue #62): drag the divider to resize; drag it past the minimum (or double-click)
-    // to snap-hide it to the edge, where a slim strip brings it back. Persisted across relaunches. This is
-    // desktop-shell-local state — the seed/screenshot model keeps the default width and never collapses.
-    var collapsed by remember { mutableStateOf(SecureStore.getString(K_SIDEBAR_COLLAPSED) == "1") }
+    // to snap-hide it. The WIDTH stays desktop-shell-local state — the seed/screenshot model keeps the
+    // default. The COLLAPSED flag does not: the four top controls re-home into the leftmost chat
+    // sub-header when the sidebar goes away (desktop chrome v2), and that surface may be rendering over a
+    // SidePaneModel, so the fact has to live on the model. Same persistence key as before.
+    val collapsed = model.sidebarCollapsed
     var sidebarW by remember {
         mutableStateOf(
             (SecureStore.getString(K_SIDEBAR_WIDTH)?.toFloatOrNull() ?: Dk.sidebarWidth.value)
@@ -76,7 +81,6 @@ fun DesktopApp(model: DesktopModel, onActivateWindow: () -> Unit = {}) {
         )
     }
     val density = LocalDensity.current
-    val setCollapsed = { v: Boolean -> collapsed = v; SecureStore.putString(K_SIDEBAR_COLLAPSED, if (v) "1" else "0") }
     // One silent update check per launch (issue #200), extending the existing #87 checker rather than
     // adding a channel: it only ever moves updateState, never downloads — applying stays a click in
     // Settings ▸ About. Delayed so it can't compete with connect/first paint, and guarded on Idle so a
@@ -91,26 +95,71 @@ fun DesktopApp(model: DesktopModel, onActivateWindow: () -> Unit = {}) {
     LaunchedEffect(model.chatAgent) {
         if (!model.chatAgent.canInitiateSessionHandoff()) model.showHandoff = false
     }
-    Box(Modifier.fillMaxSize().background(Tok.base)) {
+    // Whether the pointer sits in the left-edge band that peeks a hidden sidebar. Observed on the ROOT
+    // container's pointer moves rather than a hit-test Box at the edge: the outermost pixels of an
+    // undecorated window belong to AWT's resize border (events there never reach Compose — the first
+    // cut's 4dp hover strip triggered nothing but the resize cursor), and a strip wide enough to clear
+    // that band would steal clicks from whatever sits under it. A parent on the hit path sees every
+    // move without adding a node, so the band costs nothing and the pointer crossing x≤8dp on its way
+    // to the edge is what triggers.
+    var pointerAtLeftEdge by remember { mutableStateOf(false) }
+    val edgePx = with(density) { HOVER_REVEAL_EDGE.dp.toPx() }
+    @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+    Box(
+        Modifier.fillMaxSize().background(Tok.base)
+            .onPointerEvent(androidx.compose.ui.input.pointer.PointerEventType.Move) { e ->
+                val near = (e.changes.lastOrNull()?.position?.x ?: Float.MAX_VALUE) <= edgePx
+                if (near != pointerAtLeftEdge) pointerAtLeftEdge = near // write only on change — this runs on every move
+            }
+            .onPointerEvent(androidx.compose.ui.input.pointer.PointerEventType.Exit) { e ->
+                // Leaving THROUGH the left border — into the AWT resize band, where Compose gets no
+                // events at all — still counts as hugging the edge: clearing unconditionally here made
+                // the peek retract the instant the pointer reached the very edge it was invited to rest
+                // on. Only an exit through any OTHER border ends the band.
+                val stillLeft = (e.changes.lastOrNull()?.position?.x ?: Float.MAX_VALUE) <= edgePx
+                if (pointerAtLeftEdge != stillLeft) pointerAtLeftEdge = stillLeft
+            },
+    ) {
         // drag-to-split: the one gesture state shared between the sidebar (where a drag starts) and the
         // chat columns (where it lands). Provided here so every row below can reach the same instance.
         val drag = remember { SplitDragState() }
         CompositionLocalProvider(LocalSplitDrag provides drag) {
         Row(Modifier.fillMaxSize()) {
-            if (collapsed) {
-                SidebarRevealStrip { setCollapsed(false) }
-                Box(Modifier.width(1.dp).fillMaxHeight().background(Tok.hair)) // pane splitter
-            } else {
-                Sidebar(model, width = sidebarW.dp)
+            // Collapsed = ZERO chrome on this edge (desktop chrome v2): the old reveal strip is gone, and
+            // with it the hairline that used to stand in for the missing sidebar. The way back is the
+            // toggle in the leftmost sub-header's control cluster, or ⌘\ — both always available.
+            //
+            // The hide/show SLIDES: the box's width animates while the sidebar inside keeps its full
+            // width and clips, so rows never reflow mid-flight and the control cluster stays put until
+            // the edge sweeps past it (an instant swap read as the top-left corner jumping). First
+            // composition starts at the target, so launching collapsed doesn't play the slide.
+            val animW by animateFloatAsState(
+                targetValue = if (collapsed) 0f else sidebarW,
+                animationSpec = tween(SIDEBAR_ANIM_MS, easing = FastOutSlowInEasing),
+                label = "sidebar-width",
+            )
+            if (animW > 0.5f) {
+                Box(Modifier.width(animW.dp).fillMaxHeight().clipToBounds()) {
+                    // unbounded + Start: the sidebar must MEASURE at its full width whatever the box
+                    // animates through — a plain width() child gets clamped by the box's constraints and
+                    // the whole column re-lays-out at every frame of the slide (rows wrapping to 40px was
+                    // the "severe jitter"). This way the layout is computed once and the edge just wipes.
+                    Sidebar(
+                        model, width = sidebarW.dp,
+                        modifier = Modifier.wrapContentWidth(align = Alignment.Start, unbounded = true),
+                    )
+                }
+            }
+            if (!collapsed) {
                 SidebarResizeHandle(
                     onDrag = { dxPx ->
                         val next = sidebarW + with(density) { dxPx.toDp().value }
-                        if (next < SIDEBAR_COLLAPSE_AT) setCollapsed(true)
+                        if (next < SIDEBAR_COLLAPSE_AT) model.setSidebarCollapsed(true)
                         else sidebarW = next.coerceIn(SIDEBAR_MIN, SIDEBAR_MAX)
                     },
                     // persist once per gesture, not per drag tick — putString rewrites a whole file
-                    onDragEnd = { if (!collapsed) SecureStore.putString(K_SIDEBAR_WIDTH, sidebarW.toString()) },
-                    onCollapse = { setCollapsed(true) },
+                    onDragEnd = { if (!model.sidebarCollapsed) SecureStore.putString(K_SIDEBAR_WIDTH, sidebarW.toString()) },
+                    onCollapse = { model.setSidebarCollapsed(true) },
                 )
             }
             val watch = model.watch
@@ -136,11 +185,19 @@ fun DesktopApp(model: DesktopModel, onActivateWindow: () -> Unit = {}) {
                     val focusedAt = model.splitFocusedSlot.coerceIn(0, split.size)
                     for (slot in 0..split.size) {
                         if (slot > 0) Box(Modifier.width(1.dp).fillMaxHeight().background(Tok.hair))
-                        if (slot == focusedAt) {
-                            SplitDropColumn(drag, slot, Modifier.weight(1f)) { ChatPane(model, Modifier.fillMaxSize(), focused = split.isNotEmpty()) }
-                        } else {
-                            val pane = split[paneIndexForSlot(slot, focusedAt)]
-                            SplitDropColumn(drag, slot, Modifier.weight(1f)) { SplitPane(model, pane, Modifier.fillMaxSize()) }
+                        // which column owns the window's chrome (desktop chrome v2): the re-homed control
+                        // cluster goes to the LEFTMOST sub-header, the connection dot and the Win/Linux
+                        // window buttons to the RIGHTMOST one — the dot appears once per window, because
+                        // that is what it describes. Provided per column so neither is a count of panes.
+                        val edge = PaneEdge(leftmost = slot == 0, rightmost = slot == split.size)
+                        SplitDropColumn(drag, slot, Modifier.weight(1f)) {
+                            CompositionLocalProvider(LocalPaneEdge provides edge) {
+                                if (slot == focusedAt) {
+                                    ChatPane(model, Modifier.fillMaxSize(), focused = split.isNotEmpty())
+                                } else {
+                                    SplitPane(model, split[paneIndexForSlot(slot, focusedAt)], Modifier.fillMaxSize())
+                                }
+                            }
                         }
                     }
                 }
@@ -159,14 +216,47 @@ fun DesktopApp(model: DesktopModel, onActivateWindow: () -> Unit = {}) {
             }
         }
         }
+        // Hover-reveal (desktop chrome v2 follow-up): while the sidebar is HIDDEN, resting the pointer
+        // on the window's left edge peeks the full sidebar OVER the chat — no reflow, the columns stay
+        // put — and leaving both the edge and the panel tucks it away after a short grace (diagonal
+        // travel must not flicker it). Held open while anything it spawned is up — the machine
+        // switcher, the bell, the new-session popover, a row's context menu (a sibling POPUP: the
+        // pointer moving into it reads as "left the panel"), or a drag-to-split in flight — so the
+        // surface can't slide away under an interaction that started inside it.
+        if (collapsed) {
+            val panelSrc = remember { MutableInteractionSource() }
+            val panelHovered by panelSrc.collectIsHoveredAsState()
+            var revealed by remember { mutableStateOf(false) }
+            val heldOpen = model.switcherOpen || model.showAttention || model.showNewSession ||
+                PocketContextMenuRepresentation.anyMenuOpen || drag.session != null
+            LaunchedEffect(pointerAtLeftEdge, panelHovered, heldOpen) {
+                if (pointerAtLeftEdge || panelHovered || heldOpen) {
+                    revealed = true
+                } else if (revealed) {
+                    delay(HOVER_REVEAL_GRACE_MS)
+                    revealed = false
+                }
+            }
+            androidx.compose.animation.AnimatedVisibility(
+                visible = revealed,
+                enter = androidx.compose.animation.slideInHorizontally(tween(SIDEBAR_ANIM_MS)) { -it },
+                exit = androidx.compose.animation.slideOutHorizontally(tween(SIDEBAR_ANIM_MS)) { -it },
+                modifier = Modifier.align(Alignment.TopStart),
+            ) {
+                Row(Modifier.fillMaxHeight().hoverable(panelSrc)) {
+                    Sidebar(model, width = sidebarW.dp)
+                    Box(Modifier.width(1.dp).fillMaxHeight().background(Tok.hair))
+                }
+            }
+        }
         // drag-to-split feedback: composed right after the columns, so it paints above them and BELOW
         // every modal/popover that follows — and both it and the drop itself stand down entirely while
         // any overlay is open, so a popover can neither hide the highlight nor be dropped through
         SplitDropOverlay(drag, model)
         if (model.showNewSession) {
             LaunchedEffect(Unit) { model.fetchModels(AgentKind.CLAUDE) }
-            // anchored under the sidebar's New-session row (header 48 + row 32)
-            Overlay(onDismiss = { model.showNewSession = false }, alignment = Alignment.TopStart, padding = PaddingValues(start = 14.dp, top = 84.dp)) {
+            // anchored under the sidebar's New-session row (control row 38 + device line 27 + row 32)
+            Overlay(onDismiss = { model.showNewSession = false }, alignment = Alignment.TopStart, padding = PaddingValues(start = 14.dp, top = 100.dp)) {
                 NewSessionPopover(
                     model.newSessionSeed ?: "~/",
                     model.defaultAgent,
@@ -208,14 +298,15 @@ fun DesktopApp(model: DesktopModel, onActivateWindow: () -> Unit = {}) {
             }
         }
         if (model.switcherOpen) {
-            // anchored under the sidebar header — the fleet lives here now, not in the sidebar body
-            Overlay(onDismiss = { model.switcherOpen = false }, alignment = Alignment.TopStart, padding = PaddingValues(start = 10.dp, top = 52.dp)) {
+            // anchored under the sidebar's device line — the fleet lives here now, not in the sidebar body
+            // (control row 38 + device line 26 + hairline; +16 since the chrome-v2 row landed above it)
+            Overlay(onDismiss = { model.switcherOpen = false }, alignment = Alignment.TopStart, padding = PaddingValues(start = 10.dp, top = 68.dp)) {
                 MachineSwitcher(model)
             }
         }
         if (model.showAttention) {
             // anchored under the sidebar bell — cross-machine approvals without leaving the session
-            Overlay(onDismiss = { model.showAttention = false }, alignment = Alignment.TopStart, padding = PaddingValues(start = 14.dp, top = 52.dp)) {
+            Overlay(onDismiss = { model.showAttention = false }, alignment = Alignment.TopStart, padding = PaddingValues(start = 14.dp, top = 68.dp)) {
                 AttentionPopover(model)
             }
         }
@@ -287,6 +378,18 @@ fun DesktopApp(model: DesktopModel, onActivateWindow: () -> Unit = {}) {
     }
 }
 
+/**
+ * Where a chat column sits in the row (desktop chrome v2) — which one carries the window's chrome.
+ *
+ * The default is BOTH: a single chat column is the leftmost and the rightmost one, which is also what the
+ * watch split wants (its [WatchPane] half is a read-only mirror and grows no chrome) and what every test
+ * and screenshot that composes a [ChatPane] directly should see. Only [DesktopApp]'s split loop narrows it.
+ */
+@Immutable
+data class PaneEdge(val leftmost: Boolean = true, val rightmost: Boolean = true)
+
+val LocalPaneEdge = staticCompositionLocalOf { PaneEdge() }
+
 /** A chat column that reports where it laid out, so the drag-to-split zones can hover over it. */
 @Composable
 private fun SplitDropColumn(drag: SplitDragState, index: Int, modifier: Modifier, content: @Composable () -> Unit) {
@@ -327,6 +430,14 @@ private fun SplitDropOverlay(drag: SplitDragState, model: DesktopModel) {
 // the sidebar hidden rather than stopping at the floor.
 /** Long enough that the launch-time check never competes with connect + first paint (issue #200). */
 private const val STARTUP_UPDATE_CHECK_DELAY_MS = 8_000L
+/** One clock for the sidebar slide and everything choreographed against it (the sub-header's cluster
+ *  hand-off, its padding ease) — shared so the pieces cannot drift apart. */
+internal const val SIDEBAR_ANIM_MS = 200
+
+private const val HOVER_REVEAL_EDGE = 8 // dp — the left-edge band that peeks the hidden sidebar (must
+// clear AWT's undecorated-window resize border, whose outer pixels never reach Compose)
+private const val HOVER_REVEAL_GRACE_MS = 250L // pointer-out grace before the peek tucks away
+
 private const val SIDEBAR_MIN = 220f
 private const val SIDEBAR_MAX = 460f
 private const val SIDEBAR_COLLAPSE_AT = 170f
@@ -347,18 +458,6 @@ private fun SidebarResizeHandle(onDrag: (Float) -> Unit, onDragEnd: () -> Unit, 
         contentAlignment = Alignment.Center,
     ) {
         Box(Modifier.width(1.dp).fillMaxHeight().background(Tok.hair))
-    }
-}
-
-/** When the sidebar is hidden to the edge (issue #62), a slim strip that brings it back — click anywhere. */
-@Composable
-private fun SidebarRevealStrip(onExpand: () -> Unit) {
-    Column(
-        Modifier.width(16.dp).fillMaxHeight().background(Tok.surface).clickable(onClick = onExpand),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Spacer(Modifier.height(12.dp))
-        Icon(Icons.Rounded.KeyboardArrowRight, stringResource(Res.string.show_sidebar), tint = Tok.muted, modifier = Modifier.width(15.dp).height(15.dp))
     }
 }
 

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopCrashGuard.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopCrashGuard.kt
@@ -78,10 +78,26 @@ object DesktopCrashGuard {
         runCatching {
             Thread.setDefaultUncaughtExceptionHandler { thread, t ->
                 val where = "thread=${thread.name}"
-                if (isUiThread(thread.name)) fatal(ERR_UNCAUGHT, t, where) else note(ERR_UNCAUGHT, t, where)
+                if (isUiThread(thread.name) && !isBenignJdkTrayNpe(t)) fatal(ERR_UNCAUGHT, t, where)
+                else note(ERR_UNCAUGHT, t, where)
             }
         }
     }
+
+    /**
+     * The one EDT escape that must NOT take the app down: clicking the tray icon while AWT's
+     * [java.awt.LightweightDispatcher] happens to have its global drag listener registered NPEs inside
+     * the JDK itself — a TrayIcon mouse event carries no Component, and the listener dereferences it
+     * (observed as `Cannot invoke Component.isShowing() because <local6> is null`, the whole stack JDK
+     * frames). Nothing of ours is involved and the event queue is healthy afterwards, so treating it as
+     * fatal turned a JDK bug into "clicking the menu-bar icon sometimes quits the app". Matched
+     * NARROWLY — this exact dispatcher frame plus a TrayIcon frame — so no real fault can hide in it.
+     */
+    internal fun isBenignJdkTrayNpe(t: Throwable): Boolean =
+        t is NullPointerException &&
+            t.stackTrace.firstOrNull()?.className == "java.awt.LightweightDispatcher" &&
+            t.stackTrace.firstOrNull()?.methodName == "eventDispatched" &&
+            t.stackTrace.any { it.className == "java.awt.TrayIcon" }
 
     /**
      * Which threads' deaths must take the process with them.

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopCrashGuard.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopCrashGuard.kt
@@ -93,11 +93,20 @@ object DesktopCrashGuard {
      * fatal turned a JDK bug into "clicking the menu-bar icon sometimes quits the app". Matched
      * NARROWLY — this exact dispatcher frame plus a TrayIcon frame — so no real fault can hide in it.
      */
-    internal fun isBenignJdkTrayNpe(t: Throwable): Boolean =
-        t is NullPointerException &&
-            t.stackTrace.firstOrNull()?.className == "java.awt.LightweightDispatcher" &&
-            t.stackTrace.firstOrNull()?.methodName == "eventDispatched" &&
+    internal fun isBenignJdkTrayNpe(t: Throwable): Boolean {
+        if (t !is NullPointerException) return false
+        val top = t.stackTrace.firstOrNull()
+        // A recurring benign NPE eventually loses its stack to HotSpot's OmitStackTraceInFastThrow (C2
+        // pre-allocates a stackless instance after enough throws at one site). An EDT NPE that made it
+        // this far repeatedly WITHOUT killing the process can only be one the full-stack matcher below
+        // already pardoned — a real app NPE would have been fatal on its first, fully-stacked throw —
+        // so the stackless recurrence inherits the pardon rather than reverting to "the menu-bar icon
+        // sometimes quits the app, but only on aged processes".
+        if (t.stackTrace.isEmpty()) return true
+        return top?.className == "java.awt.LightweightDispatcher" &&
+            top.methodName == "eventDispatched" &&
             t.stackTrace.any { it.className == "java.awt.TrayIcon" }
+    }
 
     /**
      * Which threads' deaths must take the process with them.

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopModel.kt
@@ -542,7 +542,10 @@ interface DesktopModel {
     val canRenameSessions: Boolean get() = false
     /** Rename [sessionId]'s title — lands claude's own `custom-title` record on the daemon, which
      *  re-pushes Sessions to refresh the row (no optimistic local edit). */
-    fun renameSession(sessionId: String, title: String) {}
+    /** [wd] = the ROW's own project dir — the RenameSession frame resolves against a directory, and
+     *  defaulting it to the live-listed one mis-targets a rename issued from another project's row
+     *  (which is why the verb used to be gated to the current group). Null keeps the old default. */
+    fun renameSession(sessionId: String, title: String, wd: String? = null) {}
     /** The daemon's refusal of the last rename, iff it targeted [sessionId] (else null) — the sidebar
      *  row re-enters its edit state and shows this inline. Session-scoped feedback because the failure
      *  frame is session-independent: it must land on the row that ASKED, not in whatever chat happens

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopModel.kt
@@ -388,6 +388,10 @@ interface DesktopModel {
      *  conversation and killed the turn the user was watching one column over. */
     fun stopSideTurn(pane: SidePane) {}
 
+    /** Switch a pane's OWN model — the composer chip in a column. Pane-keyed like every side verb, so
+     *  the popover's pick can never land on the focused conversation. */
+    fun switchSideModel(pane: SidePane, name: String) {}
+
     /** Decide a pane's approval. Keyed by the ASK the column is holding — not by whatever the focused
      *  conversation happens to be blocked on, and not by an inbox row that may not be there. */
     fun resolvePaneApproval(ask: PermissionAsk, allow: Boolean, remember: Boolean = false) {}

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopModel.kt
@@ -465,6 +465,27 @@ interface DesktopModel {
     fun openProject(p: DkProject)
     fun selectSession(s: DkSession)
 
+    // ── window chrome: the sidebar's collapsed state ──────────────────────────────────────────────
+    // Lifted out of DesktopApp's local state by the desktop-chrome-v2 redesign: with no window-wide title
+    // bar left, the four top controls live in the SIDEBAR's own control row while it is open and re-home
+    // into the leftmost chat sub-header once it is collapsed. That second surface is rendered from a
+    // SidePaneModel in a split column, so "is the sidebar collapsed" has to be a MODEL fact rather than a
+    // value only the shell composable can see. Inert default: seed/preview models always render expanded.
+    val sidebarCollapsed: Boolean get() = false
+    /** Hide/show the sidebar — the control row's panel-left button, ⌘\, and the divider's collapse drag. */
+    fun setSidebarCollapsed(v: Boolean) {}
+
+    // ── session navigation history: the sidebar control row's ‹ › and ⌘[ / ⌘] ────────────────────
+    // Browser semantics over sessions that actually OPENED (recorded at the SessionLive echo, so every
+    // entry point counts — sidebar rows, pins, the palette, brand-new sessions). Inert defaults keep
+    // the seed/preview/test models untouched.
+    val canGoBack: Boolean get() = false
+    val canGoForward: Boolean get() = false
+    /** Reopen the previously visited session; no-op when the history has nothing behind the cursor. */
+    fun goBack() {}
+    /** Reopen the next session after a [goBack]; a fresh navigation truncates this branch. */
+    fun goForward() {}
+
     /** Remove a session row from the RECENT list — the row's hover ✕ (issue #62). Non-destructive: the
      *  transcript stays on the host and reopening its project resurfaces it. No-op for seed/preview models. */
     fun hideSession(s: DkSession) {}

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/PocketContextMenu.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/PocketContextMenu.kt
@@ -1,0 +1,161 @@
+package dev.ccpocket.app.desktop
+
+import androidx.compose.foundation.ContextMenuItem
+import androidx.compose.foundation.ContextMenuRepresentation
+import androidx.compose.foundation.ContextMenuState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import androidx.compose.ui.window.rememberPopupPositionProviderAtPosition
+import dev.ccpocket.app.theme.Tok
+
+/**
+ * A [ContextMenuItem] carrying the presentation facts the design's menu draws from ("Context Menu v1"
+ * handoff): [removal] = the destructive-ish tail verb, normal at rest and danger-tinted only under the
+ * pointer (a red label at rest pulls the eye down the whole menu); [mutedPrefix] = the two-tone
+ * "Move to group ·" lead-in. Plain [ContextMenuItem]s (text-field cut/copy/paste) render as NORMAL rows,
+ * which is what keeps this one representation serving every menu in the app.
+ */
+class PocketMenuItem(
+    label: String,
+    val removal: Boolean = false,
+    val mutedPrefix: String? = null,
+    onClick: () -> Unit,
+) : ContextMenuItem(label, onClick)
+
+/** Marker rendered as the family separator rule — never a row. See [joinMenuFamilies]. */
+object PocketMenuSeparator : ContextMenuItem("", {})
+
+/** Join verb families into one flat item list with a [PocketMenuSeparator] at every non-empty boundary —
+ *  the caller thinks in families (navigate / edit / file / remove), the wire stays a flat list. */
+fun joinMenuFamilies(vararg families: List<ContextMenuItem>): List<ContextMenuItem> =
+    families.filter { it.isNotEmpty() }
+        .reduceOrNull { acc, f -> acc + PocketMenuSeparator + f } ?: emptyList()
+
+/**
+ * The app-wide context menu (design "Context Menu v1"): raised surface, hairline border, r10, and the
+ * macOS-style inner-pill hover. Installed once over the whole shell via [LocalContextMenuRepresentation]
+ * in [dev.ccpocket.app.main], so the sidebar's session menus and every text field's cut/copy/paste all
+ * stop rendering the stock Swing-grey menu.
+ */
+object PocketContextMenuRepresentation : ContextMenuRepresentation {
+    private val openMenus = androidx.compose.runtime.mutableStateOf(0)
+
+    /** Any context menu on screen — the sidebar's hover-reveal holds itself open on this, so a panel
+     *  can't slide away under the menu it just spawned (the popup is a sibling window; the pointer
+     *  moving into it reads as "left the sidebar"). */
+    val anyMenuOpen: Boolean get() = openMenus.value > 0
+
+    // rememberPopupPositionProviderAtPosition — the same cursor-anchored provider the stock
+    // representation uses; experimental in name only for this positioning use.
+    @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+    @Composable
+    override fun Representation(state: ContextMenuState, items: () -> List<ContextMenuItem>) {
+        val status = state.status as? ContextMenuState.Status.Open ?: return
+        androidx.compose.runtime.DisposableEffect(Unit) {
+            openMenus.value++
+            onDispose { openMenus.value-- }
+        }
+        val close = { state.status = ContextMenuState.Status.Closed }
+        Popup(
+            popupPositionProvider = rememberPopupPositionProviderAtPosition(positionPx = status.rect.center),
+            onDismissRequest = close,
+            properties = PopupProperties(focusable = true), // the popup owns the keyboard — Esc must close from inside
+        ) {
+            val shape = RoundedCornerShape(10.dp)
+            Column(
+                Modifier
+                    .shadow(12.dp, shape)
+                    .clip(shape)
+                    .background(Tok.raised)
+                    .border(1.dp, Tok.hair, shape)
+                    .padding(vertical = 5.dp)
+                    .widthIn(min = 180.dp, max = 260.dp)
+                    .width(IntrinsicSize.Max)
+                    .verticalScroll(rememberScrollState()) // a menu taller than the window still reaches its tail
+                    .onPreviewKeyEvent { e ->
+                        if (e.type == KeyEventType.KeyDown && e.key == Key.Escape) { close(); true } else false
+                    },
+            ) {
+                items().forEach { item ->
+                    if (item === PocketMenuSeparator) {
+                        Box(Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp).height(1.dp).background(Tok.hair))
+                    } else {
+                        MenuRow(item) { close(); item.onClick() }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MenuRow(item: ContextMenuItem, onPick: () -> Unit) {
+    val src = remember { MutableInteractionSource() }
+    val hovered by src.collectIsHoveredAsState()
+    val pressed by src.collectIsPressedAsState()
+    val removal = (item as? PocketMenuItem)?.removal == true
+    val lit = hovered || pressed
+    val fill = when {
+        removal && lit -> Tok.danger.copy(alpha = 0.12f)
+        pressed -> PRESSED_FILL
+        hovered -> Tok.hair
+        else -> Color.Transparent
+    }
+    Row(
+        Modifier.fillMaxWidth().padding(horizontal = 4.dp).height(28.dp)
+            .clip(RoundedCornerShape(6.dp)).background(fill)
+            .hoverable(src).clickable(interactionSource = src, indication = null, onClick = onPick)
+            .padding(horizontal = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        (item as? PocketMenuItem)?.mutedPrefix?.let {
+            Text(it, color = Tok.tx2, fontFamily = Dk.ui, fontSize = 12.5.sp, style = tightCenter(12.5.sp), maxLines = 1)
+        }
+        Text(
+            item.label, color = if (removal && lit) Tok.danger else Tok.tx,
+            fontFamily = Dk.ui, fontSize = 12.5.sp, style = tightCenter(12.5.sp),
+            maxLines = 1, overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+/** The mock's pressed step (#33383E) — one notch above the hover fill. */
+private val PRESSED_FILL = Color(0xFF33383E)

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
@@ -843,10 +843,77 @@ class RepoDesktopModel(
 
     override fun selectSession(s: DkSession) { selectSessionReporting(s) }
 
+    /**
+     * Make [dir]'s project the LIVE-LISTED one when a session navigation lands outside it — the
+     * [PocketRepository.switchToSession] convention (repoint sessionsDir + fresh list), extended to the
+     * sidebar's session paths. Without it, `g.current` — and with it the #158/#202/#119 right-click
+     * verbs — only ever followed PROJECT clicks and the ⌘K switcher; a session click, a pin jump or a
+     * ⌘[/⌘] history step into another project left the previous dir "current" and the one the user is
+     * demonstrably in reduced to its non-current menu (just "Open in split").
+     * The OLD group is snapshotted first, so falling back from live rows keeps rows (an unsnapshotted
+     * group would render empty and the sidebar hides empty non-current groups).
+     */
+    private fun focusListedDir(dir: String) {
+        val cur = repo.sessionsDir.value
+        if (cur != null && sameDir(cur, dir)) return
+        snapshotCurrent()
+        repo.sessionsDir.value = dir
+        repo.listSessions(dir)
+    }
+
+    // ── session navigation history (the title bar's ‹ ›) ─────────────────────────────────────────
+    // Recorded off the sessionKey echo rather than the click handlers: every way a session opens —
+    // rows, pins, the palette, a brand-new ⌘N session — lands here through one seam, id in hand.
+    // The cursor-entry guard doubles as the back/forward re-record suppressor: [openNavEntry] moves
+    // the cursor BEFORE opening, so the landing echo matches the cursor entry and is not a new visit.
+    // In-memory on purpose — history is a within-run trail, not state worth resurrecting on launch.
+    private data class NavEntry(val accountId: String, val sessionId: String, val cwd: String, val title: String?, val agent: AgentKind)
+    private val navStack = mutableStateListOf<NavEntry>()
+    private var navCursor by mutableStateOf(-1)
+
+    init {
+        scope.launch {
+            // the PAIR, not the key alone: an open pins sessionKey before SessionLive brings workdir, so
+            // the very first session of a run would slip through a key-only flow (wd still null at pin time)
+            snapshotFlow { repo.sessionKey.value to repo.workdir.value }.collect { (id, wd) ->
+                val acct = repo.paired.value?.accountId ?: return@collect
+                if (id == null || wd == null || navStack.getOrNull(navCursor)?.sessionId == id) return@collect
+                while (navStack.size > navCursor + 1) navStack.removeAt(navStack.size - 1) // truncate the forward branch
+                navStack += NavEntry(acct, id, wd, repo.chatTitle.value, repo.sessionAgent.value ?: AgentKind.CLAUDE)
+                if (navStack.size > MAX_NAV_HISTORY) navStack.removeAt(0)
+                navCursor = navStack.size - 1
+            }
+        }
+    }
+
+    override val canGoBack: Boolean get() = navCursor > 0
+    override val canGoForward: Boolean get() = navCursor < navStack.size - 1
+    override fun goBack() { if (canGoBack) openNavEntry(navCursor - 1) }
+    override fun goForward() { if (canGoForward) openNavEntry(navCursor + 1) }
+
+    /** Reopen [navStack]'s [i]th entry — [openPin]'s open path (same or cross machine), minus recording. */
+    private fun openNavEntry(i: Int) {
+        val e = navStack[i]
+        navCursor = i // before the open — the landing echo must read this entry (see the recorder above)
+        navGen++ // user navigation — stop an in-flight RECENT refill from repointing the list (#102)
+        if (e.accountId == repo.paired.value?.accountId) {
+            focusDir(e.cwd)
+            focusListedDir(e.cwd) // a history step into another project brings its listing (and menus) along
+            optimisticSelectedId = e.sessionId
+            repo.openSession(wd = e.cwd, resumeId = e.sessionId, title = e.title, agent = e.agent)
+            return
+        }
+        optimisticSelectedId = null // another machine's session — nothing in the current list to pre-light
+        val target = repo.pairedList.firstOrNull { it.accountId == e.accountId } ?: return
+        switchMachine(target)
+        repo.requestOpenSession(e.cwd, e.sessionId, title = e.title, agent = e.agent)
+    }
+
     /** [selectSession] with [PocketRepository.openSession]'s verdict kept — promotion needs it. */
     private fun selectSessionReporting(s: DkSession): Boolean {
         navGen++ // user navigation — stop an in-flight RECENT refill from repointing the list (#102)
         focusDir(s.cwd) // clicking a session focuses its project too, so a following ⌘N lands there
+        focusListedDir(s.cwd) // …and makes it the listed one, so its right-click verbs come along
         optimisticSelectedId = s.sessionId // light the clicked row NOW, don't wait out the open (#82)
         return repo.openSession(wd = s.cwd, resumeId = s.sessionId, title = s.title, agent = s.agent)
     }
@@ -926,6 +993,7 @@ class RepoDesktopModel(
         navGen++ // user navigation — stop an in-flight RECENT refill from repointing the list (#102)
         if (p.accountId == repo.paired.value?.accountId) {
             focusDir(p.cwd) // jumping to a pin focuses its project, so a following ⌘N lands there
+            focusListedDir(p.cwd) // …and lists it, so the landing project's right-click verbs work
             optimisticSelectedId = p.sessionId // same as selectSession: light the target row through the open (#82)
             repo.openSession(wd = p.cwd, resumeId = p.sessionId, title = p.title, agent = p.agent)
             return
@@ -1454,7 +1522,11 @@ class RepoDesktopModel(
         const val K_TERMINAL_EMBED = "desktop_terminal_embed" // "1"/absent = embedded default, "0" = external (#153)
         const val K_TERMINAL_HEIGHT = "desktop_terminal_height" // dock height as a ChatPane fraction (#153)
         const val K_MENUBAR = "desktop_menubar_enabled" // menu-bar presence opt-out (issue #151); absent = on
+        // the sidebar's hidden-to-the-edge state (issue #62). Unchanged key/values: DesktopApp wrote exactly
+        // this before the chrome-v2 redesign lifted the state onto the model, so nobody's sidebar flips back.
+        const val K_SIDEBAR_COLLAPSED = "desktop_sidebar_collapsed"
         const val MAX_RECENT = 6 // RECENT groups kept per machine — enough context, never a wall
+        const val MAX_NAV_HISTORY = 50 // back/forward entries kept — a within-run trail, oldest dropped first
         const val DRAFT_DEBOUNCE_MS = 400L // composer draft persist debounce — matches the mobile composer (#88)
         const val REFILL_ECHO_TIMEOUT_MS = 4_000L // per-dir wait for the restored-RECENT sweep's listing echo (#102)
         const val REFILL_POLL_MS = 50L // echo poll cadence — snapshot notifications may not be pumping yet (#102)

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
@@ -1395,6 +1395,15 @@ class RepoDesktopModel(
         saveHeight = { store.putString(K_TERMINAL_HEIGHT, it.toString()) },
     )
 
+    // sidebar collapsed (desktop chrome v2) — desktop-only pref, persisted beside the pins under the SAME
+    // key DesktopApp used while it owned the state, so the setting survives the move. Absent = expanded.
+    private var sidebarCollapsedState by mutableStateOf(store.getString(K_SIDEBAR_COLLAPSED) == "1")
+    override val sidebarCollapsed: Boolean get() = sidebarCollapsedState
+    override fun setSidebarCollapsed(v: Boolean) {
+        sidebarCollapsedState = v
+        store.putString(K_SIDEBAR_COLLAPSED, if (v) "1" else "0")
+    }
+
     // menu-bar presence (issue #151) — desktop-only pref, persisted beside the pins. Absent = ON (the
     // environment layer defaults on; only an explicit "0" opts out, so upgrades gain the glyph).
     private var menuBarEnabledState by mutableStateOf(store.getString(K_MENUBAR) != "0")

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
@@ -807,7 +807,7 @@ class RepoDesktopModel(
             val dir = repo.sessionsDir.value ?: return false
             return repo.directories.none { sameDir(it.path, dir) && it.sharedBy != null }
         }
-    override fun renameSession(sessionId: String, title: String) { repo.renameSession(sessionId, title) }
+    override fun renameSession(sessionId: String, title: String, wd: String?) { repo.renameSession(sessionId, title, wd) }
     override fun renameError(sessionId: String): String? =
         repo.renameError.value?.takeIf { it.sessionId == sessionId }?.message
     override fun dismissRenameError() { repo.dismissRenameError() }

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
@@ -807,7 +807,14 @@ class RepoDesktopModel(
             val dir = repo.sessionsDir.value ?: return false
             return repo.directories.none { sameDir(it.path, dir) && it.sharedBy != null }
         }
-    override fun renameSession(sessionId: String, title: String, wd: String?) { repo.renameSession(sessionId, title, wd) }
+    override fun renameSession(sessionId: String, title: String, wd: String?) {
+        // acting on another project's row makes that project the listed one FIRST (the navigation
+        // convention) — the daemon answers these verbs with Sessions(thatDir), which repoints the
+        // listing anyway; going through focusListedDir means the outgoing group gets its snapshot
+        // instead of being left empty and hidden (#102's "empty non-current groups are hidden").
+        wd?.let { focusListedDir(it) }
+        repo.renameSession(sessionId, title, wd)
+    }
     override fun renameError(sessionId: String): String? =
         repo.renameError.value?.takeIf { it.sessionId == sessionId }?.message
     override fun dismissRenameError() { repo.dismissRenameError() }
@@ -863,6 +870,20 @@ class RepoDesktopModel(
         repo.listSessions(dir)
     }
 
+    // The backstop for the paths that never touch a sidebar verb: a push tap, a deep link, a launch
+    // restore. workdir only CHANGES when a conversation actually moves project (a reattach or a
+    // mid-chat re-announce re-sets the same value, which snapshotFlow dedups), so this cannot hijack
+    // a list the user browsed to while chatting — the failure that sank the commonMain SessionLive
+    // version of this rule (and phone routing derives screens from sessionsDir, so the rule must not
+    // live in shared code at all). Observe views excluded: watching must not repoint the listing.
+    init {
+        scope.launch {
+            snapshotFlow { repo.workdir.value }.collect { wd ->
+                if (wd != null && !repo.observing.value) focusListedDir(wd)
+            }
+        }
+    }
+
     // ── session navigation history (the title bar's ‹ ›) ─────────────────────────────────────────
     // Recorded off the sessionKey echo rather than the click handlers: every way a session opens —
     // rows, pins, the palette, a brand-new ⌘N session — lands here through one seam, id in hand.
@@ -879,7 +900,18 @@ class RepoDesktopModel(
             // the very first session of a run would slip through a key-only flow (wd still null at pin time)
             snapshotFlow { repo.sessionKey.value to repo.workdir.value }.collect { (id, wd) ->
                 val acct = repo.paired.value?.accountId ?: return@collect
-                if (id == null || wd == null || navStack.getOrNull(navCursor)?.sessionId == id) return@collect
+                if (id == null || wd == null) return@collect
+                val cur = navStack.getOrNull(navCursor)
+                if (cur?.sessionId == id) {
+                    // Not a new visit — but a cross-project open pins sessionKey a full RTT before
+                    // SessionLive moves workdir, so the entry recorded at pin time carries the PREVIOUS
+                    // project's dir. The settled pair lands here: correct the entry in place (title too,
+                    // same reason), or a later ⌘[ would resume this session against the wrong dirKey.
+                    if (cur.cwd != wd || cur.title != repo.chatTitle.value) {
+                        navStack[navCursor] = cur.copy(cwd = wd, title = repo.chatTitle.value ?: cur.title)
+                    }
+                    return@collect
+                }
                 while (navStack.size > navCursor + 1) navStack.removeAt(navStack.size - 1) // truncate the forward branch
                 navStack += NavEntry(acct, id, wd, repo.chatTitle.value, repo.sessionAgent.value ?: AgentKind.CLAUDE)
                 if (navStack.size > MAX_NAV_HISTORY) navStack.removeAt(0)
@@ -896,17 +928,22 @@ class RepoDesktopModel(
     /** Reopen [navStack]'s [i]th entry — [openPin]'s open path (same or cross machine), minus recording. */
     private fun openNavEntry(i: Int) {
         val e = navStack[i]
+        val from = navCursor
         navCursor = i // before the open — the landing echo must read this entry (see the recorder above)
         navGen++ // user navigation — stop an in-flight RECENT refill from repointing the list (#102)
         if (e.accountId == repo.paired.value?.accountId) {
             focusDir(e.cwd)
             focusListedDir(e.cwd) // a history step into another project brings its listing (and menus) along
             optimisticSelectedId = e.sessionId
-            repo.openSession(wd = e.cwd, resumeId = e.sessionId, title = e.title, agent = e.agent)
+            // A synchronously refused open (unsupported agent, duplicate target) moved nothing on
+            // screen — the cursor must not stay on a position the user isn't at, or the arrows lie
+            // and the NEXT navigation truncates live forward entries at the phantom spot.
+            if (!repo.openSession(wd = e.cwd, resumeId = e.sessionId, title = e.title, agent = e.agent)) navCursor = from
             return
         }
         optimisticSelectedId = null // another machine's session — nothing in the current list to pre-light
-        val target = repo.pairedList.firstOrNull { it.accountId == e.accountId } ?: return
+        val target = repo.pairedList.firstOrNull { it.accountId == e.accountId }
+        if (target == null) { navCursor = from; return } // machine unpaired since — same rollback rule
         switchMachine(target)
         repo.requestOpenSession(e.cwd, e.sessionId, title = e.title, agent = e.agent)
     }
@@ -1441,6 +1478,7 @@ class RepoDesktopModel(
         }
 
     override fun archiveSession(s: DkSession) {
+        focusListedDir(s.cwd) // same rule as renameSession — snapshot the outgoing group before the echo repoints
         repo.setSessionArchived(s.cwd, s.sessionId, archived = true, title = s.title, running = s.running)
     }
 

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
@@ -447,6 +447,8 @@ class RepoDesktopModel(
 
     override fun stopSideTurn(pane: SidePane) = repo.sidePanes.stopTurn(pane)
 
+    override fun switchSideModel(pane: SidePane, name: String) = repo.sidePanes.switchModel(pane, name)
+
     // The three verdict verbs all ride [PocketRepository.resolveAskDirect]: the ask the COLUMN is showing
     // decides, and the verdict goes out whether or not the machine-wide inbox still carries a row for it
     // (it legitimately may not — see that function's doc). The verdict fields mirror the focused path's

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SeedDesktopModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SeedDesktopModel.kt
@@ -70,7 +70,7 @@ open class SeedDesktopModel : DesktopModel {
     override fun assignGroup(sessionId: String, groupId: String?) { groupOverride[sessionId] = groupId }
     // session rename (issue #158) — local override so the seed exercises the sidebar entry
     override val canRenameSessions = true
-    override fun renameSession(sessionId: String, title: String) { titleOverride[sessionId] = title.trim() }
+    override fun renameSession(sessionId: String, title: String, wd: String?) { titleOverride[sessionId] = title.trim() }
     private val groupCollapse = mutableStateListOf<String>()
     override fun groupCollapsed(projectPath: String, groupId: String) = "$projectPath\u0000$groupId" in groupCollapse
     override fun setGroupCollapsed(projectPath: String, groupId: String, collapsed: Boolean) {

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SidePaneModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SidePaneModel.kt
@@ -130,6 +130,21 @@ class SidePaneModel(
     override fun focusThisPane() = base.promoteSplit(pane)
     override fun closeThisPane() = base.closeSplit(pane.paneId)
 
+    // ── window chrome, delegated EXPLICITLY (desktop chrome v2) ───────────────────────────────────
+    // These six are window-level in meaning (see the guard test's WINDOW_DELEGATED), but they are also the
+    // ONE family on this interface that ships a non-abstract default. `by base` is only guaranteed to
+    // forward what the interface leaves abstract, so a member with a body is exactly where a delegate can
+    // silently answer with the interface's inert default instead of the real model — and here that would
+    // mean the leftmost split column's re-homed chrome cluster never appearing (sidebarCollapsed stuck
+    // false) and its ‹ › arrows permanently greyed out (canGoBack/canGoForward stuck false). Spelled out
+    // so the answer cannot depend on that subtlety.
+    override val sidebarCollapsed: Boolean get() = base.sidebarCollapsed
+    override fun setSidebarCollapsed(v: Boolean) = base.setSidebarCollapsed(v)
+    override val canGoBack: Boolean get() = base.canGoBack
+    override val canGoForward: Boolean get() = base.canGoForward
+    override fun goBack() = base.goBack()
+    override fun goForward() = base.goForward()
+
     // ── PANE_INERT: focused-conversation verbs, deliberately no-ops here (see the class doc) ─────────
     override val historyHasMore: Boolean get() = false
     override val historyLoadingOlder: Boolean get() = false

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SidePaneModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SidePaneModel.kt
@@ -16,8 +16,9 @@ import dev.ccpocket.protocol.PermissionMode
  * machines, settings, overlays) falls through to [base], because it describes the window, not the chat.
  *
  * What is deliberately inert here, rather than delegated: the verbs that would act on the FOCUSED
- * conversation while the user is looking at this one. Changing the model, compacting, rewinding or
- * opening Changes from a side column must not quietly reach into another session, and silently doing
+ * conversation while the user is looking at this one. Compacting, rewinding or opening Changes from a
+ * side column must not quietly reach into another session (the MODEL chip earned a pane-scoped path —
+ * [SidePane.model] + the pane-keyed switch — instead of staying inert), and silently doing
  * the right thing for the wrong conversation is the one failure a split view must not have. They become
  * available the moment the pane is promoted (a click), which is also when they start meaning this
  * conversation. `PANE_INERT` marks every one of them.
@@ -48,7 +49,10 @@ class SidePaneModel(
     override val chatAgent: AgentKind get() = pane.agent
     override val chatWorkdir: String get() = pane.workdir
     override val chatBranch: String? get() = null
-    override val chatModel: String get() = ""
+    // the pane's OWN model (its SessionLive fills SidePane.model) — the chip used to answer "" here and
+    // read as "默认" while the session demonstrably ran something; switching routes through the
+    // pane-keyed verb, so a pick can never land on the focused conversation.
+    override val chatModel: String get() = pane.model.value ?: ""
     override val chatMode: PermissionMode get() = PermissionMode.DEFAULT
     override val messages: List<ChatItem> get() = pane.messages
     override val streaming: Boolean get() = pane.streaming.value
@@ -192,7 +196,7 @@ class SidePaneModel(
     override fun askHeartbeat() {}
     override fun askHeartbeatRelease() {}
     override fun canRewind(item: ChatItem.User): Boolean = false
-    override val chatModelId: String get() = ""
+    override val chatModelId: String get() = pane.model.value ?: ""
     override val chatPermissionMode: String? get() = null
     override val chatEffort: String? get() = null
     override val chatServiceTier: String? get() = null
@@ -203,7 +207,7 @@ class SidePaneModel(
     override fun browsePath(sub: String) {}
     override fun switchMode(m: PermissionMode) {}
     override fun switchMode(m: PermissionMode, permissionMode: String?) {}
-    override fun switchModel(name: String) {}
+    override fun switchModel(name: String) = base.switchSideModel(pane, name)
     override fun switchEffort(level: String?) {}
     override fun switchServiceTier(tier: String?) {}
     override fun compactConversation() {}
@@ -222,7 +226,10 @@ class SidePaneModel(
     override var showGit: Boolean
         get() = false
         set(_) {}
+    // pane-local popover state (like [composerState]): delegated, opening the chip in a column raised
+    // the FOCUSED composer's popover — visibly attached to the wrong column
+    private val showModelPopoverState = androidx.compose.runtime.mutableStateOf(false)
     override var showModelPopover: Boolean
-        get() = false
-        set(_) {}
+        get() = showModelPopoverState.value
+        set(v) { showModelPopoverState.value = v }
 }

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/Sidebar.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/Sidebar.kt
@@ -118,7 +118,6 @@ import dev.ccpocket.app.resources.open_folder
 import dev.ccpocket.app.resources.running
 import dev.ccpocket.app.resources.session_rename
 import dev.ccpocket.app.resources.split_open
-import dev.ccpocket.app.resources.unpin_session
 import dev.ccpocket.app.resources.session_rename_hint
 import dev.ccpocket.app.resources.settings_title
 import dev.ccpocket.app.resources.support_title
@@ -404,21 +403,23 @@ private fun PinRow(
     }
     val asSession = live ?: DkSession(p.sessionId, p.cwd, title, agent = p.agent)
     val splittable = !remote && splittableNow(model, asSession)
-    // rename/archive carry the pin's OWN cwd, so they work whatever the listing points at (same lift as
-    // the RECENT rows). Groups stay current-list only — the daemon lists groups per listed directory.
-    val inCurrentList = !remote && model.sessions.any { it.sessionId == p.sessionId }
-    val canRename = !remote && model.canRenameSessions && asSession.agent == AgentKind.CLAUDE
-    val menuGroups = if (inCurrentList && model.canEditGroups) model.customGroups else emptyList()
-    val canArchive = !remote && model.canArchiveSessions
     val openInSplit = stringResource(Res.string.split_open)
     val rename = stringResource(Res.string.session_rename)
     val moveTo = stringResource(Res.string.group_move_to)
     val moveOut = stringResource(Res.string.group_move_out)
     val archive = stringResource(Res.string.archive_session)
-    val unpinLabel = stringResource(Res.string.unpin_session)
+    val unpinLabel = stringResource(Res.string.unpin_project)
     ContextMenuArea(
         items = {
-            // same families as SessionRow: navigate → edit → file → remove, so the two menus read as one
+            // same families as SessionRow: navigate → edit → file → remove, so the two menus read as
+            // one. Capability reads live INSIDE this lambda — it runs when the menu opens, so N pin
+            // rows don't each rescan model.sessions on every Sessions push for a menu opened rarely.
+            // rename/archive carry the pin's OWN cwd (same lift as the RECENT rows); groups stay
+            // current-list only — the daemon lists groups per listed directory.
+            val inCurrentList = !remote && model.sessions.any { it.sessionId == p.sessionId }
+            val canRename = !remote && model.canRenameSessions && asSession.agent == AgentKind.CLAUDE
+            val menuGroups = if (inCurrentList && model.canEditGroups) model.customGroups else emptyList()
+            val canArchive = !remote && model.canArchiveSessions
             joinMenuFamilies(
                 buildList { if (splittable) add(PocketMenuItem(openInSplit) { model.openInSplit(asSession) }) },
                 buildList { if (canRename) add(PocketMenuItem(rename) { renaming = true }) },
@@ -471,12 +472,14 @@ private fun PinRow(
         }
         Text(
             title, color = Tok.tx, fontFamily = Dk.ui, fontSize = 13.sp, fontWeight = FontWeight.Medium,
+            style = tightCenter(13.sp),
             maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f),
         )
         if (remote && computer != null) {
             Icon(osIcon(computer.os), null, tint = Tok.muted, modifier = Modifier.size(11.dp))
             Text(
                 computer.name, color = Tok.muted, fontFamily = Dk.mono, fontSize = 10.sp,
+                style = tightCenter(10.sp),
                 maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.widthIn(max = 72.dp),
             )
         }
@@ -1143,13 +1146,18 @@ private fun SessionRow(
     // Claude only: rename lands a record in the session's transcript FILE — codex rollouts are
     // self-managed and opencode sessions live in SQLite (no file), so the daemon's rename path
     // fails for both; don't offer an entry that can only end in rename_failed.
-    val canRename = renameable && (s.agent == null || s.agent == AgentKind.CLAUDE)
+    // (agent is non-null on DkSession — the same predicate PinRow uses, kept identical on purpose)
+    val canRename = renameable && s.agent == AgentKind.CLAUDE
     // inline rename swaps the row for a prefilled title field (the group header's rename pattern);
     // committing sends the rename — the daemon re-pushes Sessions, which refreshes the row title.
     // A REFUSED rename (rename_failed) re-opens the editor with the daemon's reason inline: the ask
     // came from THIS row, so the feedback lands here — the chat transcript is the wrong surface (the
     // common refusal, a terminal-held session, is renamed with no chat open at all). Esc dismisses.
     var renaming by remember(s.sessionId) { mutableStateOf(false) }
+    // The refusal shows here UNCONDITIONALLY (the #158 contract, pinned by DesktopUiTest): the error is
+    // a daemon push that can land after this row recomposed or scrolled back in, so a "did *I* ask"
+    // gate would drop it. When the same session is also PINNED, the pin row's gated copy stays closed —
+    // this row is the one surface the refusal is guaranteed to reach.
     val renameError = model.renameError(s.sessionId)
     if (renaming || renameError != null) {
         Column {

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/Sidebar.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/Sidebar.kt
@@ -118,6 +118,7 @@ import dev.ccpocket.app.resources.open_folder
 import dev.ccpocket.app.resources.running
 import dev.ccpocket.app.resources.session_rename
 import dev.ccpocket.app.resources.split_open
+import dev.ccpocket.app.resources.unpin_session
 import dev.ccpocket.app.resources.session_rename_hint
 import dev.ccpocket.app.resources.settings_title
 import dev.ccpocket.app.resources.support_title
@@ -371,6 +372,65 @@ private fun PinRow(
     val pending = live?.pending ?: 0
     val dim = !remote && model.activeComputer?.online == false
     val shape = RoundedCornerShape(8.dp)
+    // live wins the label: a rename (from this row's menu or anywhere else) lands here immediately,
+    // instead of the stored pin-time snapshot going stale until the session is re-pinned
+    val title = live?.title ?: p.title
+    // Right-click parity with the RECENT rows (the #119/#158/#202/#311 verbs), scoped the same way:
+    // rename / groups / archive only when the pin's session is in the LIVE-LISTED project — liveSession
+    // is the same "current machine's loaded list" fact RECENT's g.current encodes — and split stays a
+    // this-machine gesture. RECENT's "Remove from recents" maps to this row's own removal verb: Unpin.
+    var renaming by remember(p.sessionId) { mutableStateOf(false) }
+    val renameError = model.renameError(p.sessionId)
+    if (renaming || renameError != null) {
+        Column {
+            GroupNameInput(
+                initial = title,
+                hint = stringResource(Res.string.session_rename_hint),
+                onCommit = { model.renameSession(p.sessionId, it, p.cwd); renaming = false },
+                onCancel = { renaming = false; model.dismissRenameError() },
+            )
+            if (renameError != null) {
+                Text(
+                    renameError, color = Tok.danger, fontFamily = Dk.ui, fontSize = 10.sp, lineHeight = 13.sp,
+                    modifier = Modifier.padding(start = 22.dp, end = 12.dp, top = 2.dp, bottom = 3.dp),
+                )
+            }
+        }
+        return
+    }
+    val asSession = live ?: DkSession(p.sessionId, p.cwd, title, agent = p.agent)
+    val splittable = !remote && splittableNow(model, asSession)
+    // rename/archive carry the pin's OWN cwd, so they work whatever the listing points at (same lift as
+    // the RECENT rows). Groups stay current-list only — the daemon lists groups per listed directory.
+    val inCurrentList = !remote && model.sessions.any { it.sessionId == p.sessionId }
+    val canRename = !remote && model.canRenameSessions && asSession.agent == AgentKind.CLAUDE
+    val menuGroups = if (inCurrentList && model.canEditGroups) model.customGroups else emptyList()
+    val canArchive = !remote && model.canArchiveSessions
+    val openInSplit = stringResource(Res.string.split_open)
+    val rename = stringResource(Res.string.session_rename)
+    val moveTo = stringResource(Res.string.group_move_to)
+    val moveOut = stringResource(Res.string.group_move_out)
+    val archive = stringResource(Res.string.archive_session)
+    val unpinLabel = stringResource(Res.string.unpin_session)
+    ContextMenuArea(
+        items = {
+            // same families as SessionRow: navigate → edit → file → remove, so the two menus read as one
+            joinMenuFamilies(
+                buildList { if (splittable) add(PocketMenuItem(openInSplit) { model.openInSplit(asSession) }) },
+                buildList { if (canRename) add(PocketMenuItem(rename) { renaming = true }) },
+                buildList {
+                    menuGroups.filter { it.id != live?.group }.forEach { grp ->
+                        add(PocketMenuItem(grp.name, mutedPrefix = "$moveTo ·") { model.assignGroup(p.sessionId, grp.id) })
+                    }
+                    if (live?.group != null) add(PocketMenuItem(moveOut) { model.assignGroup(p.sessionId, null) })
+                },
+                buildList {
+                    if (canArchive) add(PocketMenuItem(archive) { model.archiveSession(asSession) })
+                    add(PocketMenuItem(unpinLabel, removal = true) { model.unpin(p) })
+                },
+            )
+        },
+    ) {
     Row(
         Modifier.fillMaxWidth().height(32.dp)
             .then(
@@ -406,7 +466,7 @@ private fun PinRow(
             else -> Spacer(Modifier.width(5.dp))
         }
         Text(
-            p.title, color = Tok.tx, fontFamily = Dk.ui, fontSize = 13.sp, fontWeight = FontWeight.Medium,
+            title, color = Tok.tx, fontFamily = Dk.ui, fontSize = 13.sp, fontWeight = FontWeight.Medium,
             maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f),
         )
         if (remote && computer != null) {
@@ -425,6 +485,7 @@ private fun PinRow(
             )
             Key("⌘${index + 1}") // keycap on hover only — at rest the row is just title + state
         }
+    }
     }
 }
 
@@ -649,14 +710,15 @@ private fun RecentZone(model: DesktopModel, modifier: Modifier = Modifier) {
                     // sessions the current project can be moved between (owner + has groups) — drives the row
                     // right-click "move to group" menu; empty everywhere else so no menu appears.
                     val menuGroups = if (g.current && model.canEditGroups) custom else emptyList()
-                    // right-click "Rename session" (issue #158): the live-listed project's rows on an owner +
-                    // rename-capable daemon — same scoping as the group menu (a RECENT snapshot's dir isn't
-                    // the one the daemon would resolve the rename against).
-                    val renameable = g.current && model.canRenameSessions
-                    // #202: only the CURRENT project's rows. A non-current RECENT snapshot row would answer
-                    // with Sessions(thatProject), repointing the client's listed directory; those rows keep
-                    // the local hover-✕ instead.
-                    val canArchive = g.current && model.canArchiveSessions
+                    // right-click "Rename session" (issue #158) — EVERY group's rows now: the row hands its
+                    // own dir to the rename, so the frame resolves against the right project wherever the
+                    // listing points (the old current-only gate existed because the UI defaulted the dir).
+                    // A guest's shared project stays out — its rename would be refused daemon-side anyway.
+                    val renameable = model.canRenameSessions && g.sharedBy == null
+                    // Archive too (#202's gate lifted): the verb always carried the row's own cwd, and its
+                    // Sessions(thatProject) echo repointing the listing now MATCHES the convention that the
+                    // listed project follows wherever the user acts, instead of contradicting it.
+                    val canArchive = model.canArchiveSessions
                     // "+ New group" sits at the TOP of the project's sessions (matches mobile) — a bottom
                     // entry forces scrolling past a long session list to create a group. Current + group-aware
                     // + owner only (canEditGroups folds in groupsSupported), so it also creates the FIRST group
@@ -1088,7 +1150,7 @@ private fun SessionRow(
             GroupNameInput(
                 initial = s.title,
                 hint = stringResource(Res.string.session_rename_hint),
-                onCommit = { model.renameSession(s.sessionId, it); renaming = false },
+                onCommit = { model.renameSession(s.sessionId, it, s.cwd); renaming = false },
                 onCancel = { renaming = false; model.dismissRenameError() },
             )
             if (renameError != null) {
@@ -1114,23 +1176,28 @@ private fun SessionRow(
     val removeRecents = stringResource(Res.string.archive_remove_from_recents)
     ContextMenuArea(
         items = {
-            // order: edit → file → hide (the design's "编辑 → 归位 → 隐藏"). Archive sits directly ABOVE
-            // "Remove from recents" on purpose: the two are the pair users most need to tell apart, and
-            // reading them adjacently is what teaches the difference (persistent+shared vs local+temporary).
-            buildList {
+            // verb families in the fixed navigate → edit → file → remove order ("Context Menu v1"), a
+            // separator at each boundary. Archive sits directly ABOVE "Remove from recents" on purpose:
+            // the two are the pair users most need to tell apart, and reading them adjacently is what
+            // teaches the difference (persistent+shared vs local+temporary).
+            joinMenuFamilies(
                 // #311: the sidebar is where a session is picked, so it is also where one is sent to its
-                // own column. First in the list — it navigates, and navigation outranks editing.
-                if (splittable) add(ContextMenuItem(openInSplit) { model.openInSplit(s) })
-                if (canRename) add(ContextMenuItem(rename) { renaming = true })
-                menuGroups.filter { it.id != s.group }.forEach { grp ->
-                    add(ContextMenuItem("$moveTo · ${grp.name}") { model.assignGroup(s.sessionId, grp.id) })
-                }
-                if (s.group != null) add(ContextMenuItem(moveOut) { model.assignGroup(s.sessionId, null) })
-                if (canArchive) {
-                    add(ContextMenuItem(archive) { model.archiveSession(s) })
-                    add(ContextMenuItem(removeRecents) { model.hideSession(s) })
-                }
-            }
+                // own column. First — it navigates, and navigation outranks editing.
+                buildList { if (splittable) add(PocketMenuItem(openInSplit) { model.openInSplit(s) }) },
+                buildList { if (canRename) add(PocketMenuItem(rename) { renaming = true }) },
+                buildList {
+                    menuGroups.filter { it.id != s.group }.forEach { grp ->
+                        add(PocketMenuItem(grp.name, mutedPrefix = "$moveTo ·") { model.assignGroup(s.sessionId, grp.id) })
+                    }
+                    if (s.group != null) add(PocketMenuItem(moveOut) { model.assignGroup(s.sessionId, null) })
+                },
+                buildList {
+                    if (canArchive) {
+                        add(PocketMenuItem(archive) { model.archiveSession(s) })
+                        add(PocketMenuItem(removeRecents, removal = true) { model.hideSession(s) })
+                    }
+                },
+            )
         },
         content = { SessionRowBody(model, s, selected, indented, onClick) },
     )

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/Sidebar.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/Sidebar.kt
@@ -168,6 +168,7 @@ internal fun osIcon(os: DkOs): ImageVector = when (os) {
 @Composable
 fun Sidebar(model: DesktopModel, width: Dp = Dk.sidebarWidth, modifier: Modifier = Modifier) {
     Column(modifier.width(width).fillMaxHeight().background(Tok.surface)) {
+        SidebarControlRow(model)
         SwitcherHeader(model)
         NewSessionRow { model.openNewSession() }
         // issue #163: the sibling entry for "I don't remember the path" — browse to it instead
@@ -190,53 +191,104 @@ fun Sidebar(model: DesktopModel, width: Dp = Dk.sidebarWidth, modifier: Modifier
     }
 }
 
+// ── zone 0: the window's control row (desktop chrome v2) ────────────────────────────────────────
+
+/**
+ * The sidebar's own 38dp top row — the surface that replaced the window-wide title bar.
+ *
+ * Exactly four operations, in the order the design fixed: traffic lights (macOS, windowed) · hide the
+ * sidebar · ‹ back · › forward · search, which takes whatever width the four buttons leave and stops at
+ * the sidebar's right edge. It carries no bottom hairline on purpose: the row and the device line under
+ * it are one block of chrome sitting on the sidebar's own fill, and a rule between them would read as a
+ * title bar again.
+ *
+ * The cluster's buttons are the SAME composables the leftmost chat sub-header adopts once the sidebar is
+ * collapsed (see [SidebarToggleButton] / [SessionNavButtons]) — they move, they are not duplicated.
+ */
+@Composable
+private fun SidebarControlRow(model: DesktopModel) {
+    val chrome = LocalWindowChrome.current
+    Row(
+        Modifier.fillMaxWidth().height(38.dp).padding(start = 12.dp, end = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        // fullscreen hides them: macOS moves the real ones into its auto-revealing menu bar, and a second
+        // set painted here would be a decoration that no longer matches the window (issue #94)
+        if (chrome.mac && !chrome.fullscreen) {
+            TrafficLights(chrome.onClose, chrome.onMinimize, chrome.onToggleFullscreen)
+            Spacer(Modifier.width(10.dp))
+        }
+        SidebarToggleButton(model)
+        SessionNavButtons(model)
+        Spacer(Modifier.width(4.dp)) // the mock's 6dp gap, minus the row's own 2dp spacing
+        ChromeSearchField(onClick = { model.palette = PaletteScope.ALL }, modifier = Modifier.weight(1f))
+    }
+}
+
 // ── zone 1: machine switcher header ─────────────────────────────────────────────────────────────
 
-/** Current machine + status, click (or ⌘0) opens the fleet dropdown; the attention bell rides right. */
+/**
+ * Current machine + status, click (or ⌘0) opens the fleet dropdown; the attention bell rides right.
+ *
+ * A 26dp THIN LINE since the chrome-v2 redesign: search moved up into [SidebarControlRow], so what is
+ * left here is one fact ("which computer am I driving") and one affordance (the bell). Shrinking it is
+ * what buys the session list its ~96dp — the list now starts at 136dp instead of 232dp. The ⌘0 keycap
+ * came off with the height; the shortcut itself is unchanged.
+ */
 @Composable
 private fun SwitcherHeader(model: DesktopModel) {
     val c = model.activeComputer
     Column(Modifier.fillMaxWidth()) {
         Row(
-            Modifier.fillMaxWidth().height(48.dp).padding(horizontal = 12.dp),
+            Modifier.fillMaxWidth().height(26.dp).padding(horizontal = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             Row(
-                Modifier.weight(1f).clip(RoundedCornerShape(8.dp)).hoverFill(RoundedCornerShape(8.dp))
+                Modifier.weight(1f).clip(RoundedCornerShape(7.dp)).hoverFill(RoundedCornerShape(7.dp))
                     .clickable { model.switcherOpen = !model.switcherOpen }
-                    .padding(horizontal = 8.dp, vertical = 5.dp),
+                    .padding(horizontal = 4.dp, vertical = 2.dp),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(7.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
             ) {
                 if (c != null) {
-                    Icon(osIcon(c.os), null, tint = Tok.tx2, modifier = Modifier.size(14.dp))
+                    Icon(osIcon(c.os), null, tint = Tok.tx2, modifier = Modifier.size(12.dp))
+                    // tightCenter: this row is now nothing BUT a text sharing a centre line with an icon,
+                    // a dot and a chevron — the exact case where font-driven line boxes drift (#293)
                     Text(
-                        c.name, color = Tok.tx, fontFamily = Dk.mono, fontSize = 12.5.sp, lineHeight = 12.5.sp,
+                        c.name, color = Tok.tx2, fontFamily = Dk.mono, fontSize = 11.sp, style = tightCenter(11.sp),
+                        fontWeight = FontWeight.Medium,
                         maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f, fill = false),
                     )
-                    if (c.online) PulseDot(Tok.ok, 6.dp)
+                    if (c.online) PulseDot(Tok.ok, 5.dp)
                     else {
-                        Dot(Tok.muted, 6.dp)
-                        Text(stringResource(Res.string.status_reconnecting), color = Tok.muted, fontFamily = Dk.mono, fontSize = 10.sp)
+                        Dot(Tok.muted, 5.dp)
+                        Text(
+                            stringResource(Res.string.status_reconnecting), color = Tok.muted,
+                            fontFamily = Dk.mono, fontSize = 10.sp, style = tightCenter(10.sp),
+                            maxLines = 1, overflow = TextOverflow.Ellipsis,
+                        )
                     }
                 } else {
-                    Text(stringResource(Res.string.sidebar_no_computer), color = Tok.muted, fontFamily = Dk.ui, fontSize = 12.5.sp, modifier = Modifier.weight(1f, fill = false))
+                    Text(
+                        stringResource(Res.string.sidebar_no_computer), color = Tok.muted, fontFamily = Dk.ui,
+                        fontSize = 11.sp, style = tightCenter(11.sp), modifier = Modifier.weight(1f, fill = false),
+                    )
                 }
-                Icon(Icons.Rounded.KeyboardArrowDown, null, tint = Tok.muted, modifier = Modifier.size(13.dp))
+                Icon(Icons.Rounded.KeyboardArrowDown, null, tint = Tok.muted, modifier = Modifier.size(11.dp))
             }
-            Key("⌘0")
             val waiting = model.attention.size
             // Badge rides INLINE, not as a corner overlay: the hover pill's own clip() truncated an
-            // offset badge, and a TopEnd anchor sits above the row's centre line so it never lined
-            // up with the ⌘0 keycap beside it. Same shape the pinned/session rows already use.
+            // offset badge, and a TopEnd anchor sits above the row's centre line. Same shape the
+            // pinned/session rows already use.
             Row(
-                Modifier.clip(RoundedCornerShape(7.dp)).hoverFill(RoundedCornerShape(7.dp))
-                    .clickable { model.showAttention = !model.showAttention }.padding(4.dp),
+                Modifier.clip(RoundedCornerShape(6.dp)).hoverFill(RoundedCornerShape(6.dp))
+                    .clickable { model.showAttention = !model.showAttention }.padding(3.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
             ) {
-                Icon(Icons.Outlined.Notifications, null, tint = if (waiting > 0) Tok.tx else Tok.tx2, modifier = Modifier.size(16.dp))
+                Icon(Icons.Outlined.Notifications, null, tint = if (waiting > 0) Tok.tx else Tok.tx2, modifier = Modifier.size(13.dp))
                 if (waiting > 0) AttentionBadge(waiting)
             }
         }

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/Sidebar.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/Sidebar.kt
@@ -380,14 +380,18 @@ private fun PinRow(
     // is the same "current machine's loaded list" fact RECENT's g.current encodes — and split stays a
     // this-machine gesture. RECENT's "Remove from recents" maps to this row's own removal verb: Unpin.
     var renaming by remember(p.sessionId) { mutableStateOf(false) }
-    val renameError = model.renameError(p.sessionId)
+    // renameError is keyed by sessionId alone, and a pinned session usually ALSO has a RECENT row: on a
+    // refused rename both surfaces would swap into edit state at once. Only the row that actually sent
+    // the rename shows the error editor — that's what this flag records.
+    var renamedHere by remember(p.sessionId) { mutableStateOf(false) }
+    val renameError = model.renameError(p.sessionId).takeIf { renamedHere }
     if (renaming || renameError != null) {
         Column {
             GroupNameInput(
                 initial = title,
                 hint = stringResource(Res.string.session_rename_hint),
-                onCommit = { model.renameSession(p.sessionId, it, p.cwd); renaming = false },
-                onCancel = { renaming = false; model.dismissRenameError() },
+                onCommit = { model.renameSession(p.sessionId, it, p.cwd); renaming = false; renamedHere = true },
+                onCancel = { renaming = false; renamedHere = false; model.dismissRenameError() },
             )
             if (renameError != null) {
                 Text(
@@ -718,7 +722,9 @@ private fun RecentZone(model: DesktopModel, modifier: Modifier = Modifier) {
                     // Archive too (#202's gate lifted): the verb always carried the row's own cwd, and its
                     // Sessions(thatProject) echo repointing the listing now MATCHES the convention that the
                     // listed project follows wherever the user acts, instead of contradicting it.
-                    val canArchive = model.canArchiveSessions
+                    // guest-shared rows keep archive off too (same asymmetry rename already closed): a
+                    // guest's SetSessionArchived is a silent daemon-side no-op with no error surface.
+                    val canArchive = model.canArchiveSessions && g.sharedBy == null
                     // "+ New group" sits at the TOP of the project's sessions (matches mobile) — a bottom
                     // entry forces scrolling past a long session list to create a group. Current + group-aware
                     // + owner only (canEditGroups folds in groupsSupported), so it also creates the FIRST group

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SplitPaneView.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SplitPaneView.kt
@@ -1,6 +1,9 @@
 package dev.ccpocket.app.desktop
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -41,10 +44,16 @@ fun SplitPane(base: DesktopModel, pane: SidePane, modifier: Modifier = Modifier)
  */
 @Composable
 private fun EndedPane(model: DesktopModel, modifier: Modifier = Modifier) {
-    ChatNotice(
-        title = stringResource(Res.string.split_session_ended),
-        modifier = modifier.background(Tok.base), // a column is not opaque on its own
-        actionLabel = stringResource(Res.string.split_pane_close),
-        onAction = { model.closeThisPane() },
-    )
+    Column(modifier.fillMaxSize().background(Tok.base)) { // a column is not opaque on its own
+        // a gone column still owns its edge's window duties (desktop chrome v2): without this, a
+        // rightmost column dying took the Win/Linux window buttons and the connection dot with it,
+        // and a leftmost one under a collapsed sidebar took the toggle/nav cluster
+        EmptyChatChromeRow(model)
+        ChatNotice(
+            title = stringResource(Res.string.split_session_ended),
+            modifier = Modifier.weight(1f).fillMaxWidth(),
+            actionLabel = stringResource(Res.string.split_pane_close),
+            onAction = { model.closeThisPane() },
+        )
+    }
 }

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/WindowChrome.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/WindowChrome.kt
@@ -84,6 +84,9 @@ class DesktopWindowChrome(
      *  only — never a whole row, or the controls inside it stop receiving clicks (the old title bar's
      *  lesson: its buttons sat deliberately outside the drag handle). */
     val dragAndZoomModifier: Modifier = Modifier,
+    /** The AWT window, for the few places that must consult GLOBAL pointer state (the hover-peek's
+     *  parked-outside watchdog) — Compose stops delivering events once the pointer leaves the scene. */
+    val window: java.awt.Window? = null,
 )
 
 /** The chrome for the surface being composed. [dev.ccpocket.app.PocketShell] provides the live one around
@@ -315,6 +318,27 @@ fun ConnectChromeRow() {
         if (chrome.mac && !chrome.fullscreen) TrafficLights(chrome.onClose, chrome.onMinimize, chrome.onToggleFullscreen)
         Box(Modifier.weight(1f).height(38.dp).then(chrome.dragAndZoomModifier)) // drag / double-click zoom
         if (!chrome.mac && !chrome.fullscreen) WinControls(chrome.onMinimize, chrome.onToggleMax, chrome.onClose)
+    }
+}
+
+/**
+ * The chrome that must survive a MODAL: composed above the overlay host while one is open, restoring
+ * what the old title bar gave by construction (it sat above the overlays in [dev.ccpocket.app.main]'s
+ * Column). Without it, an undecorated window cannot be moved or — on Win/Linux — closed while
+ * Settings / the palette / a permission modal is up. Deliberately minimal: a transparent drag band and
+ * the Win/Linux window buttons. No traffic lights — macOS closes via ⌘W/menu, and doubling the lights
+ * over a scrim-dimmed copy read as a glitch.
+ */
+@Composable
+fun OverlayChromeStrip() {
+    val chrome = LocalWindowChrome.current
+    if (chrome.fullscreen) return
+    Row(
+        Modifier.fillMaxWidth().height(38.dp).padding(horizontal = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(Modifier.weight(1f).height(38.dp).then(chrome.dragAndZoomModifier))
+        if (!chrome.mac) WinControls(chrome.onMinimize, chrome.onToggleMax, chrome.onClose)
     }
 }
 

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/WindowChrome.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/WindowChrome.kt
@@ -8,17 +8,15 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.TooltipArea
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
@@ -29,97 +27,103 @@ import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.FrameWindowScope
 import dev.ccpocket.app.resources.Res
 import dev.ccpocket.app.resources.exit_fullscreen
 import dev.ccpocket.app.resources.search
+import dev.ccpocket.app.resources.tooltip_next_session
+import dev.ccpocket.app.resources.tooltip_prev_session
+import dev.ccpocket.app.resources.tooltip_toggle_sidebar
 import dev.ccpocket.app.theme.Tok
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * The custom (undecorated) title bar — draggable, with platform-appropriate window controls: macOS traffic
- * lights on the left, Windows/Linux min/max/close on the right. The GREEN traffic light toggles TRUE native
- * macOS fullscreen ([onToggleFullscreen], issue #94); double-clicking the label region still "zooms"
- * (maximize, [onToggleMax]) — two separate gestures on purpose. The search chip and status dot sit outside
- * the drag handle so they stay clickable. The dot opens the tray popover.
+ * The window's chrome, handed DOWN to whatever surface currently owns it (desktop chrome v2).
+ *
+ * There is no title bar any more: nothing spans the window width, the sidebar runs to the window top and
+ * the chat column's sub-header is its own first element. The pieces a title bar used to hold — traffic
+ * lights, min/max/close, the drag-and-zoom handle — therefore have to be reachable from two very different
+ * places (the sidebar's control row while it is open; the leftmost chat sub-header once it is collapsed),
+ * neither of which is a [FrameWindowScope] and both of which are several composables deep. Passing five
+ * callbacks plus a Modifier through every one of those layers is what this exists to avoid.
+ *
+ * The default instance is inert with an EMPTY [dragAndZoomModifier], which is what makes the seed/preview
+ * models and the screenshot test compose without a real window: [mac] false also means no traffic lights
+ * and no window buttons, so an unprovided chrome renders as "no chrome" rather than as dead controls.
  */
-@Composable
-fun FrameWindowScope.DkTitleBar(
-    mac: Boolean,
-    onClose: () -> Unit,
-    onMinimize: () -> Unit,
-    onToggleMax: () -> Unit,
-    onToggleFullscreen: () -> Unit,
-    onTray: () -> Unit,
-    onSearch: () -> Unit = {},
-) {
-    Column(Modifier.fillMaxWidth()) {
-        Row(
-            Modifier.fillMaxWidth().height(38.dp).background(Tok.base).padding(horizontal = 12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-            if (mac) TrafficLights(onClose, onMinimize, onToggleFullscreen)
-            // the label region is the drag handle. Anchor to the GLOBAL mouse position (AWT points), not the
-            // compose drag delta: deltas are physical px (2× on Retina → the window outruns the cursor) and
-            // are measured relative to the moving window itself (feedback loop → jitter). Grab the
-            // mouse-to-window offset on press and pin the window to it — density-independent, no feedback.
-            Row(
-                Modifier.weight(1f).fillMaxHeight().pointerInput(Unit) {
-                    detectTapGestures(onDoubleTap = { onToggleMax() }) // double-click zoom, beside the drag detector
-                }.pointerInput(Unit) {
-                    var grab: java.awt.Point? = null // mouse−window offset at press, in screen points
-                    detectDragGestures(
-                        onDragStart = {
-                            grab = java.awt.MouseInfo.getPointerInfo()?.location?.let {
-                                java.awt.Point(it.x - window.x, it.y - window.y)
-                            }
-                        },
-                        onDragEnd = { grab = null },
-                        onDragCancel = { grab = null },
-                    ) { change, _ ->
-                        change.consume()
-                        val g = grab ?: return@detectDragGestures
-                        java.awt.MouseInfo.getPointerInfo()?.location?.let { m ->
-                            window.setLocation(m.x - g.x, m.y - g.y)
-                        }
-                    }
-                },
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text("cc-pocket", color = Tok.muted, fontFamily = Dk.ui, fontSize = 12.5.sp, fontWeight = FontWeight.Medium)
-                Spacer(Modifier.weight(1f))
-            }
-            Row(
-                Modifier.clip(RoundedCornerShape(7.dp)).border(1.dp, Tok.hair, RoundedCornerShape(7.dp)).clickable(onClick = onSearch).padding(horizontal = 9.dp, vertical = 3.dp),
-                verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp),
-            ) {
-                Icon(Icons.Rounded.Search, null, tint = Tok.muted, modifier = Modifier.size(13.dp))
-                Text(stringResource(Res.string.search), color = Tok.muted, fontFamily = Dk.ui, fontSize = 11.5.sp, style = tightCenter(11.5.sp))
-                Key("⌘K")
-            }
-            Box(Modifier.size(14.dp).clip(RoundedCornerShape(999.dp)).clickable(onClick = onTray), contentAlignment = Alignment.Center) {
-                PulseDot(Tok.ok, 7.dp)
-            }
-            if (!mac) WinControls(onMinimize, onToggleMax, onClose)
-        }
-        Box(Modifier.fillMaxWidth().height(1.dp).background(Tok.hair))
+@Immutable
+class DesktopWindowChrome(
+    /** macOS — traffic lights on the leading edge, no [WinControls] on the trailing one. */
+    val mac: Boolean = false,
+    /** True native fullscreen (issue #94): macOS supplies its own auto-revealing menu bar, so the traffic
+     *  lights stand down rather than doubling up; Win/Linux keep [FullscreenExitStrip] instead. */
+    val fullscreen: Boolean = false,
+    val onClose: () -> Unit = {},
+    val onMinimize: () -> Unit = {},
+    /** "Zoom" — fill the current screen's usable bounds. Distinct from [onToggleFullscreen] on purpose. */
+    val onToggleMax: () -> Unit = {},
+    val onToggleFullscreen: () -> Unit = {},
+    /** Drag the window / double-click to zoom. Hang it on a surface's FLEXIBLE, non-interactive region
+     *  only — never a whole row, or the controls inside it stop receiving clicks (the old title bar's
+     *  lesson: its buttons sat deliberately outside the drag handle). */
+    val dragAndZoomModifier: Modifier = Modifier,
+)
+
+/** The chrome for the surface being composed. [dev.ccpocket.app.PocketShell] provides the live one around
+ *  the shell; everything else (tests, screenshots, previews) gets the inert default. */
+val LocalWindowChrome = staticCompositionLocalOf { DesktopWindowChrome() }
+
+/**
+ * Drag-to-move plus double-click-to-zoom for an undecorated window, as a plain Modifier.
+ *
+ * Lifted verbatim out of the old title bar, comments included — this is the part that took the tuning.
+ * Anchor to the GLOBAL mouse position (AWT points), not the compose drag delta: deltas are physical px
+ * (2× on Retina → the window outruns the cursor) and are measured relative to the moving window itself
+ * (feedback loop → jitter). Grab the mouse-to-window offset on press and pin the window to it —
+ * density-independent, no feedback.
+ */
+fun windowDragAndZoom(window: java.awt.Window, onToggleMax: () -> Unit): Modifier = Modifier
+    .pointerInput(Unit) {
+        detectTapGestures(onDoubleTap = { onToggleMax() }) // double-click zoom, beside the drag detector
     }
-}
+    .pointerInput(Unit) {
+        var grab: java.awt.Point? = null // mouse−window offset at press, in screen points
+        detectDragGestures(
+            onDragStart = {
+                grab = java.awt.MouseInfo.getPointerInfo()?.location?.let {
+                    java.awt.Point(it.x - window.x, it.y - window.y)
+                }
+            },
+            onDragEnd = { grab = null },
+            onDragCancel = { grab = null },
+        ) { change, _ ->
+            change.consume()
+            val g = grab ?: return@detectDragGestures
+            java.awt.MouseInfo.getPointerInfo()?.location?.let { m ->
+                window.setLocation(m.x - g.x, m.y - g.y)
+            }
+        }
+    }
 
 @Composable
-private fun TrafficLights(onClose: () -> Unit, onMinimize: () -> Unit, onFullscreen: () -> Unit) {
+internal fun TrafficLights(onClose: () -> Unit, onMinimize: () -> Unit, onFullscreen: () -> Unit) {
     Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
         Light(Color(0xFFED6A5E), onClose)
         Light(Color(0xFFF4BE4F), onMinimize)
@@ -132,8 +136,9 @@ private fun Light(color: Color, onClick: () -> Unit) {
     Box(Modifier.size(12.dp).clip(RoundedCornerShape(999.dp)).background(color).clickable(onClick = onClick))
 }
 
+/** Windows/Linux min · max · close, now rendered at the trailing edge of the RIGHTMOST chat sub-header. */
 @Composable
-private fun WinControls(onMinimize: () -> Unit, onMax: () -> Unit, onClose: () -> Unit) {
+internal fun WinControls(onMinimize: () -> Unit, onMax: () -> Unit, onClose: () -> Unit) {
     Row(verticalAlignment = Alignment.CenterVertically) {
         WinCell(Icons.Rounded.Remove, onMinimize)
         WinCell(Icons.Rounded.CropSquare, onMax)
@@ -145,6 +150,171 @@ private fun WinControls(onMinimize: () -> Unit, onMax: () -> Unit, onClose: () -
 private fun WinCell(icon: ImageVector, onClick: () -> Unit) {
     Box(Modifier.size(width = 30.dp, height = 38.dp).clickable(onClick = onClick), contentAlignment = Alignment.Center) {
         Icon(icon, null, tint = Tok.tx2, modifier = Modifier.size(13.dp))
+    }
+}
+
+// ── the four-control chrome cluster (desktop chrome v2) ──────────────────────────────────────────
+// Sidebar-toggle + ‹ ›, rendered in the sidebar's control row while it is open and in the LEFTMOST chat
+// sub-header once it is collapsed. ONE definition for both, so the two surfaces cannot drift: the whole
+// point of the collapsed layout is that the same buttons moved, not that a second set appeared.
+
+/** 28dp square hit target with the mock's rounded-6 raised plate on hover; [enabled] false takes the
+ *  hover plate AND the tooltip away, so a disabled arrow can't look like it is offering something. */
+@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
+@Composable
+private fun ChromeButton(
+    tooltip: String,
+    shortcut: String,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    active: Boolean = false,
+    glyph: @Composable () -> Unit,
+) {
+    val shape = RoundedCornerShape(6.dp)
+    val cell = @Composable {
+        Box(
+            Modifier.size(28.dp).clip(shape)
+                .then(if (enabled) Modifier.hoverFill(shape, base = if (active) Tok.raised else Color.Transparent) else Modifier)
+                .then(if (enabled) Modifier.clickable(onClick = onClick) else Modifier),
+            contentAlignment = Alignment.Center,
+        ) { glyph() }
+    }
+    if (!enabled) { cell(); return }
+    TooltipArea(tooltip = { TooltipCapsule(tooltip, shortcut) }, delayMillis = 500) { cell() }
+}
+
+/** The mock's tooltip: a raised hairline capsule carrying the label and its shortcut (mock:323-330). */
+@Composable
+private fun TooltipCapsule(label: String, shortcut: String) {
+    Row(
+        Modifier.clip(RoundedCornerShape(5.dp)).background(Tok.raised)
+            .border(1.dp, Tok.hair, RoundedCornerShape(5.dp))
+            .padding(horizontal = 7.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(label, color = Tok.tx, fontFamily = Dk.ui, fontSize = 10.5.sp, style = tightCenter(10.5.sp))
+        Text(shortcut, color = Tok.tx2, fontFamily = Dk.mono, fontSize = 10.sp, style = tightCenter(10.sp))
+    }
+}
+
+/** The panel-left glyph (mock:44-47): a 15×13 rounded outline with a rail line at x=5. [filled] shades the
+ *  rail — the "sidebar is hidden, this brings it back" state, matching the mock's collapsed frame. */
+@Composable
+private fun PanelLeftGlyph(color: Color, filled: Boolean) {
+    Canvas(Modifier.size(width = 15.dp, height = 13.dp)) {
+        val s = 1.5.dp.toPx()
+        val rail = 5.dp.toPx()
+        if (filled) drawRect(color.copy(alpha = 0.22f), topLeft = Offset.Zero, size = Size(rail, size.height))
+        // box-sizing: border-box — inset by half the stroke so the outline stays inside the 15×13 box
+        drawRoundRect(
+            color = color,
+            topLeft = Offset(s / 2, s / 2),
+            size = Size(size.width - s, size.height - s),
+            cornerRadius = CornerRadius(2.5.dp.toPx(), 2.5.dp.toPx()),
+            style = Stroke(width = s),
+        )
+        drawLine(color, Offset(rail + s / 2, 0f), Offset(rail + s / 2, size.height), strokeWidth = s)
+    }
+}
+
+/** ‹ / › — the mock's 6px square rotated 45° with two 1.5px borders, drawn directly as the chevron it is. */
+@Composable
+private fun ChevronGlyph(left: Boolean, color: Color) {
+    Canvas(Modifier.size(width = 6.dp, height = 10.dp)) {
+        val s = 1.5.dp.toPx()
+        val arm = size.width - s // the rotated square's half-diagonal, minus the stroke it carries
+        val tipX = if (left) s / 2 else size.width - s / 2
+        val backX = if (left) size.width - s / 2 else s / 2
+        val midY = size.height / 2
+        drawLine(color, Offset(backX, midY - arm), Offset(tipX, midY), strokeWidth = s, cap = StrokeCap.Square)
+        drawLine(color, Offset(tipX, midY), Offset(backX, midY + arm), strokeWidth = s, cap = StrokeCap.Square)
+    }
+}
+
+/** Hide/show the sidebar — the cluster's first control (⌘\). */
+@Composable
+internal fun SidebarToggleButton(model: DesktopModel) {
+    val collapsed = model.sidebarCollapsed
+    ChromeButton(
+        tooltip = stringResource(Res.string.tooltip_toggle_sidebar),
+        shortcut = "⌘\\",
+        onClick = { model.setSidebarCollapsed(!collapsed) },
+        active = collapsed, // hidden sidebar = the button is the only way back, so it reads as "on"
+    ) { PanelLeftGlyph(if (collapsed) Tok.tx else Tok.tx2, filled = collapsed) }
+}
+
+/** ‹ › over the session history (⌘[ / ⌘]) — browser semantics, disabled at either end of the trail. */
+@Composable
+internal fun SessionNavButtons(model: DesktopModel) {
+    ChromeButton(
+        tooltip = stringResource(Res.string.tooltip_prev_session),
+        shortcut = "⌘[",
+        onClick = { model.goBack() },
+        enabled = model.canGoBack,
+    ) { ChevronGlyph(left = true, color = if (model.canGoBack) Tok.tx2 else DISABLED_GLYPH) }
+    ChromeButton(
+        tooltip = stringResource(Res.string.tooltip_next_session),
+        shortcut = "⌘]",
+        onClick = { model.goForward() },
+        enabled = model.canGoForward,
+    ) { ChevronGlyph(left = false, color = if (model.canGoForward) Tok.tx2 else DISABLED_GLYPH) }
+}
+
+/** The mock's disabled chevron (#4A4E55): a muted step below [Tok.tx2], composited over the surface it
+ *  sits on so the one value works in both themes rather than pinning a dark-only hex. */
+private val DISABLED_GLYPH: Color @Composable get() = Tok.muted.copy(alpha = 0.55f)
+
+/** The 1×16dp rule that separates the re-homed cluster from the session title (mock:211). */
+@Composable
+internal fun ChromeDivider() {
+    Box(Modifier.size(width = 1.dp, height = 16.dp).background(Tok.hair))
+}
+
+/** The control row's search field — the ⌘K palette's entry point, wearing the mock's 26dp input shape.
+ *  No ⌘K keycap: at a 260px sidebar the row leaves ~78px here, which fits the magnifier and the
+ *  placeholder but not the hint, and the design's call is to drop the hint rather than shrink the field. */
+@Composable
+internal fun ChromeSearchField(onClick: () -> Unit, modifier: Modifier = Modifier) {
+    val src = remember { MutableInteractionSource() }
+    val hovered by src.collectIsHoveredAsState()
+    val shape = RoundedCornerShape(7.dp)
+    Row(
+        modifier.height(26.dp).clip(shape).background(Tok.base)
+            .border(1.dp, if (hovered) Tok.tx2.copy(alpha = 0.35f) else Tok.hair, shape)
+            .hoverable(src).clickable(onClick = onClick)
+            .padding(horizontal = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Icon(Icons.Rounded.Search, null, tint = Tok.muted, modifier = Modifier.size(12.dp))
+        Text(
+            stringResource(Res.string.search), color = Tok.muted, fontFamily = Dk.ui, fontSize = 12.sp,
+            style = tightCenter(12.sp), maxLines = 1, overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+/**
+ * The one surface that still needs a bar of its own: the pre-pairing [ConnectPanel].
+ *
+ * Everywhere else the chrome-v2 controls ride a real column — the sidebar's control row, a chat
+ * sub-header — but before a daemon is paired there is no sidebar and no chat, so removing the title bar
+ * would have left an UNDECORATED window with no way to move, zoom or close it. Deliberately bare: no
+ * title, no search, no connection dot, because at this point there is no session and, by definition, no
+ * link to report. Just the window buttons and a drag handle.
+ */
+@Composable
+fun ConnectChromeRow() {
+    val chrome = LocalWindowChrome.current
+    Row(
+        Modifier.fillMaxWidth().height(38.dp).background(Tok.base).padding(horizontal = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        if (chrome.mac && !chrome.fullscreen) TrafficLights(chrome.onClose, chrome.onMinimize, chrome.onToggleFullscreen)
+        Box(Modifier.weight(1f).height(38.dp).then(chrome.dragAndZoomModifier)) // drag / double-click zoom
+        if (!chrome.mac && !chrome.fullscreen) WinControls(chrome.onMinimize, chrome.onToggleMax, chrome.onClose)
     }
 }
 

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/DesktopCrashGuardTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/DesktopCrashGuardTest.kt
@@ -124,6 +124,12 @@ class DesktopCrashGuardTest {
         }
         assertFalse(DesktopCrashGuard.isBenignJdkTrayNpe(appOnTop))
         assertFalse(DesktopCrashGuard.isBenignJdkTrayNpe(IllegalStateException("not an NPE at all")))
+        // …and HotSpot's fast-throw variant of the same bug (OmitStackTraceInFastThrow strips the stack
+        // after enough recurrences) inherits the pardon — a real EDT NPE dies fully-stacked on throw #1
+        val fastThrow = NullPointerException().apply { stackTrace = emptyArray() }
+        assertTrue(DesktopCrashGuard.isBenignJdkTrayNpe(fastThrow))
+        // a stackless non-NPE stays fatal
+        assertFalse(DesktopCrashGuard.isBenignJdkTrayNpe(IllegalStateException("x").apply { stackTrace = emptyArray() }))
     }
 
     @Test

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/DesktopCrashGuardTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/DesktopCrashGuardTest.kt
@@ -99,6 +99,34 @@ class DesktopCrashGuardTest {
     }
 
     @Test
+    fun jdkTrayNpeIsBenignButNothingBroaderIs() {
+        // the JDK's own TrayIcon-click NPE (LightweightDispatcher dereferences a Component a TrayIcon
+        // event never carries) — matched by its exact shape, so it stops quitting the app…
+        val jdkShape = NullPointerException("Cannot invoke \"java.awt.Component.isShowing()\"").apply {
+            stackTrace = arrayOf(
+                StackTraceElement("java.awt.LightweightDispatcher", "eventDispatched", null, -1),
+                StackTraceElement("java.awt.Toolkit\$SelectiveAWTEventListener", "eventDispatched", null, -1),
+                StackTraceElement("java.awt.TrayIcon", "dispatchEvent", null, -1),
+            )
+        }
+        assertTrue(DesktopCrashGuard.isBenignJdkTrayNpe(jdkShape))
+        // …while an NPE of OURS raised during tray handling keeps its fatal path: same dispatcher
+        // frame but no TrayIcon on the stack, or app frames on top, must not slip through the pardon
+        val sameTopNoTray = NullPointerException("x").apply {
+            stackTrace = arrayOf(StackTraceElement("java.awt.LightweightDispatcher", "eventDispatched", null, -1))
+        }
+        assertFalse(DesktopCrashGuard.isBenignJdkTrayNpe(sameTopNoTray))
+        val appOnTop = NullPointerException("x").apply {
+            stackTrace = arrayOf(
+                StackTraceElement("dev.ccpocket.app.desktop.MenuBarExtraKt", "onClick", null, -1),
+                StackTraceElement("java.awt.TrayIcon", "dispatchEvent", null, -1),
+            )
+        }
+        assertFalse(DesktopCrashGuard.isBenignJdkTrayNpe(appOnTop))
+        assertFalse(DesktopCrashGuard.isBenignJdkTrayNpe(IllegalStateException("not an NPE at all")))
+    }
+
+    @Test
     fun noteAppendsWithoutThrowingAndKeepsEarlierEntries() {
         val before = DesktopCrashGuard.logFile.takeIf { it.exists() }?.readText().orEmpty()
         DesktopCrashGuard.note("CCP-QR-01", RuntimeException("first note"))

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/DesktopScreenshotTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/DesktopScreenshotTest.kt
@@ -1,33 +1,14 @@
 package dev.ccpocket.app.desktop
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Search
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import dev.ccpocket.app.theme.PocketTheme
 import dev.ccpocket.app.theme.Tok
 import dev.ccpocket.app.pairing.encode
@@ -75,34 +56,20 @@ class DesktopScreenshotTest {
         }
     }
 
-    /** The full window look: a static title bar (real DkTitleBar needs a window) over the live two-pane shell. */
+    /**
+     * The full window look. There is no title bar to replicate any more (desktop chrome v2): the sidebar
+     * runs to the window top and carries its own control row, and the chat column's sub-header is its own
+     * first element. So the shell simply fills the frame — what used to be a hand-built static bar here is
+     * now the REAL [SidebarControlRow] and [ChatSubHeader], which is one less replica to drift.
+     *
+     * A macOS chrome is provided because that is the platform the design was drawn for and the one whose
+     * traffic lights the shots are meant to show; the [DesktopWindowChrome] default (no window, no
+     * gestures) keeps everything else inert, so nothing here needs an AWT window to compose.
+     */
     @Composable
     private fun WindowFrame(model: DesktopModel) {
-        Column(Modifier.fillMaxSize()) {
-            Row(
-                Modifier.fillMaxWidth().height(38.dp).background(Tok.base).padding(horizontal = 12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-            ) {
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Box(Modifier.size(12.dp).clip(RoundedCornerShape(999.dp)).background(Color(0xFFED6A5E)))
-                    Box(Modifier.size(12.dp).clip(RoundedCornerShape(999.dp)).background(Color(0xFFF4BE4F)))
-                    Box(Modifier.size(12.dp).clip(RoundedCornerShape(999.dp)).background(Color(0xFF61C554)))
-                }
-                Text("cc-pocket", color = Tok.muted, fontWeight = FontWeight.Medium, fontSize = 12.5.sp, modifier = Modifier.padding(start = 2.dp))
-                Spacer(Modifier.weight(1f))
-                Row(
-                    Modifier.clip(RoundedCornerShape(7.dp)).border(1.dp, Tok.hair, RoundedCornerShape(7.dp)).padding(horizontal = 9.dp, vertical = 3.dp),
-                    verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    Icon(Icons.Rounded.Search, null, tint = Tok.muted, modifier = Modifier.size(13.dp))
-                    Text("Search", color = Tok.muted, fontSize = 11.5.sp)
-                    Key("⌘K")
-                }
-                Dot(Tok.ok, 7.dp)
-            }
-            Box(Modifier.fillMaxWidth().height(1.dp).background(Tok.hair))
-            Box(Modifier.fillMaxWidth().weight(1f)) { DesktopApp(model) }
+        CompositionLocalProvider(LocalWindowChrome provides DesktopWindowChrome(mac = true)) {
+            Box(Modifier.fillMaxSize()) { DesktopApp(model) }
         }
     }
 

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/RepoDesktopModelNavHistoryTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/RepoDesktopModelNavHistoryTest.kt
@@ -1,0 +1,147 @@
+package dev.ccpocket.app.desktop
+
+import androidx.compose.runtime.snapshots.Snapshot
+import dev.ccpocket.app.data.DemoData
+import dev.ccpocket.app.data.PocketRepository
+import dev.ccpocket.app.pairing.PairedDaemon
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Session navigation history (the sidebar control row's ‹ › / ⌘[ ⌘]) on a demo-mode repo: browser
+ * semantics — visits recorded off the sessionKey echo, back/forward reopen neighbors without
+ * re-recording, and a fresh navigation from mid-stack truncates the forward branch.
+ *
+ * Snapshot notifications are pumped by hand: there is no composition here, so
+ * [Snapshot.sendApplyNotifications] plays the UI's apply pump. It is pumped in a POLL rather than once
+ * (same shape the RECENT sweep uses — see [RepoDesktopModelRecentTest]) because the delivery is only
+ * synchronous while this test owns the snapshot machinery. Run after any composable test in the same
+ * JVM — the screenshot generator, the permission-timeout UI test — Compose's global snapshot manager is
+ * live on another thread, and whichever pump gets there first decides where the recorder's `collect`
+ * resumes. A single hand pump then records the visit a beat later, on that other thread, and the
+ * assertion below it read the history before it landed. Polling asserts the same facts without
+ * depending on which pump won; a recorder that genuinely stops recording still fails, it just takes
+ * [SETTLE_MS] to say so.
+ */
+class RepoDesktopModelNavHistoryTest {
+
+    /** Pump the apply notifications and wait for [cond] — see the class doc for why this is a loop. */
+    private fun settle(cond: () -> Boolean): Boolean {
+        val end = System.currentTimeMillis() + SETTLE_MS
+        while (System.currentTimeMillis() < end) {
+            Snapshot.sendApplyNotifications()
+            if (cond()) return true
+            Thread.sleep(10)
+        }
+        return cond()
+    }
+
+    private fun demoModel(): Pair<PocketRepository, RepoDesktopModel> {
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        val repo = PocketRepository(scope)
+        repo.paired.value = PairedDaemon(
+            relay = "wss://test", accountId = "acct-test", daemonPub = "pk", deviceId = "dev", credential = "cred",
+        )
+        repo.enterDemo()
+        return repo to RepoDesktopModel(repo, scope, store = FakeDesktopStore())
+    }
+
+    /** Select the [i]th session of the current project and let the recorder's snapshotFlow — which rides
+     *  the composition's apply pump in production — see it. [until] is what proves the visit landed. */
+    private fun RepoDesktopModel.visit(i: Int, until: (DkSession) -> Boolean): DkSession {
+        val s = sessions[i]
+        selectSession(s)
+        settle { until(s) }
+        return s
+    }
+
+    @Test
+    fun backAndForwardReopenNeighbors() {
+        val (repo, m) = demoModel()
+        val dir = DemoData.dirs().first()
+        m.openProject(DkProject(dir.path, dir.name))
+        settle { repo.workdir.value != null }
+
+        assertFalse(m.canGoBack) // nothing visited yet — or only the first visit below
+        val s1 = m.visit(0) { repo.sessionKey.value == it.sessionId }
+        assertFalse(m.canGoBack) // one entry — nothing behind the cursor
+        assertFalse(m.canGoForward)
+        val s2 = m.visit(1) { m.canGoBack } // a second entry is exactly what puts one behind the cursor
+        assertTrue(m.canGoBack)
+        assertFalse(m.canGoForward)
+
+        m.goBack()
+        settle { m.canGoForward }
+        assertEquals(s1.sessionId, repo.sessionKey.value) // reopened the previous session…
+        assertFalse(m.canGoBack)
+        assertTrue(m.canGoForward) // …and the branch forward survived (no re-record, no truncation)
+
+        m.goForward()
+        settle { m.canGoBack }
+        assertEquals(s2.sessionId, repo.sessionKey.value)
+        assertTrue(m.canGoBack)
+        assertFalse(m.canGoForward)
+    }
+
+    @Test
+    fun freshNavigationFromMidStackTruncatesForwardBranch() {
+        val (repo, m) = demoModel()
+        val dir = DemoData.dirs().first()
+        m.openProject(DkProject(dir.path, dir.name))
+        settle { repo.workdir.value != null }
+
+        val s1 = m.visit(0) { repo.sessionKey.value == it.sessionId }
+        m.visit(1) { m.canGoBack }
+        m.goBack()
+        settle { m.canGoForward }
+        assertTrue(m.canGoForward)
+
+        // a fresh visit while the cursor sits mid-stack. Settling on sessionKey alone would race the
+        // recorder, so wait for the truncation itself — the very thing asserted on the next line.
+        val s3 = m.visit(2) { !m.canGoForward && m.canGoBack }
+        assertFalse(m.canGoForward) // the old forward branch (s2) is gone — browser semantics
+        assertTrue(m.canGoBack)
+        assertEquals(s3.sessionId, repo.sessionKey.value)
+
+        m.goBack()
+        settle { repo.sessionKey.value == s1.sessionId }
+        assertEquals(s1.sessionId, repo.sessionKey.value) // behind s3 sits s1, not the truncated s2
+    }
+
+    @Test
+    fun crossProjectNavigationRepointsTheListedDir() {
+        // g.current — and the #158/#202/#119 right-click verbs — reads repo.sessionsDir. A session
+        // click or a ⌘[ step into ANOTHER project must bring the listing along (the switchToSession
+        // convention), or the project the user is demonstrably in offers only "Open in split".
+        val (repo, m) = demoModel()
+        val dirs = DemoData.dirs()
+        val (a, b) = dirs[0] to dirs[1]
+        m.openProject(DkProject(a.path, a.name))
+        settle { repo.sessionsDir.value == a.path }
+        val sA = m.visit(0) { repo.sessionKey.value == it.sessionId }
+
+        m.openProject(DkProject(b.path, b.name))
+        settle { repo.sessionsDir.value == b.path }
+        m.visit(1) { m.canGoBack } // a visit in b, so the back step below crosses projects
+
+        m.goBack() // lands in sA — project a's session
+        settle { repo.sessionKey.value == sA.sessionId }
+        assertEquals(a.path, repo.sessionsDir.value) // the listing followed the navigation
+
+        // …and a plain session CLICK into another project repoints too (same latent gap, same fix)
+        m.openProject(DkProject(b.path, b.name))
+        settle { repo.sessionsDir.value == b.path }
+        m.selectSession(sA)
+        settle { repo.sessionsDir.value == a.path }
+        assertEquals(a.path, repo.sessionsDir.value)
+    }
+
+    private companion object {
+        /** How long a pumped visit is given to land before the assertion calls it a regression. */
+        const val SETTLE_MS = 2_000L
+    }
+}

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/SidePaneModelDelegationGuardTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/SidePaneModelDelegationGuardTest.kt
@@ -53,14 +53,18 @@ class SidePaneModelDelegationGuardTest {
         // session's, or drew the focused burst's "2 / 3" over a single card of its own.
         "askTimedOut", "askQueuePosition", "answerQuestions", "skipQuestions",
         "paneScoped", "focusThisPane", "closeThisPane",
+        // the column's own model: SidePane.model (its SessionLive) + the pane-keyed switch verb + a
+        // pane-local popover flag. Inert, the chip read "默认" and its click no-opped; DELEGATED, the
+        // popover opened on the focused composer and a pick landed on the focused session.
+        "chatModel", "chatModelId", "switchModel", "showModelPopover",
     )
 
     /** Deliberately inert. Each one is a control ChatPane renders (or a value it renders FROM) whose
      *  delegated answer would have come from — or landed on — the focused conversation instead. */
     private val PANE_INERT = setOf(
-        // conversation identity a column does not track (it is the focused pane that owns model/mode
-        // switching, so a column claiming a model would be claiming someone else's)
-        "chatBranch", "chatModel", "chatModelId", "chatMode",
+        // conversation identity a column does not track (mode/effort/tier switching stays with the
+        // focused pane; the MODEL graduated to pane-scoped above once SidePane learned to carry it)
+        "chatBranch", "chatMode",
         "chatPermissionMode", "chatEffort", "chatServiceTier",
         "sessionDegraded", "contextUsed", "contextWindow", "observing", "takeOver",
         // transcript paging + delivery watchdogs: a column has neither, and the focused pane's answers
@@ -74,10 +78,10 @@ class SidePaneModelDelegationGuardTest {
         "activeHandoff", "handoffIsRecipient",
         // header/composer surfaces that belong to the focused conversation
         "changedFiles", "gitStatus", "slashCommands", "pathListing", "browsePath",
-        "switchMode", "switchModel", "switchEffort", "switchServiceTier",
+        "switchMode", "switchEffort", "switchServiceTier",
         "compactConversation", "clearConversation",
         "workflowRunFor", "openWorkspaceFile", "tightenAutoRun",
-        "showQuickActions", "showChanges", "showGit", "showModelPopover",
+        "showQuickActions", "showChanges", "showGit",
         // attachments are the focused pane's by construction (SidePane's KDoc); uploadsBusy() even gated
         // this column's send button on the OTHER session's uploads
         "pendingImages", "attachImages", "removePendingImage", "hasReadyImages",
@@ -92,6 +96,13 @@ class SidePaneModelDelegationGuardTest {
     /** The window, the machine, the app. None of these is reachable holding a [SidePaneModel] — see the
      *  class doc's litmus — and every one of them means the same thing in a column as anywhere else. */
     private val WINDOW_DELEGATED = setOf(
+        // window chrome (desktop chrome v2): whether the sidebar is collapsed, and the session back/forward
+        // history behind ⌘[ / ⌘]. Both describe the WINDOW — one trail per window, not per column — and both
+        // are read by the chrome cluster the leftmost column's sub-header adopts while the sidebar is hidden.
+        // They are the exception to "PANE_SCOPED + PANE_INERT == SidePaneModel's overrides": the class
+        // re-delegates them EXPLICITLY because they are the only members here with an interface default,
+        // i.e. the one shape where a silent `by` hand-off could answer with the inert default instead.
+        "sidebarCollapsed", "canGoBack", "canGoForward", "goBack", "goForward",
         // connection + computer switcher
         "connected", "connGen", "activeComputer", "computers", "selectComputer", "addComputer",
         "renameComputer", "removeComputer", "activeIsThisMachine",
@@ -132,7 +143,7 @@ class SidePaneModelDelegationGuardTest {
         // split-pane plumbing itself: these take the pane as an argument, so they are already explicit
         // (splitFocusedSlot is window layout — WHERE the focused chat renders — not conversation state)
         "sidePanes", "canSplit", "splitFocusedSlot", "openInSplit", "closeSplit", "promoteSplit", "retrySplitOpen",
-        "sendSidePrompt", "stopSideTurn", "resolvePaneApproval", "resolvePaneTaskGrant", "retryPaneSafer",
+        "sendSidePrompt", "stopSideTurn", "switchSideModel", "resolvePaneApproval", "resolvePaneTaskGrant", "retryPaneSafer",
         "answerPaneQuestions", "skipPaneQuestions", "dismissPaneAsk",
         // workflow orchestration panel (docked at window level)
         "workflowRuns", "dockedWorkflowRunId", "openWorkflowPanel", "closeWorkflowPanel",


### PR DESCRIPTION
## 概要

参考 Codex 桌面端顶栏的整轮桌面 chrome 改造（claude design「Desktop Chrome Redesign v2」定稿），加上随真机目验暴露的一串连带修复。7 个主题 commit，建议按序阅读。

## 主题分解

1. **docs**：设计定稿（chrome v2 三帧＋Context Menu 规格帧）与实现方案归档。
2. **会话前进/返回（⌘[/⌘]）＋列出项目跟随会话**：浏览器语义历史栈（sessionKey×workdir 快照流录制、游标先行防重录、中栈截断）；同链修复 `g.current` 只跟项目头点击走的缺口——SessionLive 收口统一 repoint。
3. **右键菜单组件**：自绘 `ContextMenuRepresentation`（28dp 行、内嵌胶囊 hover、族分隔线、removal hover 转红），全局替换含文本框菜单。
4. **chrome v2 主体**：`DkTitleBar` 拆除；侧栏顶行四操作；子头部承接拖窗/zoom/状态点/WinControls；收起状态入 model＋⌘\；`ConnectChromeRow`/`EmptyChatChromeRow` 兜住两条裸窗分支；切换动画（定宽裁剪防回流、簇原位交接）；左缘 8dp 悬停窥视（根容器 onPointerEvent，规避 AWT 缩放边框死区）。
5. **分屏列模型 chip pane 作用域**：`SidePane.model`＋`switchSideModel`，chip 不再恒显「默认」、切换不再打到聚焦会话；守卫测试重分类。
6. **右键动词放开＋置顶菜单**：重命名/归档带行自身 cwd 后全项目可用（原门是 UI 缺参）；置顶行补齐同源菜单；标题实时列表优先。
7. **托盘 NPE**：JDK `LightweightDispatcher`×TrayIcon 已知缺陷按栈形态窄匹配降级，不再被 #251 兜底升级成闪退。

## 验证

- `desktopTest` 全量绿（1224+ 条，含新增 NavHistory×3、CrashGuard 边界、DelegationGuard 重分类）。
- macOS 真机连续目验并迭代（抖动经录屏抽帧定位修复；悬停窥视闪退两轮修复）。
- ⚠️ 中间 commit 不保证独立可编译（主题按 hunk 拆分，依赖序已排）；以 tip 为准。
- ⚠️ Windows 真机未验（WinControls 落位、全屏、托盘），发版前必补。

## 已知涟漪

- 接口带默认体成员变更×2（`renameSession` 签名、`switchSideModel`）——增量编译陷阱见 commit 说明，CI 全量构建不受影响。
- `AttentionBadge` 缺 tightCenter 为既有违规（commonMain 共用），刻意未动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)