### PR TITLE
fix(appstore): complete and verify iPhone and iPad screenshot synchronization

### DIFF
--- a/.github/workflows/ios-store-metadata.yml
+++ b/.github/workflows/ios-store-metadata.yml
@@ -9,9 +9,17 @@ on:
         description: "Editable App Store version to create or update (for example 1.8.1)."
         required: true
         type: string
+      verify_only:
+        description: "Read back the existing store media without changing metadata or uploading anything."
+        type: boolean
+        default: false
 
 permissions:
   contents: read
+
+concurrency:
+  group: ios-store-metadata-${{ inputs.version }}
+  cancel-in-progress: false
 
 jobs:
   sync:
@@ -37,6 +45,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
+      - name: Test screenshot verification
+        run: ruby scripts/test-appstore-screenshot-state.rb
       - run: gem install fastlane --no-document
 
       - name: Stage App Store Connect API key
@@ -56,8 +66,8 @@ jobs:
                 > "$RUNNER_TEMP/asc_api_key.json"
 
       - name: Stage store-page metadata only
-        # Do not copy release_notes.txt: the repo is still versioned 1.8.0, and 1.8.1 What's New
-        # must be written from the real binary diff when that release is ready to submit.
+        if: ${{ !inputs.verify_only }}
+        # Release notes are managed by ios-release, which attaches the matching binary.
         run: |
           for locale in en-US zh-Hans; do
             mkdir -p "$RUNNER_TEMP/store-metadata/$locale"
@@ -68,6 +78,7 @@ jobs:
           done
 
       - name: Create or update App Store version ${{ inputs.version }}
+        if: ${{ !inputs.verify_only }}
         env:
           VERSION: ${{ inputs.version }}
         run: |
@@ -76,13 +87,13 @@ jobs:
             --app_version "$VERSION" \
             --metadata_path "$RUNNER_TEMP/store-metadata" \
             --skip_binary_upload true \
-            --skip_screenshots false \
-            --overwrite_screenshots true \
+            --skip_screenshots true \
             --skip_metadata false \
             --submit_for_review false \
             --force true
 
-      - name: Converge the visible 6.5-inch screenshot sets
+      - name: Converge iPhone and iPad screenshot sets
+        if: ${{ !inputs.verify_only }}
         env:
           VERSION: ${{ inputs.version }}
           ASC_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
@@ -90,13 +101,14 @@ jobs:
         run: ruby scripts/sync-appstore-screenshots.rb
 
       - name: Replace localized App Previews after processing
+        if: ${{ !inputs.verify_only }}
         env:
           VERSION: ${{ inputs.version }}
           ASC_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
         run: ruby scripts/sync-appstore-previews.rb
 
-      - name: Verify media in the visible 6.5-inch slot
+      - name: Verify iPhone and iPad media
         env:
           VERSION: ${{ inputs.version }}
           ASC_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
@@ -106,13 +118,15 @@ jobs:
       - name: Summary
         env:
           VERSION: ${{ inputs.version }}
+          VERIFY_ONLY: ${{ inputs.verify_only }}
         run: |
           {
-            echo "## App Store page synced"
+            echo "## App Store media verified"
             echo "- Version: $VERSION"
             echo "- Locales: en-US, zh-Hans"
-            echo "- Screenshots: 6 per locale (6.5-inch slot)"
+            echo "- Screenshots: 6 per locale per device family (iPhone 6.5-inch + iPad 12.9-inch)"
             echo "- App Previews: 1 per locale"
+            echo "- Read-only verification: $VERIFY_ONLY"
             echo "- Binary uploaded: no"
             echo "- Submitted for review: no"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/fastlane/Deliverfile
+++ b/fastlane/Deliverfile
@@ -1,6 +1,6 @@
 # fastlane deliver — App Store metadata source of truth.
-# The binary upload stays with xcodebuild in ios-release.yml. ios-store-metadata.yml overrides
-# skip_screenshots to create/update an editable store page without uploading or submitting a build.
+# The binary upload stays with xcodebuild in ios-release.yml. Store screenshots are managed by
+# scripts/sync-appstore-screenshots.rb for both iPhone and iPad.
 app_identifier "com.panda.ccpocket"
 skip_binary_upload true
 skip_screenshots true

--- a/scripts/appstore_screenshot_state.rb
+++ b/scripts/appstore_screenshot_state.rb
@@ -1,0 +1,43 @@
+require "digest"
+require "json"
+
+# Shared by the uploader and the independent read-only verification step.
+module AppStoreScreenshotState
+  SETS = [
+    { type: "APP_IPHONE_65", label: "iPhone 6.5-inch", glob: "*.png" },
+    { type: "APP_IPAD_PRO_3GEN_129", label: "iPad 12.9-inch", glob: "ipadPro129/*.png" },
+  ].freeze
+
+  def self.checksums(paths)
+    raise "expected 6 local screenshots, got #{paths.size}" unless paths.size == 6
+
+    paths.map { |path| Digest::MD5.file(path).hexdigest }
+  end
+
+  # Individual uploads can be COMPLETE before the collection read reflects their
+  # checksums/order. Retry reads only; never delete or re-upload during this wait.
+  def self.wait_for_set(label:, checksums:, ids: nil, attempts: 13, interval: 5, output: $stdout)
+    previous = nil
+    attempts.times do |attempt|
+      shots = yield
+      actual_checksums = shots.map { |shot| shot.source_file_checksum&.downcase }
+      if shots.size == checksums.size && shots.all?(&:complete?) && actual_checksums == checksums &&
+         (ids.nil? || shots.map(&:id) == ids)
+        return shots
+      end
+
+      snapshot = shots.map do |shot|
+        { id: shot.id, name: shot.file_name, state: shot.asset_delivery_state,
+          checksum: shot.source_file_checksum }
+      end.to_json
+      output.puts("#{label}: waiting for screenshot collection: #{snapshot}") if snapshot != previous
+      previous = snapshot
+      failed = shots.select(&:error?)
+      unless failed.empty?
+        raise "#{label}: screenshot processing failed: #{failed.map { |shot| [shot.file_name, shot.error_messages] }.inspect}"
+      end
+      sleep(interval) if attempt + 1 < attempts && interval.positive?
+    end
+    raise "#{label}: screenshot sync did not converge after #{attempts} reads; expected checksums=#{checksums.inspect}; last=#{previous}"
+  end
+end

--- a/scripts/sync-appstore-screenshots.rb
+++ b/scripts/sync-appstore-screenshots.rb
@@ -11,12 +11,13 @@
 # the size of BOTH 12.9-inch slots, and deliver would otherwise have to guess between
 # APP_IPAD_PRO_129 and APP_IPAD_PRO_3GEN_129 from the filename alone.
 #
-# Ordering note: the workflow runs `deliver --overwrite_screenshots true` BEFORE this script, and
-# that deletes every screenshot set of every locale it uploads — the iPad set included. Restoring it
-# in the same run is this script's job, so these two steps must stay in that order.
+# This script owns both screenshot families. Metadata-only deliver must skip screenshots so a
+# retry preserves already-correct sets instead of deleting and uploading them again.
 
-require "digest"
 require "spaceship"
+require_relative "appstore_screenshot_state"
+
+$stdout.sync = true
 
 version_string = ENV.fetch("VERSION")
 token = Spaceship::ConnectAPI::Token.create(
@@ -31,17 +32,10 @@ platform = Spaceship::ConnectAPI::Platform.map("ios")
 version = app.get_edit_app_store_version(platform: platform) or abort("no editable iOS version")
 abort("editable version is #{version.version_string}, expected #{version_string}") unless version.version_string == version_string
 
-DISPLAY_TYPES = Spaceship::ConnectAPI::AppScreenshotSet::DisplayType
-SETS = [
-  { type: DISPLAY_TYPES::APP_IPHONE_65, label: "6.5-inch", glob: "*.png" },
-  { type: DISPLAY_TYPES::APP_IPAD_PRO_3GEN_129, label: "iPad 12.9-inch", glob: "ipadPro129/*.png" },
-].freeze
-
 # Converge ONE display type of ONE localization onto exactly `paths`, in that order.
 def converge_set(localization, display_type, label, paths)
   locale = localization.locale
-  abort("#{locale} #{label}: expected 6 local screenshots, got #{paths.size}") unless paths.size == 6
-  checksums = paths.map { |path| Digest::MD5.file(path).hexdigest }
+  checksums = AppStoreScreenshotState.checksums(paths)
 
   shot_set = localization.get_app_screenshot_sets.find { |item| item.screenshot_display_type == display_type }
   shot_set ||= localization.create_app_screenshot_set(attributes: { screenshotDisplayType: display_type })
@@ -67,9 +61,9 @@ def converge_set(localization, display_type, label, paths)
 
   desired_ids = keepers.map(&:id)
   shot_set.reorder_screenshots(app_screenshot_ids: desired_ids)
-  final = Spaceship::ConnectAPI::AppScreenshotSet.get(app_screenshot_set_id: shot_set.id).app_screenshots
-  final_checksums = final.map { |item| item.source_file_checksum&.downcase }
-  abort("#{locale} #{label}: screenshot sync did not converge") unless final.size == 6 && final.all?(&:complete?) && final_checksums == checksums
+  AppStoreScreenshotState.wait_for_set(label: "#{locale} #{label}", checksums: checksums, ids: desired_ids) do
+    Spaceship::ConnectAPI::AppScreenshotSet.get(app_screenshot_set_id: shot_set.id).app_screenshots
+  end
 
   puts("#{locale}: 6 ordered screenshots ready in the #{label} slot")
 end
@@ -78,7 +72,7 @@ localizations = version.get_app_store_version_localizations
 
 %w[en-US zh-Hans].each do |locale|
   localization = localizations.find { |item| item.locale == locale } or abort("missing ASC locale #{locale}")
-  SETS.each do |set|
+  AppStoreScreenshotState::SETS.each do |set|
     paths = Dir["fastlane/screenshots/#{locale}/#{set[:glob]}"].sort
     converge_set(localization, set[:type], set[:label], paths)
   end

--- a/scripts/test-appstore-screenshot-state.rb
+++ b/scripts/test-appstore-screenshot-state.rb
@@ -1,0 +1,68 @@
+require "minitest/autorun"
+require "stringio"
+require_relative "appstore_screenshot_state"
+
+class AppStoreScreenshotStateTest < Minitest::Test
+  Shot = Struct.new(:id, :file_name, :source_file_checksum, :asset_delivery_state) do
+    def complete?
+      asset_delivery_state["state"] == "COMPLETE"
+    end
+    def error?
+      asset_delivery_state["state"] == "FAILED"
+    end
+    def error_messages
+      ["processing rejected"]
+    end
+  end
+
+  def shot(id, checksum, state = "COMPLETE")
+    Shot.new(id, "#{id}.png", checksum, { "state" => state })
+  end
+
+  def wait_for(snapshots, **options)
+    AppStoreScreenshotState.wait_for_set(
+      label: "en-US iPad", checksums: %w[aa bb], ids: %w[1 2],
+      attempts: snapshots.size, interval: 0, output: StringIO.new, **options
+    ) { snapshots.shift }
+  end
+
+  def test_waits_for_stale_order_and_processing_reads
+    final = [shot("1", "AA"), shot("2", "bb")]
+    assert_equal final, wait_for([
+      [shot("2", "bb"), shot("1", "aa")],
+      [shot("1", nil, "PROCESSING"), shot("2", "bb")],
+      final,
+    ])
+  end
+
+  def test_missing_extra_wrong_content_and_order_never_pass_on_counts_alone
+    [
+      [shot("1", "aa")],
+      [shot("1", "aa"), shot("2", "bb"), shot("3", "cc")],
+      [shot("1", "aa"), shot("2", "cc")],
+      [shot("2", "bb"), shot("1", "aa")],
+      [shot("3", "aa"), shot("2", "bb")],
+    ].each do |snapshot|
+      error = assert_raises(RuntimeError) { wait_for([snapshot]) }
+      assert_includes error.message, "did not converge"
+    end
+  end
+
+  def test_processing_failure_is_not_retried_as_success
+    error = assert_raises(RuntimeError) do
+      wait_for([[shot("1", "aa", "FAILED"), shot("2", "bb")]])
+    end
+    assert_includes error.message, "processing failed"
+  end
+
+  def test_both_device_families_and_complete_local_manifest_are_required
+    assert_equal %w[APP_IPHONE_65 APP_IPAD_PRO_3GEN_129], AppStoreScreenshotState::SETS.map { |set| set[:type] }
+    %w[en-US zh-Hans].each do |locale|
+      AppStoreScreenshotState::SETS.each do |set|
+        paths = Dir[File.join(__dir__, "..", "fastlane", "screenshots", locale, set[:glob])].sort
+        assert_equal 6, AppStoreScreenshotState.checksums(paths).size
+      end
+    end
+    assert_raises(RuntimeError) { AppStoreScreenshotState.checksums([]) }
+  end
+end

--- a/scripts/verify-appstore-media.rb
+++ b/scripts/verify-appstore-media.rb
@@ -1,8 +1,10 @@
 #!/usr/bin/env ruby
-# Hard gate after upload: confirm the editable ASC version contains the expected media in the same
-# 6.5-inch slot shown on the version page. A CI success without these counts is not a delivery.
+# Read-only hard gate: both locales, both screenshot families, exact content/order, and previews.
 
 require "spaceship"
+require_relative "appstore_screenshot_state"
+
+$stdout.sync = true
 
 version_string = ENV.fetch("VERSION")
 token = Spaceship::ConnectAPI::Token.create(
@@ -16,7 +18,7 @@ app = Spaceship::ConnectAPI::App.find("com.panda.ccpocket") or abort("ASC app no
 version = app.get_edit_app_store_version(platform: Spaceship::ConnectAPI::Platform.map("ios")) or abort("no editable iOS version")
 abort("editable version is #{version.version_string}, expected #{version_string}") unless version.version_string == version_string
 
-shot_type = Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_65
+puts("ASC iOS #{version.version_string}: #{version.app_store_state}")
 preview_type = Spaceship::ConnectAPI::AppPreviewSet::PreviewType::IPHONE_65
 expected_locales = %w[en-US zh-Hans]
 localizations = version.get_app_store_version_localizations
@@ -24,15 +26,22 @@ localizations = version.get_app_store_version_localizations
 expected_locales.each do |locale|
   localization = localizations.find { |item| item.locale == locale } or abort("missing ASC locale #{locale}")
 
-  shot_set = localization.get_app_screenshot_sets.find { |item| item.screenshot_display_type == shot_type }
-  shots = shot_set&.app_screenshots || []
-  bad_shots = shots.reject(&:complete?)
-  abort("#{localization.locale}: expected 6 complete #{shot_type} screenshots, got #{shots.size}") unless shots.size == 6 && bad_shots.empty?
+  shot_sets = localization.get_app_screenshot_sets
+  AppStoreScreenshotState::SETS.each do |set|
+    paths = Dir["fastlane/screenshots/#{locale}/#{set[:glob]}"].sort
+    checksums = AppStoreScreenshotState.checksums(paths)
+    shot_set = shot_sets.find { |item| item.screenshot_display_type == set[:type] }
+    abort("#{locale}: missing #{set[:type]} screenshot set") unless shot_set
+    shots = AppStoreScreenshotState.wait_for_set(label: "#{locale} #{set[:label]}", checksums: checksums) do
+      Spaceship::ConnectAPI::AppScreenshotSet.get(app_screenshot_set_id: shot_set.id).app_screenshots
+    end
+    puts("#{locale}: #{shots.size} complete #{set[:type]} screenshots; ordered source checksums match")
+  end
 
   preview_set = localization.get_app_preview_sets.find { |item| item.preview_type == preview_type }
   previews = preview_set&.app_previews || []
   good_previews = previews.select { |item| item.video_url && item.complete? }
   abort("#{localization.locale}: expected 1 processed #{preview_type} preview, got #{previews.size}") unless previews.size == 1 && good_previews.size == 1
 
-  puts("#{localization.locale}: #{shots.size} screenshots + #{previews.size} preview in the 6.5-inch slot")
+  puts("#{locale}: #{previews.size} processed iPhone 6.5-inch preview")
 end


### PR DESCRIPTION
Uploading the new iPad screenshot set could fail when App Store Connect's collection read had not caught up with completed uploads and ordering. The failure stopped the second locale, while the final verification covered only iPhone screenshots.

The workflow now preserves correct screenshots, retries collection reads for a bounded time, and independently verifies all 24 screenshots across both locales and device families by processing state, order, and source checksum. Failed asset processing still fails immediately. A read-only verification input and per-version concurrency make inspection and retries safe.

Validation: four focused Ruby tests (25 assertions), Ruby syntax checks, workflow YAML parsing, and the complete local App Store content check passed. A read-only ASC run confirmed the existing English iPad set was correct and the Chinese iPad set was missing: https://github.com/heypandax/cc-pocket/actions/runs/34139781299. The live sync and independent verification passed in https://github.com/heypandax/cc-pocket/actions/runs/34140016906: 24 ordered screenshots and two processed previews. The new Chinese iPad uploads reproduced the root cause: COMPLETE assets initially returned null source checksums; read-only polling converged after 10 seconds. PR CI also passed on the exact head.

Related to #334. No App Review submission or binary rebuild is performed by this workflow.
