### PR TITLE
feat: thinking 独立三态开关——launch 参数＋/thinking 命令＋手机桌面两端 UI (#345)

### DIFF
--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/agent/AgentBackend.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/agent/AgentBackend.kt
@@ -95,6 +95,15 @@ interface AgentBackend {
     /** Apply a backend-native service tier. Default false means unsupported/ignored. */
     fun applyServiceTier(serviceTier: String?): Boolean = false
 
+    /** Whether this backend accepts a session-level extended-thinking toggle (issue #345). Drives BOTH the
+     *  daemon's `/thinking` command gate and the App's switch visibility (the client checks the
+     *  ModelsList advertisement, which a backend sets only when this is true). */
+    val supportsThinkingToggle: Boolean get() = false
+
+    /** Apply an extended-thinking change (null = back to CLI default). True = a relaunch is required for
+     *  it to take effect (Claude bakes `--thinking` at launch); default false = unsupported/ignored. */
+    fun applyThinking(thinking: Boolean?): Boolean = false
+
     /** Capability validation hooks. Null capability means unknown/custom, so the setting passes through;
      *  a known model can explicitly reject a stale persisted value. */
     fun normalizeEffort(model: String?, effort: String?): String? = effort

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/agent/AgentSpec.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/agent/AgentSpec.kt
@@ -15,6 +15,13 @@ data class AgentSpec(
     val mode: PermissionMode = PermissionMode.DEFAULT,
     val appendSystemPrompt: String? = null,
     val effort: String? = null, // reasoning effort: low|medium|high|xhigh|max
+    // Extended-thinking toggle (Claude only, issue #345): orthogonal to effort on purpose. null = don't
+    // touch it (the CLI's own default incl. the user's global `alwaysThinkingEnabled` setting decides);
+    // true/false = --thinking enabled/disabled. Exists because a gateway whose models reject thinking
+    // content fails a high-effort session with "Content block is not a thinking block" while
+    // effort=max + thinking off works — the same two controls the VS Code extension exposes. Other
+    // backends ignore it (they don't advertise the toggle, so no client ever sets it on them).
+    val thinking: Boolean? = null,
     /** Backend-native permission-mode id not representable by the legacy protocol enum (Claude `auto`). */
     val permissionMode: String? = null,
     /** Backend-native service tier (Codex `priority` = Fast); null follows the CLI/account default. */

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/claude/ClaudeBackend.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/claude/ClaudeBackend.kt
@@ -208,6 +208,11 @@ class ClaudeBackend(
     override fun supportedEfforts(model: String?): Set<String> = CLAUDE_EFFORTS
     override fun normalizeEffort(model: String?, effort: String?): String? = effort?.takeIf { it in CLAUDE_EFFORTS }
 
+    // --thinking is baked at launch exactly like --effort (issue #345); the flag exists on the CLI since
+    // 2.1.x with enabled|adaptive|disabled — scripts/probe-claude-wire.py scenario `thinkingflag` pins it.
+    override val supportsThinkingToggle: Boolean = true
+    override fun applyThinking(thinking: Boolean?): Boolean = true
+
     // claude marks `-p` transcripts entrypoint:"sdk-cli" and the desktop --resume picker hides those; once
     // the process is dead the file is safe to rewrite so this session shows up there.
     override suspend fun onProcessEnded(sessionId: String?) {

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/claude/ClaudeLauncher.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/claude/ClaudeLauncher.kt
@@ -107,6 +107,12 @@ object ClaudeLauncher {
         }
         spec.model?.let { add("--model"); add(it) }
         spec.effort?.let { add("--effort"); add(it) }
+        // Thinking is a SEPARATE CLI control from effort (issue #345): effort sets the reasoning budget,
+        // --thinking gates extended thinking entirely. A gateway whose models reject thinking content
+        // fails high-effort turns with "Content block is not a thinking block"; thinking off + effort max
+        // works — the same two controls the VS Code extension exposes. Null = emit nothing and let the
+        // CLI's own default (incl. the user's global alwaysThinkingEnabled) decide.
+        spec.thinking?.let { add("--thinking"); add(if (it) "enabled" else "disabled") }
         val appendPrompt = if (spec.cleanRoom && spec.mode == PermissionMode.PLAN) {
             listOfNotNull(CLEAN_ROOM_PLAN_PROMPT, spec.appendSystemPrompt).joinToString("\n\n")
         } else {

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/claude/ClaudeModelService.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/claude/ClaudeModelService.kt
@@ -53,6 +53,11 @@ class ClaudeModelService(
             // mode; `ultra` is not an accepted Claude effort and must never be advertised here.
             supportedEfforts = CLAUDE_EFFORTS,
             permissionModes = listOf(CLAUDE_PERMISSION_MODE_AUTO),
+            // The CLI's `--thinking enabled|adaptive|disabled` (issue #345) — a gateway machine's
+            // models may reject thinking content while the user still wants a high effort, so the
+            // phone gets a separate switch. Gating on this field keeps the switch hidden against an
+            // older daemon, which would silently drop the OpenSession field and show a lie.
+            supportsThinkingToggle = true,
             gatewayModelsSource = when {
                 authoritative.isNotEmpty() -> "gateway"
                 gateway.isNotEmpty() -> "history"

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/Conversation.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/conversation/Conversation.kt
@@ -222,6 +222,11 @@ class Conversation(
     @Volatile
     private var effort: String? = null
 
+    // mutable: a phone can switch extended thinking mid-session via `/thinking on|off|default`
+    // (issue #345). Orthogonal to effort on purpose — see AgentSpec.thinking. Null = CLI default.
+    @Volatile
+    private var thinking: Boolean? = null
+
     // Backend-native launch knobs that are deliberately additive strings on the wire: growing the legacy
     // PermissionMode enum would make already-shipped peers drop the whole SessionLive frame.
     @Volatile
@@ -670,9 +675,10 @@ class Conversation(
         val effort: String?,
         val permissionMode: String?,
         val serviceTier: String?,
+        val thinking: Boolean? = null,
     )
 
-    fun launchKnobs(): LaunchKnobs = LaunchKnobs(mode, model, effort, permissionMode, serviceTier)
+    fun launchKnobs(): LaunchKnobs = LaunchKnobs(mode, model, effort, permissionMode, serviceTier, thinking)
 
     /** One-shot queue drain: the oldest queued prompt leaves the ledger to become the next spawn's
      *  argv message — launchProcess re-records it (initialSend) under the fresh generation, so the
@@ -756,6 +762,8 @@ class Conversation(
             permissionMode = permissionMode,
             serviceTier = serviceTier,
             title = sessionTitle,
+            // issue #345: the baked-in thinking toggle, re-announced on every relaunch like mode/model/effort
+            thinking = thinking,
         )
 
     /** The current permission mode — read by the shell approval gate so it can't be spoofed from the phone. */
@@ -795,6 +803,10 @@ class Conversation(
         sinceSeq: Long? = null,
         permissionMode: String? = null,
         serviceTier: String? = null,
+        // issue #345: the extended-thinking toggle the client chose for this open (null = CLI default).
+        // Stored as-is — no normalization hook exists because there is nothing to normalize: a tri-state
+        // Boolean cannot go stale the way a persisted effort level can against a retired model.
+        thinking: Boolean? = null,
         // issue #282: open this conversation as a TRUNCATED branch of [resumeId] rather than a plain
         // resume. Set only by SessionRegistry.rewind, which has already validated the anchor against the
         // file on disk; null keeps every other open byte-for-byte as it was.
@@ -803,6 +815,7 @@ class Conversation(
         this.rewindLaunch = rewind
         this.model = model
         this.effort = backend.normalizeEffort(model, effort) // drop stale persisted levels a known model cannot run
+        this.thinking = thinking
         this.permissionMode = normalizePermissionMode(permissionMode)
         this.serviceTier = normalizeServiceTier(serviceTier)
         this.openedResumeId = resumeId
@@ -829,7 +842,7 @@ class Conversation(
             // launchProcess defers to the first sendPrompt, which anchors on sessionId ?: openedResumeId).
             launchProcess(
                 AgentSpec(
-                    workdir, resumeId, model, mode, effort = this.effort,
+                    workdir, resumeId, model, mode, effort = this.effort, thinking = this.thinking,
                     permissionMode = this.permissionMode, serviceTier = this.serviceTier, forkSession = fork,
                 ),
             )
@@ -1198,7 +1211,7 @@ class Conversation(
         val fork = if (sessionId == null) openedWithFork else resumeId != sessionId
         launchProcess(
             AgentSpec(
-                workdir, resumeId = resumeId, model = model, mode = mode, effort = effort,
+                workdir, resumeId = resumeId, model = model, mode = mode, effort = effort, thinking = thinking,
                 permissionMode = permissionMode, serviceTier = serviceTier,
                 forkSession = fork, initialPrompt = initialSend?.text,
             ),
@@ -1334,6 +1347,23 @@ class Conversation(
         recordPendingSettings(mode = null, model = null, effort = null, effortChanged = true)
     }
 
+    /** Switch extended thinking — next-turn semantics (issue #345), same deferral as the other launch knobs.
+     *  Refused (announce-only, state unchanged) for backends that never advertised the toggle — the App
+     *  hides the switch, but the daemon must hold the line for any hand-rolled `/thinking` prompt. */
+    suspend fun switchThinking(newThinking: Boolean?) {
+        if (!backend.supportsThinkingToggle) {
+            log.info("$convoId refusing /thinking for backend ${backend.kind} (toggle not supported)")
+            sink.emit(live(sessionId))
+            return
+        }
+        if (newThinking == thinking) { // no-op, but re-announce so an out-of-sync client corrects itself
+            sink.emit(live(sessionId))
+            return
+        }
+        thinking = newThinking
+        recordPendingSettings(mode = null, model = null, effort = null, thinkingChanged = true)
+    }
+
     /** Switch Codex's service tier independently from reasoning effort (`priority` is the Fast tier). */
     suspend fun switchServiceTier(newServiceTier: String?) {
         val normalized = normalizeServiceTier(newServiceTier)
@@ -1369,13 +1399,17 @@ class Conversation(
         effortChanged: Boolean = false,
         permissionModeChanged: Boolean = false,
         serviceTierChanged: Boolean = false,
+        thinkingChanged: Boolean = false,
     ) {
         if (recordedPreFirstTurn()) return
         val relaunchForSettings = backend.applySettings(mode = mode, model = model, effort = effort)
         val relaunchForEffort = effortChanged && backend.applyEffort(this.effort)
         val relaunchForPermissionMode = permissionModeChanged && backend.applyPermissionMode(permissionMode)
         val relaunchForServiceTier = serviceTierChanged && backend.applyServiceTier(serviceTier)
-        if (relaunchForSettings || relaunchForEffort || relaunchForPermissionMode || relaunchForServiceTier) pendingRelaunch = true
+        val relaunchForThinking = thinkingChanged && backend.applyThinking(this.thinking)
+        if (relaunchForSettings || relaunchForEffort || relaunchForPermissionMode || relaunchForServiceTier || relaunchForThinking) {
+            pendingRelaunch = true
+        }
         sink.emit(live(sessionId))
     }
 
@@ -1999,7 +2033,7 @@ class Conversation(
                         runCatching {
                             launchProcess(
                                 AgentSpec(
-                                    workdir, sessionId ?: openedResumeId, model, mode, effort = effort,
+                                    workdir, sessionId ?: openedResumeId, model, mode, effort = effort, thinking = thinking,
                                     permissionMode = permissionMode, serviceTier = serviceTier, initialPrompt = next.text,
                                 ),
                                 armExecuting = true,
@@ -2022,7 +2056,7 @@ class Conversation(
                     runCatching {
                         launchProcess(
                             AgentSpec(
-                                workdir, sessionId ?: openedResumeId, model, mode, effort = effort,
+                                workdir, sessionId ?: openedResumeId, model, mode, effort = effort, thinking = thinking,
                                 permissionMode = permissionMode, serviceTier = serviceTier,
                             ),
                             armExecuting = true,
@@ -2113,7 +2147,7 @@ class Conversation(
             if (hasUnconsumedPrompts()) sink.emit(AssistantChunk(convoId, seq.getAndIncrement(), StreamPiece.Text(FORK_NOTICE)))
             launchProcess(
                 AgentSpec(
-                    workdir, resumeId = anchor, model = model, mode = mode, effort = effort,
+                    workdir, resumeId = anchor, model = model, mode = mode, effort = effort, thinking = thinking,
                     permissionMode = permissionMode, serviceTier = serviceTier, forkSession = true,
                 ),
             )
@@ -2373,7 +2407,7 @@ class Conversation(
             val launched = runCatching {
                 launchProcess(
                     AgentSpec(
-                        workdir, anchor, model, mode, effort = effort,
+                        workdir, anchor, model, mode, effort = effort, thinking = thinking,
                         permissionMode = permissionMode, serviceTier = serviceTier,
                         forkSession = fork, initialPrompt = outgoing,
                     ),
@@ -2426,6 +2460,9 @@ class Conversation(
         val handler: suspend () -> Unit = when (trimmed.substringBefore(' ').substringBefore('\n')) {
             "/model" -> ({ handleModelCommand(trimmed) })
             "/effort" -> ({ handleEffortCommand(trimmed) })
+            // capability-gated like /compact: a backend without the toggle keeps the passthrough (the CLI
+            // would reject the unknown command anyway — intercepting only to refuse is worse than passing)
+            "/thinking" -> if (backend.supportsThinkingToggle) ({ handleThinkingCommand(trimmed) }) else return false
             // capability-routed, not kind-gated (issue #301): a backend that answers false keeps today's
             // passthrough (Claude's /compact is a prompt-backed builtin the CLI itself runs)
             "/compact" -> if (backend.supportsNativeCompact) ({ handleNativeCompactCommand() }) else return false
@@ -2524,6 +2561,40 @@ class Conversation(
     }
 
     /**
+     * Handle the phone's `/thinking on|off|default` (issue #345) — the agent `-p` ignores slash commands, so
+     * the daemon honors it. Mirrors handleEffortCommand: "default" clears back to the CLI's own default
+     * (incl. the user's global `alwaysThinkingEnabled`), "off"/"on" bake `--thinking disabled|enabled` on
+     * the next launch. Note thinking is orthogonal to effort on purpose — "off" plus a high effort is the
+     * supported combination gateway users need (models that reject thinking content fail otherwise).
+     */
+    private suspend fun handleThinkingCommand(text: String) {
+        val arg = text.removePrefix("/thinking").trim().lowercase()
+        if (arg.isEmpty()) {
+            reply("Current thinking: ${thinkingLabel()}.\nUsage: /thinking on|off|default.")
+            return
+        }
+        if (arg !in setOf("on", "off", "default")) {
+            reply("Unsupported thinking \"$arg\". Choose one of: on, off, default.")
+            return
+        }
+        val wasExecuting = isExecuting()
+        switchThinking(
+            when (arg) {
+                "on" -> true
+                "off" -> false
+                else -> null
+            },
+        )
+        if (!wasExecuting) reply("✓ Thinking set to ${thinkingLabel()} for this session. Your next message will use it.")
+    }
+
+    private fun thinkingLabel(): String = when (thinking) {
+        true -> "on"
+        false -> "off"
+        null -> "default"
+    }
+
+    /**
      * Handle the phone's `/clear` — there is no stream-json "clear", so the daemon starts a fresh session in
      * the same cwd (no resume), keeping the chosen model/effort/mode. The phone's transcript is wiped via an
      * empty history; the next turn lands on a brand-new sessionId.
@@ -2549,7 +2620,7 @@ class Conversation(
         runtimeContextWindow = null
         launchProcess(
             AgentSpec(
-                workdir, resumeId = null, model = model, mode = mode, effort = effort,
+                workdir, resumeId = null, model = model, mode = mode, effort = effort, thinking = thinking,
                 permissionMode = permissionMode, serviceTier = serviceTier,
             ),
         )
@@ -2635,7 +2706,7 @@ class Conversation(
         lastSyntheticText = null
         launchProcess(
             AgentSpec(
-                workdir, resumeId = null, model = null, mode = mode, effort = effort,
+                workdir, resumeId = null, model = null, mode = mode, effort = effort, thinking = thinking,
                 permissionMode = permissionMode, serviceTier = serviceTier,
             ),
         )

--- a/daemon/src/main/kotlin/dev/ccpocket/daemon/session/SessionRegistry.kt
+++ b/daemon/src/main/kotlin/dev/ccpocket/daemon/session/SessionRegistry.kt
@@ -558,6 +558,7 @@ class SessionRegistry(
                 sinceSeq = open.lastEventSeq,
                 permissionMode = open.permissionMode,
                 serviceTier = open.serviceTier,
+                thinking = open.thinking,
             )
         }
         if (started.isFailure) {
@@ -705,6 +706,7 @@ class SessionRegistry(
                 sid, knobs.model, knobs.effort,
                 permissionMode = knobs.permissionMode,
                 serviceTier = knobs.serviceTier,
+                thinking = knobs.thinking,
                 // LAZY, like every plain open. Nothing is forked until the person actually sends the
                 // first turn — back out here and no transcript, no session row and no ledger entry were
                 // created, which is the strongest possible reading of "a fork is never implicit". It is

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/claude/ClaudeLauncherTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/claude/ClaudeLauncherTest.kt
@@ -49,6 +49,25 @@ class ClaudeLauncherTest {
         assertEquals("max", args[args.indexOf("--effort") + 1])
     }
 
+    /**
+     * Issue #345: thinking is a SEPARATE flag from effort — the two ride side by side, and a high effort
+     * with thinking off is the exact combination gateway users need (models that reject thinking content
+     * fail "Content block is not a thinking block" otherwise).
+     */
+    @Test
+    fun thinking_flag_maps_the_tri_state_and_null_emits_nothing() {
+        val off = ClaudeLauncher.buildArgs(AgentSpec(Path.of("/x"), effort = "max", thinking = false))
+        assertEquals("disabled", off[off.indexOf("--thinking") + 1], "off must reach the CLI as --thinking disabled")
+        assertEquals("max", off[off.indexOf("--effort") + 1], "effort stays untouched alongside a thinking switch")
+
+        val on = ClaudeLauncher.buildArgs(AgentSpec(Path.of("/x"), thinking = true))
+        assertEquals("enabled", on[on.indexOf("--thinking") + 1])
+
+        // null = the CLI's own default (incl. the user's global alwaysThinkingEnabled) — emit NO flag
+        val unset = ClaudeLauncher.buildArgs(AgentSpec(Path.of("/x")))
+        assertFalse("--thinking" in unset)
+    }
+
     @Test
     fun fork_session_added_only_when_forking_a_resume() {
         val forked = ClaudeLauncher.buildArgs(

--- a/daemon/src/test/kotlin/dev/ccpocket/daemon/conversation/ConversationThinkingTest.kt
+++ b/daemon/src/test/kotlin/dev/ccpocket/daemon/conversation/ConversationThinkingTest.kt
@@ -1,0 +1,200 @@
+package dev.ccpocket.daemon.conversation
+
+import dev.ccpocket.daemon.agent.AgentBackend
+import dev.ccpocket.daemon.agent.AgentEvent
+import dev.ccpocket.daemon.agent.AgentIo
+import dev.ccpocket.daemon.agent.AgentSpec
+import dev.ccpocket.daemon.claude.StreamParser
+import dev.ccpocket.protocol.AgentKind
+import dev.ccpocket.protocol.Frame
+import dev.ccpocket.protocol.HistoryMessage
+import dev.ccpocket.protocol.ImageData
+import dev.ccpocket.protocol.PermissionMode
+import dev.ccpocket.protocol.SessionLive
+import dev.ccpocket.protocol.SessionSummary
+import dev.ccpocket.protocol.StreamPiece
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.JsonObject
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Issue #345 — the `/thinking on|off|default` slash command, the tri-state it drives, and the
+ * launch-baked flag it must reach on the next relaunch.
+ *
+ * The stub backend mirrors ClaudeBackend's contract exactly where thinking is concerned (supports
+ * the toggle, demands a relaunch); the recorded AgentSpecs let the cases assert the flag actually
+ * rides the relaunch-then-send path, not just the announced badge.
+ */
+class ConversationThinkingTest {
+
+    private fun win() = System.getProperty("os.name").lowercase().contains("win")
+
+    /** Claude-shaped stub: records every AgentSpec it is asked to launch. */
+    private class RecordingBackend(val thinkingCapable: Boolean = true) : AgentBackend {
+        override val kind = AgentKind.CLAUDE
+        val specs = CopyOnWriteArrayList<AgentSpec>()
+        override fun processBuilder(spec: AgentSpec): ProcessBuilder {
+            specs.add(spec)
+            return ProcessBuilder("sh", "-c", "sleep 30")
+        }
+        override suspend fun attach(io: AgentIo, spec: AgentSpec) {}
+        override suspend fun parse(line: String): List<AgentEvent> = StreamParser.parse(line)
+        override suspend fun sendPrompt(text: String, images: List<ImageData>) {}
+        override suspend fun interrupt() {}
+        override suspend fun respondPermission(
+            askId: String, allow: Boolean, remember: Boolean,
+            originalInput: JsonObject?, updatedInput: String?, denyMessage: String?,
+        ) {}
+        override fun applySettings(mode: PermissionMode?, model: String?, effort: String?) = true
+        override suspend fun onProcessEnded(sessionId: String?) {}
+        override fun transcriptDir(workdir: String): Path = Path.of(workdir)
+        override fun listSessions(workdir: String): List<SessionSummary> = emptyList()
+        override fun replayHistory(workdir: String, sessionId: String): List<HistoryMessage> = emptyList()
+        override fun resumeContextTokens(workdir: String, sessionId: String): Long? = null
+
+        override val supportsThinkingToggle = thinkingCapable
+        override fun applyThinking(thinking: Boolean?) = true
+    }
+
+    private class Harness(backend: RecordingBackend) {
+        val frames = CopyOnWriteArrayList<Frame>()
+        val scope = CoroutineScope(kotlinx.coroutines.Dispatchers.Default)
+        val convo = Conversation(
+            convoId = "cThink", initialWorkdir = Files.createTempDirectory("ccp-think"),
+            initialMode = PermissionMode.DEFAULT,
+            initialSink = { f -> frames.add(f) },
+            parentScope = scope, backend = backend,
+        )
+        suspend fun await(cond: (List<Frame>) -> Boolean) =
+            withTimeout(10_000) { while (!cond(frames.toList())) delay(20) }
+        suspend fun close() {
+            convo.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun slash_thinking_off_is_accepted_announced_and_reaches_the_relaunch_spec() {
+        if (win()) return
+        runBlocking {
+            val backend = RecordingBackend()
+            val h = Harness(backend)
+            try {
+                h.convo.open(resumeId = null, model = null)
+                h.await { fs -> fs.any { it is SessionLive } }
+
+                h.convo.sendPrompt("/thinking off")
+                // the badge flips optimistically — SessionLive re-announces the new state
+                h.await { fs -> fs.filterIsInstance<SessionLive>().any { it.thinking == false } }
+                // and the reply turn confirms (idle session → in-chat confirmation)
+                h.await { fs -> fs.any { it is dev.ccpocket.protocol.TurnDone } }
+
+                // the change is launch-baked: the NEXT prompt relaunches with --thinking disabled in the spec
+                h.convo.sendPrompt("hello there")
+                h.await { backend.specs.any { it.thinking == false && it.initialPrompt == "hello there" } }
+            } finally {
+                h.close()
+            }
+        }
+    }
+
+    @Test
+    fun slash_thinking_default_clears_off_and_null_rides_the_relaunch() {
+        if (win()) return
+        runBlocking {
+            val backend = RecordingBackend()
+            val h = Harness(backend)
+            try {
+                h.convo.open(resumeId = null, model = null, thinking = false)
+                h.await { fs -> fs.filterIsInstance<SessionLive>().any { it.thinking == false } }
+
+                h.convo.sendPrompt("/thinking default")
+                h.await { fs -> fs.filterIsInstance<SessionLive>().any { it.thinking == null } }
+
+                h.convo.sendPrompt("again")
+                h.await { backend.specs.any { it.thinking == null && it.initialPrompt == "again" } }
+            } finally {
+                h.close()
+            }
+        }
+    }
+
+    @Test
+    fun open_carries_the_initial_thinking_choice_into_the_first_launch() {
+        if (win()) return
+        runBlocking {
+            val backend = RecordingBackend()
+            val h = Harness(backend)
+            try {
+                h.convo.open(resumeId = null, model = null, thinking = true)
+                h.convo.sendPrompt("first turn")
+                h.await { backend.specs.any { it.thinking == true } }
+            } finally {
+                h.close()
+            }
+        }
+    }
+
+    @Test
+    fun unsupported_backend_never_intercepts_slash_thinking() {
+        if (win()) return
+        runBlocking {
+            val backend = RecordingBackend(thinkingCapable = false)
+            val h = Harness(backend)
+            try {
+                h.convo.open(resumeId = null, model = null)
+                h.await { fs -> fs.any { it is SessionLive } }
+
+                // NOT intercepted (capability-gated in tryIntercept): the text goes to the agent as an
+                // ordinary prompt — one launch whose spec is the plain spawn, and no switch announcement.
+                h.convo.sendPrompt("/thinking off")
+                h.await { fs -> backend.specs.isNotEmpty() } // the turn spawned the (stub) agent process
+
+                val lives = h.frames.filterIsInstance<SessionLive>()
+                assertTrue(lives.none { it.thinking != null }, "an incapable backend must never announce a thinking state")
+                assertTrue(backend.specs.all { it.thinking == null }, "an incapable backend must never receive the flag")
+            } finally {
+                h.close()
+            }
+        }
+    }
+
+    @Test
+    fun slash_thinking_usage_and_bad_arg_reply_without_touching_state() {
+        if (win()) return
+        runBlocking {
+            val backend = RecordingBackend()
+            val h = Harness(backend)
+            try {
+                h.convo.open(resumeId = null, model = null, thinking = false)
+                h.await { fs -> fs.filterIsInstance<SessionLive>().any { it.thinking == false } }
+
+                h.convo.sendPrompt("/thinking bogus")
+                h.await { fs ->
+                    fs.any { it is dev.ccpocket.protocol.AssistantChunk && (it.piece as? StreamPiece.Text)?.text?.contains("Unsupported thinking") == true }
+                }
+                // state untouched: still off
+                assertTrue(h.frames.filterIsInstance<SessionLive>().all { it.thinking == false })
+
+                h.convo.sendPrompt("/thinking")
+                h.await { fs ->
+                    fs.any { it is dev.ccpocket.protocol.AssistantChunk && (it.piece as? StreamPiece.Text)?.text?.contains("Usage: /thinking") == true }
+                }
+                assertEquals(false, h.frames.filterIsInstance<SessionLive>().last().thinking, "usage reply must not flip the state")
+            } finally {
+                h.close()
+            }
+        }
+    }
+}

--- a/mobile/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -621,6 +621,9 @@
     <string name="session_info_title">会话</string>
     <string name="label_model">模型</string>
     <string name="label_effort">思考深度</string>
+    <!-- issue #345：与「思考深度」独立——CLI 自己的正交开关。网关模型可能完全不吃 thinking 内容，
+         这个开关为它们关掉扩展思考。 -->
+    <string name="label_thinking">扩展思考</string>
     <string name="fast_mode">快速模式</string>
     <string name="fast_mode_detail">Codex priority 服务档位 · 响应更快，但用量更高</string>
     <string name="value_on">开</string>

--- a/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/mobile/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -621,6 +621,9 @@
     <string name="session_info_title">Session</string>
     <string name="label_model">Model</string>
     <string name="label_effort">Thinking depth</string>
+    <!-- issue #345: separate from effort — the CLI's own orthogonal toggle. Models on gateways may
+         reject thinking content entirely; this switch turns extended thinking off for them. -->
+    <string name="label_thinking">Extended thinking</string>
     <string name="fast_mode">Fast</string>
     <string name="fast_mode_detail">Codex priority service tier · faster responses with increased usage</string>
     <string name="value_on">On</string>

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
@@ -1243,6 +1243,10 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
     val model = mutableStateOf<String?>(null)                // daemon's actual model for this session (header + info sheet)
     val sessionAgent = mutableStateOf<AgentKind?>(null)      // backend driving this session (Claude/Codex) — header badge
     val effort = mutableStateOf<String?>(null)               // reasoning effort: low|medium|high|xhigh|max (null = default)
+    // extended thinking, INDEPENDENT of effort (issue #345): null = CLI default (incl. the user's global
+    // alwaysThinkingEnabled), true/false = --thinking enabled/disabled baked at the next launch. Gateway
+    // machines need it: models that reject thinking content fail high-effort turns otherwise.
+    val thinking = mutableStateOf<Boolean?>(null)
     val serviceTier = mutableStateOf<String?>(null)          // Codex `priority` = Fast (independent from effort)
     val sessionOrigin = mutableStateOf<String?>(null)        // external trigger source, e.g. "feishu-bot" → header "via …" chip (issue #91)
     val contextWindow = mutableStateOf<Long?>(null)          // context capacity in tokens (derived from model if daemon omits it)
@@ -1607,6 +1611,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         val agent: AgentKind = AgentKind.CLAUDE,
         val permissionMode: String? = null,
         val serviceTier: String? = null,
+        val thinking: Boolean? = null,
     )
     private val sessionParams = mutableMapOf<String, SessionParams>()
 
@@ -1621,6 +1626,8 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
                     AgentKind.valueOf(t[4]),
                     t.getOrNull(5)?.ifEmpty { null },
                     t.getOrNull(6)?.ifEmpty { null },
+                    // issue #345: appended column — "" (old rows) = null/default, else "0"/"1"
+                    t.getOrNull(7)?.let { s -> when (s) { "0" -> false; "1" -> true; else -> null } },
                 )
             }
         }
@@ -1633,6 +1640,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
                 listOf(
                     sid, p.mode.name, p.model ?: "", p.effort ?: "", p.agent.name,
                     p.permissionMode ?: "", p.serviceTier ?: "",
+                    when (p.thinking) { true -> "1"; false -> "0"; null -> "" },
                 ).joinToString("\t")
             }
         SecureStore.putString(K_SESSION_PARAMS, lines)
@@ -2662,7 +2670,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         slashCommands.clear()
         clearBackgroundJobs()
         sessionDegraded.value = false; degradedSendArmed = false
-        model.value = null; effort.value = null; sessionAgent.value = null
+        model.value = null; effort.value = null; sessionAgent.value = null; thinking.value = null
         contextUsed.value = null; contextWindow.value = null
         refreshing.value = false; sessionsRefreshing.value = false
         abandonVoice()
@@ -3207,6 +3215,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
                 f.mode?.let { mode.value = it } // daemon is the source of truth — corrects the optimistic badge
                 permissionMode.value = f.permissionMode // unconditional: a normal mode clears a prior `auto`
                 effort.value = f.effort // unconditional: `/effort default` must clear an optimistic explicit level
+                thinking.value = f.thinking // #345: same unconditional reconcile — `/thinking default` clears the optimistic value
                 serviceTier.value = f.serviceTier // unconditional: null restores account/default tier
                 f.agent?.let { sessionAgent.value = it } // daemon truth for the backend badge
                 val liveAgent = f.agent ?: sessionAgent.value ?: AgentKind.CLAUDE
@@ -3246,6 +3255,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
                         sessionAgent.value ?: AgentKind.CLAUDE,
                         permissionMode.value,
                         serviceTier.value,
+                        thinking.value,
                     )
                 }
                 persistSessionParams() // survive app restarts too — reopening tomorrow restores mode/effort/agent
@@ -5324,8 +5334,14 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
             openAgent == AgentKind.CODEX &&
                 (candidate == null || knownCapabilities == null || knownCapabilities.serviceTiers.any { it.id == candidate })
         }
+        // #345: the thinking toggle restores per-session, exactly like effort — a gateway user who turned
+        // thinking off for this session must not get it silently re-enabled by a reopen. No cross-agent
+        // migration and no default ladder: only a persisted choice rides, and only at a daemon that
+        // advertised the toggle (an old daemon would drop the field and show a lie).
+        val openThinking = saved?.thinking?.takeIf { agentModels[openAgent]?.supportsThinkingToggle == true }
         mode.value = openMode; permissionMode.value = openPermissionMode; allowRules.clear()
         model.value = openModel; effort.value = openEffort; serviceTier.value = openServiceTier; contextUsed.value = null // reconciled by SessionLive
+        thinking.value = openThinking
         sessionAgent.value = openAgent // optimistic; SessionLive corrects from daemon truth
         // Pre-fetch OpenCode model list so the picker has it ready when the user opens it,
         // rather than only fetching on picker-open (SessionSheets.kt ModelPicker LaunchedEffect).
@@ -5349,6 +5365,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
             lastEventSeq = lastEventSeqFor(resumeId),
             permissionMode = openPermissionMode,
             serviceTier = openServiceTier,
+            thinking = openThinking,
         )
         send(request)
         delay(SESSION_OPEN_TIMEOUT_MS) // safety: clear if the daemon never answers (matches `switching`)
@@ -6628,6 +6645,20 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
         switchViaCommand("/effort ${target ?: "default"}")
     }
 
+    /** Switch extended thinking (issue #345) — routed through the daemon's `/thinking` interception with
+     *  the same next-turn semantics as effort. The UI gates on [supportsThinkingToggle] so this only ever
+     *  fires at a daemon that advertised the command. */
+    fun switchThinking(enabled: Boolean?) {
+        if (convoId.value == null || enabled == thinking.value) return
+        thinking.value = enabled // optimistic; the daemon's next SessionLive corrects it
+        switchViaCommand("/thinking ${when (enabled) { true -> "on"; false -> "off"; null -> "default" }}")
+    }
+
+    /** Whether the daemon's model list for [agent] advertised a thinking toggle (issue #345). The switch
+     *  hides itself when false — an old daemon would silently drop the OpenSession field and show a lie. */
+    fun supportsThinkingToggle(agent: AgentKind = sessionAgent.value ?: AgentKind.CLAUDE): Boolean =
+        agentModels[agent]?.supportsThinkingToggle == true
+
     fun switchServiceTier(tier: String?) {
         val c = convoId.value ?: return
         val target = tier?.trim()?.takeIf { it.isNotEmpty() }
@@ -6783,6 +6814,9 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
             mode.value = defaultMode.value
             permissionMode.value = defaultPermissionMode.value.takeIf { agent == AgentKind.CLAUDE }
             serviceTier.value = (saved?.serviceTier ?: defaultServiceTier.value).takeIf { agent == AgentKind.CODEX }
+            // #345: same per-session restore as openSession — a takeover must not silently re-enable thinking
+            val takeoverThinking = saved?.thinking?.takeIf { agentModels[agent]?.supportsThinkingToggle == true }
+            thinking.value = takeoverThinking
             send(
                 OpenSession(
                     wd,
@@ -6797,6 +6831,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
                     lastEventSeq = lastEventSeqFor(sid),
                     permissionMode = permissionMode.value,
                     serviceTier = serviceTier.value,
+                    thinking = takeoverThinking,
                 ),
             )
         }

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/data/PocketRepository.kt
@@ -2726,7 +2726,12 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
     }
 
     /** All outbound frames funnel here; a throw means the link is dead — trigger the reconnect path. */
-    private suspend fun send(frame: Frame) {
+    private suspend fun send(request: Frame) {
+        // Reconnect, SessionGone recovery and split panes also resume through this seam. Restore the
+        // session's choice here so none of those OpenSession paths silently falls back to CLI default.
+        val frame = if (request is OpenSession && request.thinking == null) {
+            request.copy(thinking = thinkingForSession(request.resumeId, request.agent))
+        } else request
         // Reverse capability guard (#275/#276): an old daemon coerces the unknown `zcode` enum to the Claude
         // default, so never fire an agent-carrying frame at a daemon that lacks
         // that backend — but ONLY once the daemon has actually told us, THIS connection, what it supports.
@@ -5334,11 +5339,10 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
             openAgent == AgentKind.CODEX &&
                 (candidate == null || knownCapabilities == null || knownCapabilities.serviceTiers.any { it.id == candidate })
         }
-        // #345: the thinking toggle restores per-session, exactly like effort — a gateway user who turned
-        // thinking off for this session must not get it silently re-enabled by a reopen. No cross-agent
-        // migration and no default ladder: only a persisted choice rides, and only at a daemon that
-        // advertised the toggle (an old daemon would drop the field and show a lie).
-        val openThinking = saved?.thinking?.takeIf { agentModels[openAgent]?.supportsThinkingToggle == true }
+        // UNKNOWN is not UNSUPPORTED: a cold open can precede the first ModelsList reply. The optional
+        // field is safe for old peers to ignore; the UI still requires an explicit advertisement and
+        // SessionLive remains authoritative about what the daemon actually applied.
+        val openThinking = thinkingForSession(resumeId, openAgent)
         mode.value = openMode; permissionMode.value = openPermissionMode; allowRules.clear()
         model.value = openModel; effort.value = openEffort; serviceTier.value = openServiceTier; contextUsed.value = null // reconciled by SessionLive
         thinking.value = openThinking
@@ -6659,6 +6663,11 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
     fun supportsThinkingToggle(agent: AgentKind = sessionAgent.value ?: AgentKind.CLAUDE): Boolean =
         agentModels[agent]?.supportsThinkingToggle == true
 
+    private fun thinkingForSession(sessionId: String?, agent: AgentKind): Boolean? =
+        sessionParams[sessionId]?.takeIf { it.agent == agent }?.thinking?.takeIf {
+            agent == AgentKind.CLAUDE && agentModels[agent]?.supportsThinkingToggle != false
+        }
+
     fun switchServiceTier(tier: String?) {
         val c = convoId.value ?: return
         val target = tier?.trim()?.takeIf { it.isNotEmpty() }
@@ -6815,7 +6824,7 @@ class PocketRepository(private val scope: CoroutineScope, private val pinnedTo: 
             permissionMode.value = defaultPermissionMode.value.takeIf { agent == AgentKind.CLAUDE }
             serviceTier.value = (saved?.serviceTier ?: defaultServiceTier.value).takeIf { agent == AgentKind.CODEX }
             // #345: same per-session restore as openSession — a takeover must not silently re-enable thinking
-            val takeoverThinking = saved?.thinking?.takeIf { agentModels[agent]?.supportsThinkingToggle == true }
+            val takeoverThinking = thinkingForSession(sid, agent)
             thinking.value = takeoverThinking
             send(
                 OpenSession(

--- a/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/SessionSheets.kt
+++ b/mobile/composeApp/src/commonMain/kotlin/dev/ccpocket/app/ui/SessionSheets.kt
@@ -212,6 +212,19 @@ fun SessionInfoSheet(repo: PocketRepository, onDismiss: () -> Unit, onHandoff: (
                 )
                 Hairline()
                 AboutRow(stringResource(Res.string.label_effort), repo.effort.value ?: stringResource(Res.string.value_default))
+                if (repo.supportsThinkingToggle()) {
+                    Hairline()
+                    AboutRow(
+                        stringResource(Res.string.label_thinking),
+                        stringResource(
+                            when (repo.thinking.value) {
+                                true -> Res.string.value_on
+                                false -> Res.string.value_off
+                                null -> Res.string.value_default
+                            },
+                        ),
+                    )
+                }
                 if (repo.serviceTier.value == "priority") {
                     Hairline()
                     AboutRow(stringResource(Res.string.fast_mode), stringResource(Res.string.value_on))
@@ -350,7 +363,7 @@ private fun Hairline() = Box(Modifier.fillMaxWidth().height(1.dp).background(Tok
 // ════════════════════════════════════════════════════════════════════
 //  Quick actions: switch model / effort, compact, clear, simplify
 // ════════════════════════════════════════════════════════════════════
-private enum class QaSub { MAIN, MODEL, EFFORT }
+private enum class QaSub { MAIN, MODEL, EFFORT, THINKING }
 
 @Composable
 fun QuickActionsSheet(
@@ -395,6 +408,22 @@ fun QuickActionsSheet(
                                 ) { sub = QaSub.MODEL }
                                 if (repo.effortOptions().isNotEmpty()) {
                                     ActionRow(stringResource(Res.string.label_effort), value = repo.effort.value ?: stringResource(Res.string.value_default), chevron = true) { sub = QaSub.EFFORT }
+                                }
+                                // #345: the thinking tri-state is a peer of effort — shown only when the daemon
+                                // advertises the toggle, because an old daemon silently ignores /thinking and the
+                                // row would then claim "off" while the CLI keeps thinking for itself.
+                                if (repo.supportsThinkingToggle()) {
+                                    ActionRow(
+                                        stringResource(Res.string.label_thinking),
+                                        value = stringResource(
+                                            when (repo.thinking.value) {
+                                                true -> Res.string.value_on
+                                                false -> Res.string.value_off
+                                                null -> Res.string.value_default
+                                            },
+                                        ),
+                                        chevron = true,
+                                    ) { sub = QaSub.THINKING }
                                 }
                                 if (repo.serviceTierOptions().any { it.id == "priority" }) {
                                     ActionRow(
@@ -459,6 +488,29 @@ fun QuickActionsSheet(
                     selected = repo.effort.value ?: "default",
                     onBack = { sub = QaSub.MAIN },
                 ) { repo.switchEffort(it.takeUnless { value -> value == "default" }); onDismiss() }
+                // Labels stay positional against [states] so the pick maps back by index — never by
+                // comparing localized strings.
+                QaSub.THINKING -> {
+                    val states = listOf<Boolean?>(null, true, false)
+                    val labels = states.map {
+                        stringResource(
+                            when (it) {
+                                true -> Res.string.value_on
+                                false -> Res.string.value_off
+                                null -> Res.string.value_default
+                            },
+                        )
+                    }
+                    OptionPicker(
+                        title = stringResource(Res.string.label_thinking),
+                        options = labels,
+                        selected = labels.getOrNull(states.indexOf(repo.thinking.value)),
+                        onBack = { sub = QaSub.MAIN },
+                    ) { pick ->
+                        repo.switchThinking(states.getOrNull(labels.indexOf(pick)))
+                        onDismiss()
+                    }
+                }
             }
         }
     }

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/DesktopModel.kt
@@ -704,6 +704,11 @@ interface DesktopModel {
     val chatPermissionMode: String? get() = null
     val chatEffort: String? get() = null
     val chatServiceTier: String? get() = null
+    /** #345 tri-state: null = CLI default, true = enabled, false = disabled. Default null keeps
+     *  Seed/test fakes compiling — and keeps the row hidden via [supportsThinkingToggle]. */
+    val chatThinking: Boolean? get() = null
+    /** Whether the daemon advertises the thinking toggle; gates the ⋯ row/page visibility. */
+    val supportsThinkingToggle: Boolean get() = false
     /** The daemon's third-party ANTHROPIC_BASE_URL (issue #139) — non-null puts the gateway model
      *  presets first in the ⋯ model picker. Default null keeps Seed/test fakes compiling. */
     val gatewayBaseUrl: String? get() = null
@@ -756,6 +761,8 @@ interface DesktopModel {
     fun switchModel(name: String) {}
     fun switchEffort(level: String?) {}
     fun switchServiceTier(tier: String?) {}
+    /** #345: tri-state — null restores the CLI default. Inert unless the daemon advertises the toggle. */
+    fun switchThinking(enabled: Boolean?) {}
     fun effortOptions(): List<String> = emptyList()
     fun serviceTierOptions(): List<dev.ccpocket.protocol.ModelServiceTier> = emptyList()
     fun effortOptionsFor(agent: AgentKind, model: String?): List<String> = emptyList()

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/Popovers.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/Popovers.kt
@@ -63,6 +63,7 @@ import dev.ccpocket.app.resources.ho_menu_row
 import dev.ccpocket.app.resources.label_agent
 import dev.ccpocket.app.resources.label_effort
 import dev.ccpocket.app.resources.label_mode
+import dev.ccpocket.app.resources.label_thinking
 import dev.ccpocket.app.resources.label_model
 import dev.ccpocket.app.resources.value_model_default
 import dev.ccpocket.app.resources.mode_accept_short
@@ -332,7 +333,7 @@ private fun NewSessionModelRow(choices: List<ModelChoice>, chosen: String?, fall
 // Mirrors mobile's QuickActionsSheet so the two shells stay in sync (mobile moved the mode
 // switch here off the top bar); drives the same repo verbs via DesktopModel. Model is no longer
 // a page here — the row shortcuts to the composer chip's anchored popover (issue #157).
-private enum class QaPage { MAIN, EFFORT, MODE }
+private enum class QaPage { MAIN, EFFORT, MODE, THINKING }
 
 @Composable
 fun QuickActionsPopover(model: DesktopModel, onDismiss: () -> Unit) {
@@ -354,6 +355,22 @@ fun QuickActionsPopover(model: DesktopModel, onDismiss: () -> Unit) {
                 }
                 if (model.effortOptions().isNotEmpty()) {
                     QaRow(stringResource(Res.string.label_effort), value = model.chatEffort ?: stringResource(Res.string.value_default), chevron = true) { page = QaPage.EFFORT }
+                }
+                // #345: the thinking tri-state, a peer of effort — only while the daemon advertises the
+                // toggle (an old daemon silently ignores /thinking, and the row would claim "off" while
+                // the CLI keeps thinking for itself).
+                if (model.supportsThinkingToggle) {
+                    QaRow(
+                        stringResource(Res.string.label_thinking),
+                        value = stringResource(
+                            when (model.chatThinking) {
+                                true -> Res.string.value_on
+                                false -> Res.string.value_off
+                                null -> Res.string.value_default
+                            },
+                        ),
+                        chevron = true,
+                    ) { page = QaPage.THINKING }
                 }
                 if (model.serviceTierOptions().any { it.id == "priority" }) {
                     QaRow(
@@ -397,6 +414,12 @@ fun QuickActionsPopover(model: DesktopModel, onDismiss: () -> Unit) {
                 model.effortOptions().forEach { opt ->
                     QaOption(opt, opt.equals(model.chatEffort, true)) { model.switchEffort(opt); onDismiss() }
                 }
+            }
+            QaPage.THINKING -> {
+                QaBack(stringResource(Res.string.label_thinking)) { page = QaPage.MAIN }
+                QaOption(stringResource(Res.string.value_default), model.chatThinking == null) { model.switchThinking(null); onDismiss() }
+                QaOption(stringResource(Res.string.value_on), model.chatThinking == true) { model.switchThinking(true); onDismiss() }
+                QaOption(stringResource(Res.string.value_off), model.chatThinking == false) { model.switchThinking(false); onDismiss() }
             }
             QaPage.MODE -> {
                 QaBack(stringResource(Res.string.label_mode)) { page = QaPage.MAIN }

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/RepoDesktopModel.kt
@@ -1205,6 +1205,9 @@ class RepoDesktopModel(
     override val chatPermissionMode: String? get() = repo.permissionMode.value
     override val chatEffort: String? get() = repo.effort.value
     override val chatServiceTier: String? get() = repo.serviceTier.value
+    // #345 tri-state — same state the mobile sheet reads/writes
+    override val chatThinking: Boolean? get() = repo.thinking.value
+    override val supportsThinkingToggle: Boolean get() = repo.supportsThinkingToggle()
     override val gatewayBaseUrl: String? get() = repo.gatewayBaseUrl.value // issue #139: DaemonInfo's gateway hint
     // issue #167 ②: the gateway's own model list, same source the mobile picker reads
     override val gatewayModels: List<String>
@@ -1229,6 +1232,7 @@ class RepoDesktopModel(
     override fun switchModel(name: String) = repo.switchModel(name)
     override fun switchEffort(level: String?) = repo.switchEffort(level)
     override fun switchServiceTier(tier: String?) = repo.switchServiceTier(tier)
+    override fun switchThinking(enabled: Boolean?) = repo.switchThinking(enabled)
     override fun effortOptions(): List<String> = repo.effortOptions()
     override fun serviceTierOptions() = repo.serviceTierOptions()
     override fun effortOptionsFor(agent: AgentKind, model: String?): List<String> = repo.effortOptions(agent, model)

--- a/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SidePaneModel.kt
+++ b/mobile/composeApp/src/desktopMain/kotlin/dev/ccpocket/app/desktop/SidePaneModel.kt
@@ -221,6 +221,11 @@ class SidePaneModel(
     override fun switchModel(name: String) = base.switchSideModel(pane, name)
     override fun switchEffort(level: String?) {}
     override fun switchServiceTier(tier: String?) {}
+    // #345: the thinking tri-state rides with effort — inert in a column (no ⋯ popover here, and a
+    // pick would land on the focused session's next launch)
+    override val chatThinking: Boolean? get() = null
+    override val supportsThinkingToggle: Boolean get() = false
+    override fun switchThinking(enabled: Boolean?) {}
     override fun compactConversation() {}
     override fun clearConversation() {}
     override fun retryOpen() = base.retrySplitOpen(pane)

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/data/ThinkingToggleTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/data/ThinkingToggleTest.kt
@@ -1,0 +1,111 @@
+package dev.ccpocket.app.data
+
+import dev.ccpocket.protocol.AgentKind
+import dev.ccpocket.protocol.Frame
+import dev.ccpocket.protocol.ModelsList
+import dev.ccpocket.protocol.OpenSession
+import dev.ccpocket.protocol.SendPrompt
+import dev.ccpocket.protocol.SessionLive
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Issue #345 — the extended-thinking toggle's client-side plumbing: advertisement gating (an old
+ * daemon must never show a switch it would silently drop), the `/thinking` command routing, and the
+ * per-session persistence that survives a reopen.
+ */
+class ThinkingToggleTest {
+    private fun repo(scope: CoroutineScope, sent: MutableList<Frame>) =
+        PocketRepository(scope).apply { onSendForTest = { sent += it } }
+
+    private fun advertised(repo: PocketRepository, support: Boolean) = repo.receiveForTest(
+        ModelsList(agent = AgentKind.CLAUDE, models = listOf("opus"), supportsThinkingToggle = support),
+    )
+
+    @Test
+    fun switch_hidden_until_the_daemon_advertises_and_fires_the_command_when_it_does() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val sent = mutableListOf<Frame>()
+        val repo = repo(scope, sent)
+        try {
+            advertised(repo, false)
+            assertFalse(repo.supportsThinkingToggle(), "an old daemon never advertises — the switch hides")
+
+            advertised(repo, true)
+            assertTrue(repo.supportsThinkingToggle())
+
+            repo.receiveForTest(SessionLive("c1", "/x", "sid-1", agent = AgentKind.CLAUDE))
+            repo.switchThinking(false)
+            assertEquals(false, repo.thinking.value, "optimistic flip")
+            val cmd = sent.filterIsInstance<SendPrompt>().single()
+            assertEquals("/thinking off", cmd.text)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun session_live_reconciles_the_toggle_in_both_directions() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val sent = mutableListOf<Frame>()
+        val repo = repo(scope, sent)
+        try {
+            repo.receiveForTest(SessionLive("c1", "/x", "sid-1", agent = AgentKind.CLAUDE, thinking = false))
+            assertEquals(false, repo.thinking.value)
+
+            // `/thinking default` must clear an optimistic explicit value — the daemon's null wins
+            repo.receiveForTest(SessionLive("c1", "/x", "sid-1", agent = AgentKind.CLAUDE, thinking = null))
+            assertNull(repo.thinking.value)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun persisted_choice_restores_on_reopen_only_at_a_supporting_daemon() {
+        // SEED: session sid-9 was last seen with thinking OFF. The seeding repo must be a different
+        // instance than the opening one — the opener would otherwise be refused by the #235 alreadyOpen
+        // guard (the session it is being asked to open IS its current one). The persisted row crosses
+        // instances via the test SecureStore file, exactly like an app restart.
+        val seedScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val seed = repo(seedScope, mutableListOf())
+        try {
+            advertised(seed, true)
+            seed.receiveForTest(SessionLive("c1", "/x", "sid-9", agent = AgentKind.CLAUDE, thinking = false))
+        } finally {
+            seedScope.cancel()
+        }
+
+        // REOPEN at a supporting daemon: the remembered choice relaunches with the session
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val sent = mutableListOf<Frame>()
+        val repo = repo(scope, sent)
+        try {
+            advertised(repo, true)
+            assertTrue(repo.openSession("/x", "sid-9", agent = AgentKind.CLAUDE))
+            assertEquals(false, sent.filterIsInstance<OpenSession>().single().thinking)
+        } finally {
+            scope.cancel()
+        }
+
+        // the same persisted choice against an OLD daemon (never advertised) must not ride the open:
+        // the field would be silently dropped and the badge would lie
+        val scope2 = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val sent2 = mutableListOf<Frame>()
+        val repo2 = repo(scope2, sent2)
+        try {
+            repo2.receiveForTest(ModelsList(agent = AgentKind.CLAUDE, models = listOf("opus")))
+            assertTrue(repo2.openSession("/x", "sid-9", agent = AgentKind.CLAUDE))
+            assertNull(sent2.filterIsInstance<OpenSession>().single().thinking, "a never-advertising daemon must not receive the toggle")
+        } finally {
+            scope2.cancel()
+        }
+    }
+}

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/data/ThinkingToggleTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/data/ThinkingToggleTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -106,6 +107,89 @@ class ThinkingToggleTest {
             assertNull(sent2.filterIsInstance<OpenSession>().single().thinking, "a never-advertising daemon must not receive the toggle")
         } finally {
             scope2.cancel()
+        }
+    }
+    @Test
+    fun cold_reopen_keeps_off_before_the_models_reply() {
+        val sid = "thinking-cold-reopen"
+        seedOff(sid)
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val sent = mutableListOf<Frame>()
+        val repo = repo(scope, sent)
+        try {
+            assertFalse(repo.supportsThinkingToggle(), "UNKNOWN must not expose the switch")
+            assertTrue(repo.openSession("/x", sid, agent = AgentKind.CLAUDE))
+            assertEquals(false, sent.filterIsInstance<OpenSession>().single().thinking)
+            advertised(repo, true) // the real response can arrive AFTER OpenSession
+            repo.receiveForTest(SessionLive("cold", "/x", sid, agent = AgentKind.CLAUDE, thinking = false))
+            assertEquals(false, repo.thinking.value)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun recovery_opens_restore_off_but_do_not_override_an_explicit_value() = runBlocking {
+        val sid = "thinking-recovery-open"
+        seedOff(sid)
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val sent = mutableListOf<Frame>()
+        val repo = repo(scope, sent)
+        try {
+            // Reconnect, SessionGone and split-pane opens omit the field and all use this send seam.
+            repo.sendForTest(OpenSession("/x", sid, lastEventSeq = 42))
+            assertEquals(OpenSession("/x", sid, lastEventSeq = 42, thinking = false), sent.last())
+            repo.sendForTest(OpenSession("/x", sid, thinking = true))
+            assertEquals(true, (sent.last() as OpenSession).thinking)
+            advertised(repo, false)
+            repo.sendForTest(OpenSession("/x", sid))
+            assertNull((sent.last() as OpenSession).thinking, "known unsupported is distinct from unknown")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun recovery_does_not_copy_thinking_to_a_new_session_or_another_agent() = runBlocking {
+        val sid = "thinking-agent-boundary"
+        seedOff(sid)
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val sent = mutableListOf<Frame>()
+        val repo = repo(scope, sent)
+        try {
+            repo.sendForTest(OpenSession("/x"))
+            assertNull((sent.last() as OpenSession).thinking)
+            repo.sendForTest(OpenSession("/x", sid, agent = AgentKind.CODEX))
+            assertNull((sent.last() as OpenSession).thinking)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun default_acknowledgement_clears_the_choice_used_by_recovery() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val sent = mutableListOf<Frame>()
+        val repo = repo(scope, sent)
+        try {
+            advertised(repo, true)
+            repo.receiveForTest(SessionLive("default", "/x", "thinking-default", agent = AgentKind.CLAUDE, thinking = false))
+            repo.receiveForTest(SessionLive("default", "/x", "thinking-default", agent = AgentKind.CLAUDE, thinking = null))
+            repo.sendForTest(OpenSession("/x", "thinking-default"))
+            assertNull((sent.last() as OpenSession).thinking)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    private fun seedOff(sid: String) {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        try {
+            val seed = repo(scope, mutableListOf())
+            advertised(seed, true)
+            seed.receiveForTest(SessionLive("seed-$sid", "/x", sid, agent = AgentKind.CLAUDE, thinking = false))
+        } finally {
+            scope.cancel()
         }
     }
 }

--- a/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/SidePaneModelDelegationGuardTest.kt
+++ b/mobile/composeApp/src/desktopTest/kotlin/dev/ccpocket/app/desktop/SidePaneModelDelegationGuardTest.kt
@@ -75,6 +75,9 @@ class SidePaneModelDelegationGuardTest {
         // focused pane; the MODEL graduated to pane-scoped above once SidePane learned to carry it)
         "chatBranch", "chatMode",
         "chatPermissionMode", "chatEffort", "chatServiceTier",
+        // #345: the thinking tri-state rides with effort — a column shows no toggle and a pick
+        // would land on the FOCUSED session's next launch
+        "chatThinking", "supportsThinkingToggle", "switchThinking",
         "sessionDegraded", "contextUsed", "contextWindow", "observing", "takeOver",
         // transcript paging: a column keeps no scrollback loader, so the focused pane's answer would put
         // another session's "load older" over this stream. (Delivery-receipt / stall cues graduated to

--- a/protocol/src/commonMain/kotlin/dev/ccpocket/protocol/Messages.kt
+++ b/protocol/src/commonMain/kotlin/dev/ccpocket/protocol/Messages.kt
@@ -143,6 +143,15 @@ data class OpenSession(
     val permissionMode: String? = null,
     /** Backend-native service tier. Codex `"priority"` is the Fast toggle; null follows CLI/account default. */
     val serviceTier: String? = null,
+    /**
+     * Extended-thinking toggle (Claude): null (the default) = don't touch it — the CLI's own default
+     * (incl. the user's global `alwaysThinkingEnabled`) decides; true → `--thinking enabled`;
+     * false → `--thinking disabled`. Orthogonal to [effort] on purpose (issue #345: a gateway whose
+     * models reject thinking content fails a high-effort session with "Content block is not a thinking
+     * block", while effort=max + thinking off works — the same two controls the VS Code extension
+     * exposes). Trailing optional so old daemons drop it (back to CLI default) and old Apps never send it.
+     */
+    val thinking: Boolean? = null,
 ) : ToDaemon
 
 /** Restart the live conversation's claude process under a new cwd. */
@@ -875,6 +884,13 @@ data class SessionLive(
     val serviceTier: String? = null,
     /** Daemon-authoritative display title. Additive so older peers ignore it and older daemons decode as null. */
     val title: String? = null,
+    /**
+     * The session's extended-thinking toggle as the daemon has it baked into the running launch (null =
+     * CLI default, true = `--thinking enabled`, false = `--thinking disabled`; issue #345). Re-announced
+     * on every relaunch together with mode/model/effort. Additive: older peers ignore it, older daemons
+     * decode it as null.
+     */
+    val thinking: Boolean? = null,
 ) : ToPhone
 
 /** A streamed assistant content piece. seq is monotonic per convo for ordering. */
@@ -2050,6 +2066,15 @@ data class ModelsList(
      * ignores it. Empty means "not advertised" (→ fallback), never "this backend has no modes".
      */
     val modePresets: List<AgentModePreset> = emptyList(),
+    /**
+     * Whether this backend accepts a session-level extended-thinking toggle (Claude's `--thinking
+     * enabled|disabled`, issue #345). The App shows its Thinking switch only when true — sending
+     * [OpenSession.thinking] to a daemon that never advertised support would be silently dropped
+     * (the field wouldn't exist there), showing "off" while the CLI still thinks. Trailing + defaulted
+     * both ways, like [gatewayModels]: an older daemon never sends it (no switch shown), an older App
+     * ignores it. False means "not advertised", never "thinking is impossible".
+     */
+    val supportsThinkingToggle: Boolean = false,
 ) : ToPhone
 
 /**

--- a/protocol/src/commonTest/kotlin/dev/ccpocket/protocol/SerializationRoundTripTest.kt
+++ b/protocol/src/commonTest/kotlin/dev/ccpocket/protocol/SerializationRoundTripTest.kt
@@ -58,11 +58,13 @@ class SerializationRoundTripTest {
             effort = "ultra",
             permissionMode = CLAUDE_PERMISSION_MODE_AUTO,
             serviceTier = "priority",
+            thinking = false,
         )
         val openJson = PocketJson.encodeToString(open)
         assertTrue("\"mode\":\"default\"" in openJson, openJson) // old daemon keeps its safe fallback
         assertTrue("\"permissionMode\":\"auto\"" in openJson, openJson)
         assertTrue("\"serviceTier\":\"priority\"" in openJson, openJson)
+        assertTrue("\"thinking\":false" in openJson, openJson) // #345: rides alongside, effort untouched
         assertEquals(open, PocketJson.decodeFromString<OpenSession>(openJson))
 
         val live = SessionLive(
@@ -74,9 +76,11 @@ class SerializationRoundTripTest {
             effort = "max",
             permissionMode = CLAUDE_PERMISSION_MODE_AUTO,
             serviceTier = "priority",
+            thinking = false,
         )
         val liveJson = PocketJson.encodeToString(live)
         assertTrue("\"title\":\"Authoritative session title\"" in liveJson, liveJson)
+        assertTrue("\"thinking\":false" in liveJson, liveJson)
         assertEquals(live, PocketJson.decodeFromString<SessionLive>(liveJson))
 
         // Frames sent before #183 omit both native fields and continue to decode to null.
@@ -180,6 +184,32 @@ class SerializationRoundTripTest {
         // an already-shipped phone's concrete serializer skips the populated rows entirely
         assertEquals(
             OldModelsList(agent = AgentKind.CODEX, models = listOf("gpt-5.6-sol")),
+            PocketJson.decodeFromString<OldModelsList>(PocketJson.encodeToString(advertised)),
+        )
+    }
+
+    @Test
+    fun thinking_toggle_is_additive_and_legacy_safe() {
+        // #345: the daemon advertises; absent field on an old daemon decodes to false = "don't show the switch"
+        val advertised = ModelsList(agent = AgentKind.CLAUDE, models = listOf("opus"), supportsThinkingToggle = true)
+        assertTrue(
+            "\"supportsThinkingToggle\":true" in PocketJson.encodeToString(advertised),
+            "a new daemon must announce the toggle explicitly",
+        )
+        // encodeDefaults emits the false default explicitly (same wire shape as gatewayModels:[]) —
+        // what matters is that it reads back as not-advertised, never as a claim
+        assertTrue(
+            "\"supportsThinkingToggle\":false" in PocketJson.encodeToString(ModelsList(agent = AgentKind.CLAUDE, models = listOf("opus"))),
+            "an unadvertised backend encodes the explicit false default",
+        )
+        assertEquals(
+            false,
+            PocketJson.decodeFromString<ModelsList>("""{"agent":"claude","models":["opus"]}""").supportsThinkingToggle,
+            "an old daemon's frame (no field) reads as not-advertised",
+        )
+        // and an already-shipped phone skips the unknown key without failing the frame
+        assertEquals(
+            OldModelsList(agent = AgentKind.CLAUDE, models = listOf("opus")),
             PocketJson.decodeFromString<OldModelsList>(PocketJson.encodeToString(advertised)),
         )
     }

--- a/scripts/probe-claude-wire.py
+++ b/scripts/probe-claude-wire.py
@@ -64,7 +64,7 @@ lock 为 07-10 增，workflow/fgtask/bgcontinue 为 07-11 增、在 2.1.206 上�
           副本」的备选路线（已实证可行：CLI 按文件名认会话，行内 sessionId 改不改都接受）。
 
 用法：python3 scripts/probe-claude-wire.py [steer|queue|ask|ask_plan|task|workflow|lock|fgtask|bgcontinue|
-      skill|scope|scope_acceptedits|settingsources|cleanroom|entrypoint|rewind|all]（默认 all）
+      skill|scope|scope_acceptedits|settingsources|cleanroom|entrypoint|rewind|thinkingflag|all]（默认 all）
       CLAUDE_BIN=/path/to/claude 可覆盖二进制。失败退出码非 0。
 探针在 /tmp/ccprobe 下起真实 claude 进程（bypassPermissions / default / acceptEdits），会消耗少量用量。
 """
@@ -1060,6 +1060,46 @@ def scenario_entrypoint() -> bool:
     return ok
 
 
+def scenario_thinkingflag() -> bool:
+    print("── thinkingflag：--thinking 三态 flag 仍在（#345 thinking 开关烧进 launch 参数的地基）──")
+    # daemon 的 thinking 开关把 tri-state 烧进 launch 参数（ClaudeLauncher：--thinking enabled|disabled，
+    # 与 --effort 正交），押的是两条 CLI 行为：
+    #   ① --thinking 只吃 enabled|adaptive|disabled，别的值在参数解析期即退出 —— flag 被改名/移除或
+    #      取值集合漂移时，App 上的「关」会变成一个永远起不来的会话（CLI 直接退，stream 无 init），
+    #      且 daemon 无法从报错里区分「值不对」和「flag 没了」；
+    #   ② --thinking disabled 下轮次照常完成、整轮零 thinking 块 —— 这是网关不吃 thinking 时的止血
+    #      开关：上游不再收到带 signature 的 thinking 块，"Content block is not a thinking block" 从
+    #      请求侧消失。漂移＝开关失明，会话照旧间歇性炸。
+    env = dict(os.environ)
+    env.pop("CLAUDECODE", None)
+    env.pop("CLAUDE_CODE_ENTRYPOINT", None)
+    os.makedirs(WORKDIR, exist_ok=True)  # 单场景直跑时 Probe 还没机会建它
+    ok = True
+    # ① bogus 值启动即拒，且报错点名全部三个合法值
+    r = subprocess.run(
+        [CLAUDE, "-p", "Say ok", "--thinking", "bogus"],
+        capture_output=True, text=True, timeout=60, env=env, cwd=WORKDIR,
+    )
+    ok &= check("--thinking bogus → 参数解析期即拒", r.returncode != 0, f"exit={r.returncode}")
+    missing = [v for v in ("enabled", "adaptive", "disabled") if v not in r.stderr]
+    ok &= check("报错点名三个合法值（flag 存在且集合未漂移）", not missing,
+                "stderr 含 enabled/adaptive/disabled" if not missing else f"missing: {missing}")
+    # ② disabled 烧死后轮次照常完成，且整轮零 thinking 块
+    p = Probe(["--permission-mode", "bypassPermissions", "--thinking", "disabled"])
+    try:
+        p.send("Do not use any tools. Reply with exactly: ok")
+        ok &= check("disabled 轮次照常完成", p.wait_for("result"), "result arrived")
+        thinking_blocks = [
+            c for j in p.raw if j.get("type") == "assistant"
+            for c in j.get("message", {}).get("content", []) if c.get("type") == "thinking"
+        ]
+        ok &= check("disabled 整轮零 thinking 块", thinking_blocks == [],
+                    f"{len(thinking_blocks)} thinking block(s)")
+    finally:
+        p.kill()
+    return ok
+
+
 def main():
     which = sys.argv[1] if len(sys.argv) > 1 else "all"
     version = subprocess.run([CLAUDE, "--version"], capture_output=True, text=True).stdout.strip()
@@ -1071,12 +1111,13 @@ def main():
         "scope": scenario_scope, "scope_acceptedits": scenario_scope_acceptedits,
         "settingsources": scenario_settingsources, "cleanroom": scenario_cleanroom,
         "entrypoint": scenario_entrypoint, "rewind": scenario_rewind,
+        "thinkingflag": scenario_thinkingflag,
     }
     run = scenarios.values() if which == "all" else [scenarios[which]]
     results = [fn() for fn in run]
     print()
     if all(results):
-        print("✅ wire behavior unchanged — App 依赖的九条 CLI 行为全部成立")
+        print("✅ wire behavior unchanged — App 依赖的 CLI 行为全部成立")
         sys.exit(0)
     print("❌ CLI 行为漂移！排查 daemon 的 StreamParser/PermissionBridge/AskQuestions 是否需要适配")
     sys.exit(1)

--- a/scripts/probe-claude-wire.py
+++ b/scripts/probe-claude-wire.py
@@ -1088,7 +1088,18 @@ def scenario_thinkingflag() -> bool:
     p = Probe(["--permission-mode", "bypassPermissions", "--thinking", "disabled"])
     try:
         p.send("Do not use any tools. Reply with exactly: ok")
-        ok &= check("disabled 轮次照常完成", p.wait_for("result"), "result arrived")
+        arrived = p.wait_for("result")
+        results = [j for j in p.raw if j.get("type") == "result"]
+        result = results[-1] if results else {}
+        succeeded = arrived and result.get("subtype") == "success" and result.get("is_error") is False
+        ok &= check("disabled 轮次成功完成", succeeded,
+                    f"result arrived={arrived}, subtype={result.get('subtype')}, is_error={result.get('is_error')}")
+        assistants = [j.get("message", {}) for j in p.raw if j.get("type") == "assistant"]
+        synthetic = any(m.get("model") == "<synthetic>" for m in assistants)
+        reply = "".join(c.get("text", "") for m in assistants
+                        for c in m.get("content", []) if c.get("type") == "text").strip()
+        ok &= check("disabled 收到真实 ok 回复", not synthetic and reply == "ok",
+                    f"synthetic={synthetic}, reply_matches={reply == 'ok'}")
         thinking_blocks = [
             c for j in p.raw if j.get("type") == "assistant"
             for c in j.get("message", {}).get("content", []) if c.get("type") == "thinking"

--- a/scripts/update-local-desktop.sh
+++ b/scripts/update-local-desktop.sh
@@ -10,8 +10,9 @@ APP_DST="/Applications/CC Pocket.app"
 LEGACY_DST="/Applications/cc-pocket.app"   # 改名前（≤1.2.2 dev）的安装位置，避免留下两个 App
 
 echo "── 1/4 构建桌面 App（createDistributable）──"
-# 本机只有 Homebrew JDK：跳过 compose 的 vendor 检查（仅本地 dev 安装，不做分发签名）
-JAVA_HOME=/opt/homebrew/opt/openjdk@17 ./gradlew :mobile:composeApp:createDistributable \
+# 本机只有 Homebrew JDK：跳过 compose 的 vendor 检查（仅本地 dev 安装，不做分发签名）。
+# JAVA_HOME 已设置时尊重现值（Intel 机上 JDK 不在 /opt/homebrew）——与 check-all.sh 同款兜底。
+JAVA_HOME="${JAVA_HOME:-/opt/homebrew/opt/openjdk@17}" ./gradlew :mobile:composeApp:createDistributable \
   -Pcompose.desktop.packaging.checkJdkVendor=false --quiet
 [ -d "$APP_SRC" ] || { echo "构建产物不存在：$APP_SRC"; exit 1; }
 


### PR DESCRIPTION
Fixes #345

## 命题

对第三方网关（`ANTHROPIC_BASE_URL`）使用不吃 thinking 的上游模型时，会话间歇性失败：`API Error: Content block is not a thinking block`。根因：effort 档位高时 claude CLI 发起的请求带 thinking 块（带 signature）→ tool_use → tool_result，下一轮原样重发 thinking 内容，上游不吃 thinking 即拒绝。

实证（VSCode 插件）：**effort 和 thinking 是两个正交开关**——effort 开到 max、thinking 关掉，同样的网关+模型不报错。cc-pocket 只有 effort 开关没有 thinking 开关，等于断了这条止血路径。

## 改动

- **protocol**：`OpenSession`/`SessionLive` 加三态 `thinking: Boolean?`（null=CLI 默认 / true=enabled / false=disabled），trailing-optional 兼容；`ModelsList` 加 `supportsThinkingToggle` 能力通告——旧 daemon 不通告时 App 隐藏开关（防「显示关了实际没关」）。round-trip 测试覆盖新旧端兼容形状。
- **daemon**：`ClaudeLauncher` 把三态与 `--effort` 正交地烧进 `--thinking enabled|disabled`；`Conversation` 拦截 `/thinking on|off|default` 斜杠命令（capability 门控，不支持的后端透传）；切换走 #84 next-turn 语义（pending relaunch，同 sessionId resume）。9 处 AgentSpec 构造点全部携带。
- **App（手机+桌面同一份 commonMain）**：快捷菜单 effort 旁加 Thinking 三态行/子页（默认/开/关）；Session info 只读行；会话持久化恢复；桌面分屏列按 `SidePaneModelDelegationGuardTest` 契约归 PANE_INERT。
- **探针**：`probe-claude-wire.py` 加 `thinkingflag` 场景——①`--thinking bogus` 参数解析期即拒且报错点名 enabled/adaptive/disabled 三个合法值（flag 存在性与取值集合漂移会让「关」变成永远起不来的会话）；②`--thinking disabled` 轮次照常完成且整轮零 thinking 块。

## 兼容性

- 旧 App + 新 daemon：字段缺省 null=CLI 默认，零行为变化。
- 新 App + 旧 daemon：`supportsThinkingToggle` 不通告 → 开关隐藏，不会出现「显示关了实际没关」。
- thinking 与 effort 严格独立；上游自发输出的 reasoning 不受开关控制（无害，transcript 照记）。

## 验证

- `check-all.sh` 全量绿（protocol + daemon + relay + mobile desktopTest）。
- `probe-claude-wire.py thinkingflag` 4 项全绿。
- 本机部署后 desktop 端到端：第三方网关 + 不吃 thinking 的上游模型，effort 保持 max、thinking 关，会话不再报 "Content block is not a thinking block"。

---

另含一个独立小 commit：`update-local-desktop.sh` 尊重已有 JAVA_HOME（Intel 机 JDK 不在 /opt/homebrew，与 check-all.sh 同款兜底）。